### PR TITLE
フェーズ2: JVMとOSのメモリ統計取得

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -224,8 +224,8 @@ mod が開ける扉は TPS だけではなく、MSPT 分布（p95/最大）・�
 
 **v1（バニラ / Forge / NeoForge、mod なし）**
 - [x] 起動スクリプトのラップ、stdin/stdout 接続、java PID 特定
-- [ ] hsperfdata パーサ
-- [ ] `/proc` RSS + cgroup 取得
+- [x] hsperfdata パーサ
+- [x] `/proc` RSS + cgroup 取得
 - [ ] `JAVA_TOOL_OPTIONS` 注入と GC ログ tail
 - [ ] ログ分類パーサ（チャット / コマンド / 参加退出 / ラグ / その他）
 - [ ] TUI（統計ヘッダ + 3ペイン + 入力欄）

--- a/internal/hsperfdata/metrics.go
+++ b/internal/hsperfdata/metrics.go
@@ -1,0 +1,137 @@
+package hsperfdata
+
+import (
+	"fmt"
+	"time"
+)
+
+type Number struct {
+	Value     int64
+	Available bool
+}
+
+type Duration struct {
+	Value     time.Duration
+	Available bool
+}
+
+type Memory struct {
+	Used      Number
+	Committed Number
+	Max       Number
+}
+
+type Generation struct {
+	Name   string
+	Memory Memory
+}
+
+type Collector struct {
+	Name        string
+	Invocations Number
+	Time        Duration
+}
+
+type Metrics struct {
+	Heap                 Memory
+	Generations          []Generation
+	Metaspace            Memory
+	CompressedClassSpace Memory
+	Collectors           []Collector
+	Uptime               Duration
+	Threads              Number
+}
+
+func (s Snapshot) Metrics() Metrics {
+	var metrics Metrics
+
+	generationCount, _ := s.Long("sun.gc.generations")
+	for index := int64(0); index < generationCount; index++ {
+		prefix := fmt.Sprintf("sun.gc.generation.%d", index)
+		name, _ := s.String(prefix + ".name")
+		spaces, _ := s.Long(prefix + ".spaces")
+
+		generation := Generation{
+			Name: name,
+			Memory: Memory{
+				Committed: number(s, prefix+".capacity"),
+				Max:       number(s, prefix+".maxCapacity"),
+			},
+		}
+		for space := int64(0); space < spaces; space++ {
+			used, ok := s.Long(fmt.Sprintf("%s.space.%d.used", prefix, space))
+			if !ok {
+				continue
+			}
+			generation.Memory.Used.Value += used
+			generation.Memory.Used.Available = true
+		}
+		metrics.Generations = append(metrics.Generations, generation)
+		addNumber(&metrics.Heap.Used, generation.Memory.Used)
+		addNumber(&metrics.Heap.Committed, generation.Memory.Committed)
+		addNumber(&metrics.Heap.Max, generation.Memory.Max)
+	}
+	if maximum, ok := s.Long("sun.gc.policy.maxCapacity"); ok {
+		metrics.Heap.Max = Number{Value: maximum, Available: true}
+	}
+
+	metrics.Metaspace = memory(s, "sun.gc.metaspace")
+	metrics.CompressedClassSpace = memory(s, "sun.gc.compressedclassspace")
+
+	frequency, frequencyOK := s.Long("sun.os.hrt.frequency")
+	if ticks, ok := s.Long("sun.os.hrt.ticks"); ok && frequencyOK && frequency > 0 {
+		metrics.Uptime = Duration{
+			Value:     ticksToDuration(ticks, frequency),
+			Available: true,
+		}
+	}
+
+	metrics.Threads = number(s, "java.threads.live")
+
+	collectorCount, _ := s.Long("sun.gc.collectors")
+	for index := int64(0); index < collectorCount; index++ {
+		prefix := fmt.Sprintf("sun.gc.collector.%d", index)
+		name, _ := s.String(prefix + ".name")
+		collector := Collector{
+			Name:        name,
+			Invocations: number(s, prefix+".invocations"),
+		}
+		if ticks, ok := s.Long(prefix + ".time"); ok && frequencyOK && frequency > 0 {
+			collector.Time = Duration{
+				Value:     ticksToDuration(ticks, frequency),
+				Available: true,
+			}
+		}
+		metrics.Collectors = append(metrics.Collectors, collector)
+	}
+
+	return metrics
+}
+
+func memory(snapshot Snapshot, prefix string) Memory {
+	return Memory{
+		Used:      number(snapshot, prefix+".used"),
+		Committed: number(snapshot, prefix+".capacity"),
+		Max:       number(snapshot, prefix+".maxCapacity"),
+	}
+}
+
+func number(snapshot Snapshot, name string) Number {
+	value, ok := snapshot.Long(name)
+	return Number{Value: value, Available: ok}
+}
+
+func addNumber(total *Number, value Number) {
+	if !value.Available {
+		return
+	}
+	total.Value += value.Value
+	total.Available = true
+}
+
+func ticksToDuration(ticks, frequency int64) time.Duration {
+	seconds := ticks / frequency
+	remainder := ticks % frequency
+	return time.Duration(seconds)*time.Second +
+		time.Duration(remainder)*time.Second/time.Duration(frequency)
+}

--- a/internal/hsperfdata/metrics.go
+++ b/internal/hsperfdata/metrics.go
@@ -45,11 +45,16 @@ type Metrics struct {
 func (s Snapshot) Metrics() Metrics {
 	var metrics Metrics
 
-	generationCount, _ := s.Long("sun.gc.generations")
+	generationCount, generationsAvailable := s.Long("sun.gc.generations")
+	var (
+		heapUsed      []Number
+		heapCommitted []Number
+		heapMax       []Number
+	)
 	for index := int64(0); index < generationCount; index++ {
 		prefix := fmt.Sprintf("sun.gc.generation.%d", index)
 		name, _ := s.String(prefix + ".name")
-		spaces, _ := s.Long(prefix + ".spaces")
+		spaces, spacesAvailable := s.Long(prefix + ".spaces")
 
 		generation := Generation{
 			Name: name,
@@ -58,18 +63,25 @@ func (s Snapshot) Metrics() Metrics {
 				Max:       number(s, prefix+".maxCapacity"),
 			},
 		}
-		for space := int64(0); space < spaces; space++ {
-			used, ok := s.Long(fmt.Sprintf("%s.space.%d.used", prefix, space))
-			if !ok {
-				continue
+		if spacesAvailable {
+			used := make([]Number, 0, spaces)
+			for space := int64(0); space < spaces; space++ {
+				used = append(used, number(
+					s,
+					fmt.Sprintf("%s.space.%d.used", prefix, space),
+				))
 			}
-			generation.Memory.Used.Value += used
-			generation.Memory.Used.Available = true
+			generation.Memory.Used = sumNumbers(used)
 		}
 		metrics.Generations = append(metrics.Generations, generation)
-		addNumber(&metrics.Heap.Used, generation.Memory.Used)
-		addNumber(&metrics.Heap.Committed, generation.Memory.Committed)
-		addNumber(&metrics.Heap.Max, generation.Memory.Max)
+		heapUsed = append(heapUsed, generation.Memory.Used)
+		heapCommitted = append(heapCommitted, generation.Memory.Committed)
+		heapMax = append(heapMax, generation.Memory.Max)
+	}
+	if generationsAvailable {
+		metrics.Heap.Used = sumNumbers(heapUsed)
+		metrics.Heap.Committed = sumNumbers(heapCommitted)
+		metrics.Heap.Max = sumNumbers(heapMax)
 	}
 	if maximum, ok := s.Long("sun.gc.policy.maxCapacity"); ok {
 		metrics.Heap.Max = Number{Value: maximum, Available: true}
@@ -121,12 +133,16 @@ func number(snapshot Snapshot, name string) Number {
 	return Number{Value: value, Available: ok}
 }
 
-func addNumber(total *Number, value Number) {
-	if !value.Available {
-		return
+func sumNumbers(values []Number) Number {
+	var total Number
+	for _, value := range values {
+		if !value.Available {
+			return Number{}
+		}
+		total.Value += value.Value
 	}
-	total.Value += value.Value
 	total.Available = true
+	return total
 }
 
 func ticksToDuration(ticks, frequency int64) time.Duration {

--- a/internal/hsperfdata/metrics_test.go
+++ b/internal/hsperfdata/metrics_test.go
@@ -1,0 +1,82 @@
+package hsperfdata
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMetrics(t *testing.T) {
+	snapshot := Snapshot{Counters: map[string]Counter{
+		"sun.gc.generations":                      {long: 2},
+		"sun.gc.generation.0.name":                {text: "young", isString: true},
+		"sun.gc.generation.0.spaces":              {long: 2},
+		"sun.gc.generation.0.capacity":            {long: 300},
+		"sun.gc.generation.0.maxCapacity":         {long: 600},
+		"sun.gc.generation.0.space.0.used":        {long: 100},
+		"sun.gc.generation.0.space.1.used":        {long: 20},
+		"sun.gc.generation.1.name":                {text: "old", isString: true},
+		"sun.gc.generation.1.spaces":              {long: 1},
+		"sun.gc.generation.1.capacity":            {long: 700},
+		"sun.gc.generation.1.maxCapacity":         {long: 1400},
+		"sun.gc.generation.1.space.0.used":        {long: 400},
+		"sun.gc.policy.maxCapacity":               {long: 2048},
+		"sun.gc.metaspace.used":                   {long: 50},
+		"sun.gc.metaspace.capacity":               {long: 80},
+		"sun.gc.metaspace.maxCapacity":            {long: 500},
+		"sun.gc.compressedclassspace.used":        {long: 10},
+		"sun.gc.compressedclassspace.capacity":    {long: 20},
+		"sun.gc.compressedclassspace.maxCapacity": {long: 100},
+		"sun.gc.collectors":                       {long: 1},
+		"sun.gc.collector.0.name":                 {text: "young GC", isString: true},
+		"sun.gc.collector.0.invocations":          {long: 12},
+		"sun.gc.collector.0.time":                 {long: 1250},
+		"sun.os.hrt.frequency":                    {long: 1000},
+		"sun.os.hrt.ticks":                        {long: 12_500},
+		"java.threads.live":                       {long: 37},
+	}}
+
+	metrics := snapshot.Metrics()
+
+	assertNumber(t, metrics.Heap.Used, 520)
+	assertNumber(t, metrics.Heap.Committed, 1000)
+	assertNumber(t, metrics.Heap.Max, 2048)
+	assertNumber(t, metrics.Metaspace.Used, 50)
+	assertNumber(t, metrics.CompressedClassSpace.Max, 100)
+	assertNumber(t, metrics.Threads, 37)
+	if len(metrics.Generations) != 2 || metrics.Generations[1].Name != "old" {
+		t.Fatalf("Generations = %#v", metrics.Generations)
+	}
+	if !metrics.Uptime.Available || metrics.Uptime.Value != 12_500*time.Millisecond {
+		t.Fatalf("Uptime = %#v", metrics.Uptime)
+	}
+	if len(metrics.Collectors) != 1 {
+		t.Fatalf("Collectors = %#v", metrics.Collectors)
+	}
+	if metrics.Collectors[0].Name != "young GC" {
+		t.Fatalf("collector name = %q", metrics.Collectors[0].Name)
+	}
+	assertNumber(t, metrics.Collectors[0].Invocations, 12)
+	if !metrics.Collectors[0].Time.Available ||
+		metrics.Collectors[0].Time.Value != 1250*time.Millisecond {
+		t.Fatalf("collector time = %#v", metrics.Collectors[0].Time)
+	}
+}
+
+func TestMetricsKeepsUnavailableValuesExplicit(t *testing.T) {
+	metrics := (Snapshot{Counters: map[string]Counter{}}).Metrics()
+
+	if metrics.Heap.Used.Available ||
+		metrics.Heap.Committed.Available ||
+		metrics.Heap.Max.Available ||
+		metrics.Uptime.Available ||
+		metrics.Threads.Available {
+		t.Fatalf("Metrics = %#v", metrics)
+	}
+}
+
+func assertNumber(t *testing.T, got Number, want int64) {
+	t.Helper()
+	if !got.Available || got.Value != want {
+		t.Fatalf("number = %#v, want %d", got, want)
+	}
+}

--- a/internal/hsperfdata/metrics_test.go
+++ b/internal/hsperfdata/metrics_test.go
@@ -74,6 +74,43 @@ func TestMetricsKeepsUnavailableValuesExplicit(t *testing.T) {
 	}
 }
 
+func TestMetricsRejectsPartialSpaceSum(t *testing.T) {
+	snapshot := Snapshot{Counters: map[string]Counter{
+		"sun.gc.generations":               {long: 1},
+		"sun.gc.generation.0.spaces":       {long: 2},
+		"sun.gc.generation.0.capacity":     {long: 300},
+		"sun.gc.generation.0.maxCapacity":  {long: 600},
+		"sun.gc.generation.0.space.0.used": {long: 100},
+	}}
+
+	metrics := snapshot.Metrics()
+
+	if metrics.Generations[0].Memory.Used.Available || metrics.Heap.Used.Available {
+		t.Fatalf("Metrics = %#v", metrics)
+	}
+}
+
+func TestMetricsRejectsPartialGenerationSum(t *testing.T) {
+	snapshot := Snapshot{Counters: map[string]Counter{
+		"sun.gc.generations":               {long: 2},
+		"sun.gc.generation.0.spaces":       {long: 1},
+		"sun.gc.generation.0.capacity":     {long: 300},
+		"sun.gc.generation.0.maxCapacity":  {long: 600},
+		"sun.gc.generation.0.space.0.used": {long: 100},
+		"sun.gc.generation.1.spaces":       {long: 1},
+		"sun.gc.generation.1.maxCapacity":  {long: 1400},
+		"sun.gc.generation.1.space.0.used": {long: 400},
+	}}
+
+	metrics := snapshot.Metrics()
+
+	if metrics.Heap.Committed.Available {
+		t.Fatalf("Heap committed = %#v", metrics.Heap.Committed)
+	}
+	assertNumber(t, metrics.Heap.Used, 500)
+	assertNumber(t, metrics.Heap.Max, 2000)
+}
+
 func assertNumber(t *testing.T, got Number, want int64) {
 	t.Helper()
 	if !got.Available || got.Value != want {

--- a/internal/hsperfdata/parser.go
+++ b/internal/hsperfdata/parser.go
@@ -1,0 +1,168 @@
+package hsperfdata
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	prologueSize = 32
+	entrySize    = 20
+	magic        = 0xcafec0c0
+)
+
+var (
+	ErrNotAccessible = errors.New("hsperfdataはまだ読み取り可能ではありません")
+	ErrUnsupported   = errors.New("未対応のhsperfdata形式です")
+)
+
+type Counter struct {
+	long     int64
+	text     string
+	isString bool
+}
+
+func (c Counter) Long() (int64, bool) {
+	return c.long, !c.isString
+}
+
+func (c Counter) String() (string, bool) {
+	return c.text, c.isString
+}
+
+type Snapshot struct {
+	Counters map[string]Counter
+	Overflow int64
+}
+
+func (s Snapshot) Long(name string) (int64, bool) {
+	counter, ok := s.Counters[name]
+	if !ok {
+		return 0, false
+	}
+	return counter.Long()
+}
+
+func (s Snapshot) String(name string) (string, bool) {
+	counter, ok := s.Counters[name]
+	if !ok {
+		return "", false
+	}
+	return counter.String()
+}
+
+func Parse(data []byte) (Snapshot, error) {
+	if len(data) < prologueSize {
+		return Snapshot{}, errors.New("hsperfdataのプロローグが短すぎます")
+	}
+
+	order, err := byteOrder(data[4])
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if order.Uint32(data[0:4]) != magic {
+		return Snapshot{}, errors.New("hsperfdataのマジック値が不正です")
+	}
+	if data[5] != 2 {
+		return Snapshot{}, fmt.Errorf("%w: バージョン%d.%d", ErrUnsupported, data[5], data[6])
+	}
+	if data[7] == 0 {
+		return Snapshot{}, ErrNotAccessible
+	}
+
+	used := int(order.Uint32(data[8:12]))
+	overflow := int64(int32(order.Uint32(data[12:16])))
+	entryOffset := int(order.Uint32(data[24:28]))
+	numEntries := int(order.Uint32(data[28:32]))
+	if used < prologueSize || used > len(data) {
+		return Snapshot{}, fmt.Errorf("hsperfdataの使用量が不正です: %d", used)
+	}
+	if entryOffset < prologueSize || entryOffset > used || entryOffset%4 != 0 {
+		return Snapshot{}, fmt.Errorf("hsperfdataのエントリ開始位置が不正です: %d", entryOffset)
+	}
+	if numEntries < 0 || numEntries > (used-entryOffset)/entrySize {
+		return Snapshot{}, fmt.Errorf("hsperfdataのエントリ数が不正です: %d", numEntries)
+	}
+
+	snapshot := Snapshot{
+		Counters: make(map[string]Counter, numEntries),
+		Overflow: overflow,
+	}
+	offset := entryOffset
+	for index := 0; index < numEntries; index++ {
+		name, counter, next, err := parseEntry(data[:used], offset, order)
+		if err != nil {
+			return Snapshot{}, fmt.Errorf("hsperfdataエントリ%d: %w", index, err)
+		}
+		snapshot.Counters[name] = counter
+		offset = next
+	}
+	return snapshot, nil
+}
+
+func parseEntry(data []byte, offset int, order binary.ByteOrder) (string, Counter, int, error) {
+	if offset < 0 || offset%4 != 0 || offset+entrySize > len(data) {
+		return "", Counter{}, 0, fmt.Errorf("開始位置が不正です: %d", offset)
+	}
+
+	entryLength := int(order.Uint32(data[offset : offset+4]))
+	if entryLength < entrySize || offset+entryLength > len(data) {
+		return "", Counter{}, 0, fmt.Errorf("長さが不正です: %d", entryLength)
+	}
+
+	nameOffset := int(order.Uint32(data[offset+4 : offset+8]))
+	vectorLength := int(order.Uint32(data[offset+8 : offset+12]))
+	dataType := data[offset+12]
+	dataOffset := int(order.Uint32(data[offset+16 : offset+20]))
+	if nameOffset < entrySize || nameOffset >= entryLength {
+		return "", Counter{}, 0, fmt.Errorf("名前の位置が不正です: %d", nameOffset)
+	}
+	if dataOffset <= nameOffset || dataOffset >= entryLength {
+		return "", Counter{}, 0, fmt.Errorf("データの位置が不正です: %d", dataOffset)
+	}
+
+	nameBytes := data[offset+nameOffset : offset+dataOffset]
+	terminator := strings.IndexByte(string(nameBytes), 0)
+	if terminator <= 0 {
+		return "", Counter{}, 0, errors.New("名前がNUL終端されていません")
+	}
+	name := string(nameBytes[:terminator])
+
+	switch {
+	case vectorLength == 0 && dataType == 'J':
+		if dataOffset+8 > entryLength {
+			return "", Counter{}, 0, errors.New("long値がエントリ境界を越えています")
+		}
+		value := int64(order.Uint64(data[offset+dataOffset : offset+dataOffset+8]))
+		return name, Counter{long: value}, offset + entryLength, nil
+	case vectorLength > 0 && dataType == 'B':
+		if dataOffset+vectorLength > entryLength {
+			return "", Counter{}, 0, errors.New("文字列がエントリ境界を越えています")
+		}
+		value := data[offset+dataOffset : offset+dataOffset+vectorLength]
+		if end := strings.IndexByte(string(value), 0); end >= 0 {
+			value = value[:end]
+		}
+		return name, Counter{text: string(value), isString: true}, offset + entryLength, nil
+	default:
+		return "", Counter{}, 0, fmt.Errorf(
+			"%w: 型=%q ベクタ長=%d",
+			ErrUnsupported,
+			dataType,
+			vectorLength,
+		)
+	}
+}
+
+func byteOrder(value byte) (binary.ByteOrder, error) {
+	switch value {
+	case 0:
+		return binary.BigEndian, nil
+	case 1:
+		return binary.LittleEndian, nil
+	default:
+		return nil, fmt.Errorf("hsperfdataのバイトオーダーが不正です: %d", value)
+	}
+}

--- a/internal/hsperfdata/parser_test.go
+++ b/internal/hsperfdata/parser_test.go
@@ -1,0 +1,128 @@
+package hsperfdata
+
+import (
+	"encoding/binary"
+	"errors"
+	"testing"
+)
+
+func TestParseLittleEndian(t *testing.T) {
+	data := perfData(t, binary.LittleEndian,
+		longEntry("sun.gc.generation.0.space.0.used", 1234),
+		stringEntry("sun.gc.generation.0.name", "young"),
+	)
+
+	snapshot, err := Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, ok := snapshot.Long("sun.gc.generation.0.space.0.used"); !ok || value != 1234 {
+		t.Fatalf("long = %d, %v", value, ok)
+	}
+	if value, ok := snapshot.String("sun.gc.generation.0.name"); !ok || value != "young" {
+		t.Fatalf("string = %q, %v", value, ok)
+	}
+}
+
+func TestParseBigEndian(t *testing.T) {
+	data := perfData(t, binary.BigEndian, longEntry("java.threads.live", 42))
+
+	snapshot, err := Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, ok := snapshot.Long("java.threads.live"); !ok || value != 42 {
+		t.Fatalf("long = %d, %v", value, ok)
+	}
+}
+
+func TestParseRejectsInaccessibleData(t *testing.T) {
+	data := perfData(t, binary.LittleEndian, longEntry("counter", 1))
+	data[7] = 0
+
+	_, err := Parse(data)
+	if !errors.Is(err, ErrNotAccessible) {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestParseRejectsUnsupportedVersion(t *testing.T) {
+	data := perfData(t, binary.LittleEndian, longEntry("counter", 1))
+	data[5] = 3
+
+	_, err := Parse(data)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestParseRejectsEntryOutsideUsedArea(t *testing.T) {
+	data := perfData(t, binary.LittleEndian, longEntry("counter", 1))
+	binary.LittleEndian.PutUint32(data[32:36], uint32(len(data)))
+
+	if _, err := Parse(data); err == nil {
+		t.Fatal("Parse succeeded")
+	}
+}
+
+type testEntry struct {
+	name   string
+	long   int64
+	text   string
+	isText bool
+}
+
+func longEntry(name string, value int64) testEntry {
+	return testEntry{name: name, long: value}
+}
+
+func stringEntry(name, value string) testEntry {
+	return testEntry{name: name, text: value, isText: true}
+}
+
+func perfData(t *testing.T, order binary.ByteOrder, entries ...testEntry) []byte {
+	t.Helper()
+
+	data := make([]byte, prologueSize)
+	if order == binary.LittleEndian {
+		data[4] = 1
+	}
+	data[5] = 2
+	data[7] = 1
+	order.PutUint32(data[0:4], magic)
+	order.PutUint32(data[24:28], prologueSize)
+	order.PutUint32(data[28:32], uint32(len(entries)))
+
+	for _, item := range entries {
+		name := append([]byte(item.name), 0)
+		dataOffset := align(entrySize+len(name), 8)
+		valueLength := 8
+		vectorLength := 0
+		dataType := byte('J')
+		if item.isText {
+			valueLength = len(item.text) + 1
+			vectorLength = valueLength
+			dataType = 'B'
+		}
+		entryLength := align(dataOffset+valueLength, 4)
+		entry := make([]byte, entryLength)
+		order.PutUint32(entry[0:4], uint32(entryLength))
+		order.PutUint32(entry[4:8], entrySize)
+		order.PutUint32(entry[8:12], uint32(vectorLength))
+		entry[12] = dataType
+		order.PutUint32(entry[16:20], uint32(dataOffset))
+		copy(entry[entrySize:], name)
+		if item.isText {
+			copy(entry[dataOffset:], item.text)
+		} else {
+			order.PutUint64(entry[dataOffset:dataOffset+8], uint64(item.long))
+		}
+		data = append(data, entry...)
+	}
+	order.PutUint32(data[8:12], uint32(len(data)))
+	return data
+}
+
+func align(value, alignment int) int {
+	return (value + alignment - 1) &^ (alignment - 1)
+}

--- a/internal/hsperfdata/reader_linux.go
+++ b/internal/hsperfdata/reader_linux.go
@@ -21,6 +21,10 @@ func Open(pid int) (*Reader, error) {
 }
 
 func openAt(tempDir string, pid int) (*Reader, error) {
+	return openAtUID(tempDir, pid, uint32(os.Geteuid()))
+}
+
+func openAtUID(tempDir string, pid int, uid uint32) (*Reader, error) {
 	if pid <= 0 {
 		return nil, fmt.Errorf("PIDが不正です: %d", pid)
 	}
@@ -33,7 +37,10 @@ func openAt(tempDir string, pid int) (*Reader, error) {
 		return nil, fmt.Errorf("hsperfdataを探す: %w", err)
 	}
 	for _, path := range matches {
-		reader, err := openPath(path)
+		if !ownedBy(filepath.Dir(path), uid) {
+			continue
+		}
+		reader, err := openPath(path, uid)
 		if err == nil {
 			return reader, nil
 		}
@@ -41,7 +48,7 @@ func openAt(tempDir string, pid int) (*Reader, error) {
 	return nil, fmt.Errorf("%w: PID %d", ErrNotFound, pid)
 }
 
-func openPath(path string) (*Reader, error) {
+func openPath(path string, uid uint32) (*Reader, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("hsperfdataを開く: %w", err)
@@ -51,9 +58,9 @@ func openPath(path string) (*Reader, error) {
 		_ = file.Close()
 		return nil, fmt.Errorf("hsperfdataのサイズを読む: %w", err)
 	}
-	if !info.Mode().IsRegular() || info.Size() < prologueSize {
+	if !info.Mode().IsRegular() || info.Size() < prologueSize || !fileInfoOwnedBy(info, uid) {
 		_ = file.Close()
-		return nil, errors.New("hsperfdataが通常ファイルではないか、短すぎます")
+		return nil, errors.New("hsperfdataの種類、サイズ、所有者が不正です")
 	}
 
 	data, err := syscall.Mmap(
@@ -92,4 +99,14 @@ func (r *Reader) Close() error {
 		r.file = nil
 	}
 	return errors.Join(unmapErr, closeErr)
+}
+
+func ownedBy(path string, uid uint32) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.IsDir() && fileInfoOwnedBy(info, uid)
+}
+
+func fileInfoOwnedBy(info os.FileInfo, uid uint32) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && stat.Uid == uid
 }

--- a/internal/hsperfdata/reader_linux.go
+++ b/internal/hsperfdata/reader_linux.go
@@ -11,13 +11,15 @@ import (
 
 var ErrNotFound = errors.New("hsperfdataが見つかりません")
 
+const hotSpotTempDir = "/tmp"
+
 type Reader struct {
 	file *os.File
 	data []byte
 }
 
 func Open(pid int) (*Reader, error) {
-	return openAt(os.TempDir(), pid)
+	return openAt(hotSpotTempDir, pid)
 }
 
 func openAt(tempDir string, pid int) (*Reader, error) {

--- a/internal/hsperfdata/reader_linux.go
+++ b/internal/hsperfdata/reader_linux.go
@@ -1,0 +1,95 @@
+package hsperfdata
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+)
+
+var ErrNotFound = errors.New("hsperfdataが見つかりません")
+
+type Reader struct {
+	file *os.File
+	data []byte
+}
+
+func Open(pid int) (*Reader, error) {
+	return openAt(os.TempDir(), pid)
+}
+
+func openAt(tempDir string, pid int) (*Reader, error) {
+	if pid <= 0 {
+		return nil, fmt.Errorf("PIDが不正です: %d", pid)
+	}
+	matches, err := filepath.Glob(filepath.Join(
+		tempDir,
+		"hsperfdata_*",
+		strconv.Itoa(pid),
+	))
+	if err != nil {
+		return nil, fmt.Errorf("hsperfdataを探す: %w", err)
+	}
+	for _, path := range matches {
+		reader, err := openPath(path)
+		if err == nil {
+			return reader, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: PID %d", ErrNotFound, pid)
+}
+
+func openPath(path string) (*Reader, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("hsperfdataを開く: %w", err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("hsperfdataのサイズを読む: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Size() < prologueSize {
+		_ = file.Close()
+		return nil, errors.New("hsperfdataが通常ファイルではないか、短すぎます")
+	}
+
+	data, err := syscall.Mmap(
+		int(file.Fd()),
+		0,
+		int(info.Size()),
+		syscall.PROT_READ,
+		syscall.MAP_SHARED,
+	)
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("hsperfdataをmmapする: %w", err)
+	}
+	return &Reader{file: file, data: data}, nil
+}
+
+func (r *Reader) Sample() (Snapshot, error) {
+	if r == nil || r.data == nil {
+		return Snapshot{}, errors.New("hsperfdataリーダーは閉じられています")
+	}
+	return Parse(r.data)
+}
+
+func (r *Reader) Close() error {
+	if r == nil {
+		return nil
+	}
+	var unmapErr error
+	if r.data != nil {
+		unmapErr = syscall.Munmap(r.data)
+		r.data = nil
+	}
+	var closeErr error
+	if r.file != nil {
+		closeErr = r.file.Close()
+		r.file = nil
+	}
+	return errors.Join(unmapErr, closeErr)
+}

--- a/internal/hsperfdata/reader_linux_test.go
+++ b/internal/hsperfdata/reader_linux_test.go
@@ -42,6 +42,26 @@ func TestReaderReportsMissingFile(t *testing.T) {
 	}
 }
 
+func TestReaderIgnoresFilesOwnedByAnotherUID(t *testing.T) {
+	tempDir := t.TempDir()
+	perfDir := filepath.Join(tempDir, "hsperfdata_other")
+	if err := os.Mkdir(perfDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(perfDir, "123"),
+		perfData(t, binary.LittleEndian, longEntry("counter", 1)),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := openAtUID(tempDir, 123, uint32(os.Geteuid()+1))
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v", err)
+	}
+}
+
 func TestClosedReaderCannotSample(t *testing.T) {
 	tempDir := t.TempDir()
 	perfDir := filepath.Join(tempDir, "hsperfdata_test")

--- a/internal/hsperfdata/reader_linux_test.go
+++ b/internal/hsperfdata/reader_linux_test.go
@@ -35,6 +35,13 @@ func TestReaderMapsPerfDataFile(t *testing.T) {
 	}
 }
 
+func TestHotSpotTempDirDoesNotFollowTMPDIR(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	if hotSpotTempDir != "/tmp" {
+		t.Fatalf("hotSpotTempDir = %q", hotSpotTempDir)
+	}
+}
+
 func TestReaderReportsMissingFile(t *testing.T) {
 	_, err := openAt(t.TempDir(), 123)
 	if !errors.Is(err, ErrNotFound) {

--- a/internal/hsperfdata/reader_linux_test.go
+++ b/internal/hsperfdata/reader_linux_test.go
@@ -1,0 +1,70 @@
+package hsperfdata
+
+import (
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReaderMapsPerfDataFile(t *testing.T) {
+	tempDir := t.TempDir()
+	perfDir := filepath.Join(tempDir, "hsperfdata_test")
+	if err := os.Mkdir(perfDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(perfDir, "123")
+	data := perfData(t, binary.LittleEndian, longEntry("java.threads.live", 9))
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := openAt(tempDir, 123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+
+	snapshot, err := reader.Sample()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, ok := snapshot.Long("java.threads.live"); !ok || value != 9 {
+		t.Fatalf("threads = %d, %v", value, ok)
+	}
+}
+
+func TestReaderReportsMissingFile(t *testing.T) {
+	_, err := openAt(t.TempDir(), 123)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestClosedReaderCannotSample(t *testing.T) {
+	tempDir := t.TempDir()
+	perfDir := filepath.Join(tempDir, "hsperfdata_test")
+	if err := os.Mkdir(perfDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(perfDir, "123")
+	if err := os.WriteFile(
+		path,
+		perfData(t, binary.LittleEndian, longEntry("counter", 1)),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := openAt(tempDir, 123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reader.Sample(); err == nil {
+		t.Fatal("Sample succeeded after Close")
+	}
+}

--- a/internal/procstats/procstats_linux.go
+++ b/internal/procstats/procstats_linux.go
@@ -27,11 +27,22 @@ type Memory struct {
 	CgroupLimit   Limit
 }
 
-func ReadMemory(pid int) (Memory, error) {
-	return readMemoryAt("/proc", "/sys/fs/cgroup", pid)
+type cgroupMembership struct {
+	version int
+	path    string
 }
 
-func readMemoryAt(procRoot, cgroupRoot string, pid int) (Memory, error) {
+type cgroupMount struct {
+	version    int
+	root       string
+	mountPoint string
+}
+
+func ReadMemory(pid int) (Memory, error) {
+	return readMemoryAt("/proc", "/proc/self/mountinfo", pid)
+}
+
+func readMemoryAt(procRoot, mountInfoPath string, pid int) (Memory, error) {
 	if pid <= 0 {
 		return Memory{}, fmt.Errorf("PIDが不正です: %d", pid)
 	}
@@ -50,7 +61,7 @@ func readMemoryAt(procRoot, cgroupRoot string, pid int) (Memory, error) {
 	}
 
 	memory := Memory{RSS: rss}
-	cgroupPath, err := readCgroupPath(filepath.Join(
+	memberships, err := readCgroups(filepath.Join(
 		procRoot,
 		strconv.Itoa(pid),
 		"cgroup",
@@ -58,9 +69,36 @@ func readMemoryAt(procRoot, cgroupRoot string, pid int) (Memory, error) {
 	if err != nil {
 		return memory, nil
 	}
-	groupDir := filepath.Join(cgroupRoot, strings.TrimPrefix(cgroupPath, "/"))
-	memory.CgroupCurrent = readNumber(filepath.Join(groupDir, "memory.current"))
-	memory.CgroupLimit = readLimit(filepath.Join(groupDir, "memory.max"))
+	mounts, err := readCgroupMounts(mountInfoPath)
+	if err != nil {
+		return memory, nil
+	}
+
+	for _, membership := range memberships {
+		for _, mount := range mounts {
+			if membership.version != mount.version {
+				continue
+			}
+			groupDir := resolveCgroupDir(mount, membership.path)
+			switch membership.version {
+			case 2:
+				memory.CgroupCurrent = readNumber(filepath.Join(groupDir, "memory.current"))
+				memory.CgroupLimit = readLimit(filepath.Join(groupDir, "memory.max"), false)
+			case 1:
+				memory.CgroupCurrent = readNumber(filepath.Join(
+					groupDir,
+					"memory.usage_in_bytes",
+				))
+				memory.CgroupLimit = readLimit(filepath.Join(
+					groupDir,
+					"memory.limit_in_bytes",
+				), true)
+			}
+			if memory.CgroupCurrent.Available || memory.CgroupLimit.Available {
+				return memory, nil
+			}
+		}
+	}
 	return memory, nil
 }
 
@@ -86,29 +124,92 @@ func parseRSS(status *os.File) (Number, error) {
 	return Number{}, nil
 }
 
-func readCgroupPath(path string) (string, error) {
+func readCgroups(path string) ([]cgroupMembership, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer file.Close()
 
+	var memberships []cgroupMembership
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		line := scanner.Text()
-		if !strings.HasPrefix(line, "0::") {
+		fields := strings.SplitN(scanner.Text(), ":", 3)
+		if len(fields) != 3 || fields[2] == "" || !filepath.IsAbs(fields[2]) {
 			continue
 		}
-		group := strings.TrimPrefix(line, "0::")
-		if group == "" || !filepath.IsAbs(group) {
-			return "", errors.New("cgroup v2のパスが不正です")
+		switch {
+		case fields[0] == "0" && fields[1] == "":
+			memberships = append(memberships, cgroupMembership{version: 2, path: fields[2]})
+		case contains(fields[1], "memory"):
+			memberships = append(memberships, cgroupMembership{version: 1, path: fields[2]})
 		}
-		return group, nil
 	}
 	if err := scanner.Err(); err != nil {
-		return "", err
+		return nil, err
 	}
-	return "", errors.New("cgroup v2を使用していません")
+	if len(memberships) == 0 {
+		return nil, errors.New("memory cgroupに所属していません")
+	}
+	return memberships, nil
+}
+
+func readCgroupMounts(path string) ([]cgroupMount, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var mounts []cgroupMount
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		separator := index(fields, "-")
+		if separator < 6 || separator+3 >= len(fields) {
+			continue
+		}
+
+		version := 0
+		switch fields[separator+1] {
+		case "cgroup2":
+			version = 2
+		case "cgroup":
+			if contains(fields[separator+3], "memory") {
+				version = 1
+			}
+		}
+		if version == 0 {
+			continue
+		}
+		mounts = append(mounts, cgroupMount{
+			version:    version,
+			root:       unescapeMountField(fields[3]),
+			mountPoint: unescapeMountField(fields[4]),
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if len(mounts) == 0 {
+		return nil, errors.New("memory cgroupのマウントがありません")
+	}
+	return mounts, nil
+}
+
+func resolveCgroupDir(mount cgroupMount, group string) string {
+	root := filepath.Clean(mount.root)
+	group = filepath.Clean(group)
+	relative := strings.TrimPrefix(group, string(filepath.Separator))
+	if root != string(filepath.Separator) {
+		switch {
+		case group == root:
+			relative = ""
+		case strings.HasPrefix(group, root+string(filepath.Separator)):
+			relative = strings.TrimPrefix(group, root+string(filepath.Separator))
+		}
+	}
+	return filepath.Join(mount.mountPoint, relative)
 }
 
 func readNumber(path string) Number {
@@ -123,7 +224,7 @@ func readNumber(path string) Number {
 	return Number{Value: value, Available: true}
 }
 
-func readLimit(path string) Limit {
+func readLimit(path string, version1 bool) Limit {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return Limit{}
@@ -136,5 +237,37 @@ func readLimit(path string) Limit {
 	if err != nil {
 		return Limit{}
 	}
+	const cgroupV1Unlimited = uint64(1<<63 - 4096)
+	if version1 && limit >= cgroupV1Unlimited {
+		return Limit{Available: true, Unlimited: true}
+	}
 	return Limit{Value: limit, Available: true}
+}
+
+func contains(list, item string) bool {
+	for _, value := range strings.Split(list, ",") {
+		if value == item {
+			return true
+		}
+	}
+	return false
+}
+
+func index(values []string, target string) int {
+	for position, value := range values {
+		if value == target {
+			return position
+		}
+	}
+	return -1
+}
+
+func unescapeMountField(value string) string {
+	replacer := strings.NewReplacer(
+		`\040`, " ",
+		`\011`, "\t",
+		`\012`, "\n",
+		`\134`, `\`,
+	)
+	return replacer.Replace(value)
 }

--- a/internal/procstats/procstats_linux.go
+++ b/internal/procstats/procstats_linux.go
@@ -1,0 +1,140 @@
+package procstats
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type Number struct {
+	Value     uint64
+	Available bool
+}
+
+type Limit struct {
+	Value     uint64
+	Available bool
+	Unlimited bool
+}
+
+type Memory struct {
+	RSS           Number
+	CgroupCurrent Number
+	CgroupLimit   Limit
+}
+
+func ReadMemory(pid int) (Memory, error) {
+	return readMemoryAt("/proc", "/sys/fs/cgroup", pid)
+}
+
+func readMemoryAt(procRoot, cgroupRoot string, pid int) (Memory, error) {
+	if pid <= 0 {
+		return Memory{}, fmt.Errorf("PIDが不正です: %d", pid)
+	}
+
+	status, err := os.Open(filepath.Join(procRoot, strconv.Itoa(pid), "status"))
+	if err != nil {
+		return Memory{}, fmt.Errorf("プロセスのstatusを開く: %w", err)
+	}
+	rss, err := parseRSS(status)
+	closeErr := status.Close()
+	if err != nil {
+		return Memory{}, err
+	}
+	if closeErr != nil {
+		return Memory{}, fmt.Errorf("プロセスのstatusを閉じる: %w", closeErr)
+	}
+
+	memory := Memory{RSS: rss}
+	cgroupPath, err := readCgroupPath(filepath.Join(
+		procRoot,
+		strconv.Itoa(pid),
+		"cgroup",
+	))
+	if err != nil {
+		return memory, nil
+	}
+	groupDir := filepath.Join(cgroupRoot, strings.TrimPrefix(cgroupPath, "/"))
+	memory.CgroupCurrent = readNumber(filepath.Join(groupDir, "memory.current"))
+	memory.CgroupLimit = readLimit(filepath.Join(groupDir, "memory.max"))
+	return memory, nil
+}
+
+func parseRSS(status *os.File) (Number, error) {
+	scanner := bufio.NewScanner(status)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 0 || fields[0] != "VmRSS:" {
+			continue
+		}
+		if len(fields) != 3 || fields[2] != "kB" {
+			return Number{}, fmt.Errorf("VmRSSの形式が不正です: %q", scanner.Text())
+		}
+		kibibytes, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			return Number{}, fmt.Errorf("VmRSSを読む: %w", err)
+		}
+		return Number{Value: kibibytes * 1024, Available: true}, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return Number{}, fmt.Errorf("プロセスのstatusを読む: %w", err)
+	}
+	return Number{}, nil
+}
+
+func readCgroupPath(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "0::") {
+			continue
+		}
+		group := strings.TrimPrefix(line, "0::")
+		if group == "" || !filepath.IsAbs(group) {
+			return "", errors.New("cgroup v2のパスが不正です")
+		}
+		return group, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", errors.New("cgroup v2を使用していません")
+}
+
+func readNumber(path string) Number {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Number{}
+	}
+	value, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return Number{}
+	}
+	return Number{Value: value, Available: true}
+}
+
+func readLimit(path string) Limit {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Limit{}
+	}
+	value := strings.TrimSpace(string(data))
+	if value == "max" {
+		return Limit{Available: true, Unlimited: true}
+	}
+	limit, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return Limit{}
+	}
+	return Limit{Value: limit, Available: true}
+}

--- a/internal/procstats/procstats_linux_test.go
+++ b/internal/procstats/procstats_linux_test.go
@@ -1,38 +1,29 @@
 package procstats
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 )
 
-func TestReadMemory(t *testing.T) {
+func TestReadMemoryCgroupV2FromNonstandardMount(t *testing.T) {
 	procRoot := t.TempDir()
-	cgroupRoot := t.TempDir()
+	cgroupRoot := filepath.Join(t.TempDir(), "custom cgroup")
 	writeProcessFile(t, procRoot, 123, "status", "Name:\tjava\nVmRSS:\t12345 kB\n")
 	writeProcessFile(t, procRoot, 123, "cgroup", "0::/server.slice/minecraft\n")
 
 	groupDir := filepath.Join(cgroupRoot, "server.slice", "minecraft")
-	if err := os.MkdirAll(groupDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(
-		filepath.Join(groupDir, "memory.current"),
-		[]byte("23456789\n"),
-		0o600,
-	); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(
-		filepath.Join(groupDir, "memory.max"),
-		[]byte("1073741824\n"),
-		0o600,
-	); err != nil {
-		t.Fatal(err)
-	}
+	writeCgroupFile(t, groupDir, "memory.current", "23456789\n")
+	writeCgroupFile(t, groupDir, "memory.max", "1073741824\n")
+	mountInfo := writeMountInfo(t, procRoot, fmt.Sprintf(
+		"1 1 0:1 / %s rw - cgroup2 cgroup rw\n",
+		escapeMountField(cgroupRoot),
+	))
 
-	memory, err := readMemoryAt(procRoot, cgroupRoot, 123)
+	memory, err := readMemoryAt(procRoot, mountInfo, 123)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,19 +36,55 @@ func TestReadMemory(t *testing.T) {
 	}
 }
 
+func TestReadMemoryCurrentProcess(t *testing.T) {
+	memory, err := ReadMemory(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !memory.RSS.Available || memory.RSS.Value == 0 {
+		t.Fatalf("RSS = %#v", memory.RSS)
+	}
+}
+
+func TestReadMemoryCgroupV1(t *testing.T) {
+	procRoot := t.TempDir()
+	cgroupRoot := filepath.Join(t.TempDir(), "memory")
+	writeProcessFile(t, procRoot, 123, "status", "VmRSS:\t10 kB\n")
+	writeProcessFile(t, procRoot, 123, "cgroup", "5:cpu:/server\n6:memory:/server\n")
+
+	groupDir := filepath.Join(cgroupRoot, "server")
+	writeCgroupFile(t, groupDir, "memory.usage_in_bytes", "200\n")
+	writeCgroupFile(t, groupDir, "memory.limit_in_bytes", "500\n")
+	mountInfo := writeMountInfo(t, procRoot, fmt.Sprintf(
+		"2 1 0:2 / %s rw - cgroup cgroup rw,memory\n",
+		escapeMountField(cgroupRoot),
+	))
+
+	memory, err := readMemoryAt(procRoot, mountInfo, 123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNumber(t, memory.CgroupCurrent, 200)
+	if !memory.CgroupLimit.Available ||
+		memory.CgroupLimit.Unlimited ||
+		memory.CgroupLimit.Value != 500 {
+		t.Fatalf("CgroupLimit = %#v", memory.CgroupLimit)
+	}
+}
+
 func TestReadMemoryReportsUnlimitedCgroup(t *testing.T) {
 	procRoot := t.TempDir()
 	cgroupRoot := t.TempDir()
 	writeProcessFile(t, procRoot, 123, "status", "VmRSS:\t1 kB\n")
 	writeProcessFile(t, procRoot, 123, "cgroup", "0::/\n")
-	if err := os.WriteFile(filepath.Join(cgroupRoot, "memory.current"), []byte("100\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(cgroupRoot, "memory.max"), []byte("max\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeCgroupFile(t, cgroupRoot, "memory.current", "100\n")
+	writeCgroupFile(t, cgroupRoot, "memory.max", "max\n")
+	mountInfo := writeMountInfo(t, procRoot, fmt.Sprintf(
+		"1 1 0:1 / %s rw - cgroup2 cgroup rw\n",
+		escapeMountField(cgroupRoot),
+	))
 
-	memory, err := readMemoryAt(procRoot, cgroupRoot, 123)
+	memory, err := readMemoryAt(procRoot, mountInfo, 123)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,9 +96,10 @@ func TestReadMemoryReportsUnlimitedCgroup(t *testing.T) {
 func TestReadMemoryKeepsCgroupUnavailable(t *testing.T) {
 	procRoot := t.TempDir()
 	writeProcessFile(t, procRoot, 123, "status", "VmRSS:\t10 kB\n")
-	writeProcessFile(t, procRoot, 123, "cgroup", "5:memory:/server\n")
+	writeProcessFile(t, procRoot, 123, "cgroup", "")
+	mountInfo := writeMountInfo(t, procRoot, "")
 
-	memory, err := readMemoryAt(procRoot, t.TempDir(), 123)
+	memory, err := readMemoryAt(procRoot, mountInfo, 123)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,8 +113,9 @@ func TestReadMemoryKeepsMissingRSSUnavailable(t *testing.T) {
 	procRoot := t.TempDir()
 	writeProcessFile(t, procRoot, 123, "status", "Name:\tjava\n")
 	writeProcessFile(t, procRoot, 123, "cgroup", "")
+	mountInfo := writeMountInfo(t, procRoot, "")
 
-	memory, err := readMemoryAt(procRoot, t.TempDir(), 123)
+	memory, err := readMemoryAt(procRoot, mountInfo, 123)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,8 +128,19 @@ func TestReadMemoryRejectsMalformedRSS(t *testing.T) {
 	procRoot := t.TempDir()
 	writeProcessFile(t, procRoot, 123, "status", "VmRSS:\tunknown kB\n")
 
-	if _, err := readMemoryAt(procRoot, t.TempDir(), 123); err == nil {
+	if _, err := readMemoryAt(procRoot, "", 123); err == nil {
 		t.Fatal("readMemoryAt succeeded")
+	}
+}
+
+func TestResolveCgroupMountRoot(t *testing.T) {
+	mount := cgroupMount{
+		root:       "/parent",
+		mountPoint: "/sys/fs/cgroup",
+	}
+	got := resolveCgroupDir(mount, "/parent/server")
+	if got != "/sys/fs/cgroup/server" {
+		t.Fatalf("path = %q", got)
 	}
 }
 
@@ -113,6 +153,35 @@ func writeProcessFile(t *testing.T, root string, pid int, name, content string) 
 	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func writeCgroupFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeMountInfo(t *testing.T, root, content string) string {
+	t.Helper()
+	path := filepath.Join(root, "mountinfo")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func escapeMountField(value string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\134`,
+		" ", `\040`,
+		"\t", `\011`,
+		"\n", `\012`,
+	)
+	return replacer.Replace(value)
 }
 
 func assertNumber(t *testing.T, got Number, want uint64) {

--- a/internal/procstats/procstats_linux_test.go
+++ b/internal/procstats/procstats_linux_test.go
@@ -1,0 +1,123 @@
+package procstats
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestReadMemory(t *testing.T) {
+	procRoot := t.TempDir()
+	cgroupRoot := t.TempDir()
+	writeProcessFile(t, procRoot, 123, "status", "Name:\tjava\nVmRSS:\t12345 kB\n")
+	writeProcessFile(t, procRoot, 123, "cgroup", "0::/server.slice/minecraft\n")
+
+	groupDir := filepath.Join(cgroupRoot, "server.slice", "minecraft")
+	if err := os.MkdirAll(groupDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(groupDir, "memory.current"),
+		[]byte("23456789\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(groupDir, "memory.max"),
+		[]byte("1073741824\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	memory, err := readMemoryAt(procRoot, cgroupRoot, 123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNumber(t, memory.RSS, 12345*1024)
+	assertNumber(t, memory.CgroupCurrent, 23456789)
+	if !memory.CgroupLimit.Available ||
+		memory.CgroupLimit.Unlimited ||
+		memory.CgroupLimit.Value != 1073741824 {
+		t.Fatalf("CgroupLimit = %#v", memory.CgroupLimit)
+	}
+}
+
+func TestReadMemoryReportsUnlimitedCgroup(t *testing.T) {
+	procRoot := t.TempDir()
+	cgroupRoot := t.TempDir()
+	writeProcessFile(t, procRoot, 123, "status", "VmRSS:\t1 kB\n")
+	writeProcessFile(t, procRoot, 123, "cgroup", "0::/\n")
+	if err := os.WriteFile(filepath.Join(cgroupRoot, "memory.current"), []byte("100\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cgroupRoot, "memory.max"), []byte("max\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	memory, err := readMemoryAt(procRoot, cgroupRoot, 123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !memory.CgroupLimit.Available || !memory.CgroupLimit.Unlimited {
+		t.Fatalf("CgroupLimit = %#v", memory.CgroupLimit)
+	}
+}
+
+func TestReadMemoryKeepsCgroupUnavailable(t *testing.T) {
+	procRoot := t.TempDir()
+	writeProcessFile(t, procRoot, 123, "status", "VmRSS:\t10 kB\n")
+	writeProcessFile(t, procRoot, 123, "cgroup", "5:memory:/server\n")
+
+	memory, err := readMemoryAt(procRoot, t.TempDir(), 123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNumber(t, memory.RSS, 10*1024)
+	if memory.CgroupCurrent.Available || memory.CgroupLimit.Available {
+		t.Fatalf("Memory = %#v", memory)
+	}
+}
+
+func TestReadMemoryKeepsMissingRSSUnavailable(t *testing.T) {
+	procRoot := t.TempDir()
+	writeProcessFile(t, procRoot, 123, "status", "Name:\tjava\n")
+	writeProcessFile(t, procRoot, 123, "cgroup", "")
+
+	memory, err := readMemoryAt(procRoot, t.TempDir(), 123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if memory.RSS.Available {
+		t.Fatalf("RSS = %#v", memory.RSS)
+	}
+}
+
+func TestReadMemoryRejectsMalformedRSS(t *testing.T) {
+	procRoot := t.TempDir()
+	writeProcessFile(t, procRoot, 123, "status", "VmRSS:\tunknown kB\n")
+
+	if _, err := readMemoryAt(procRoot, t.TempDir(), 123); err == nil {
+		t.Fatal("readMemoryAt succeeded")
+	}
+}
+
+func writeProcessFile(t *testing.T, root string, pid int, name, content string) {
+	t.Helper()
+	dir := filepath.Join(root, strconv.Itoa(pid))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertNumber(t *testing.T, got Number, want uint64) {
+	t.Helper()
+	if !got.Available || got.Value != want {
+		t.Fatalf("Number = %#v, want %d", got, want)
+	}
+}


### PR DESCRIPTION
## 概要

- hsperfdata 2.0をmmapし、long・文字列カウンタを解析
- ヒープ、世代、Metaspace、GC、uptime、スレッド数へ変換
- /procからRSS、cgroup v2からmemory.current / memory.maxを取得
- 取得不能値をAvailable=falseとして保持

## 検証

- go test ./...
- go vet ./...
- CGO_ENABLED=0 go build -ldflags="-s -w" -o /tmp/hso ./cmd/hso