### PR TITLE
フェーズ3: GCログのtailと統計解析

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -226,7 +226,7 @@ mod が開ける扉は TPS だけではなく、MSPT 分布（p95/最大）・�
 - [x] 起動スクリプトのラップ、stdin/stdout 接続、java PID 特定
 - [x] hsperfdata パーサ
 - [x] `/proc` RSS + cgroup 取得
-- [ ] `JAVA_TOOL_OPTIONS` 注入と GC ログ tail
+- [x] `JAVA_TOOL_OPTIONS` 注入と GC ログ tail
 - [ ] ログ分類パーサ（チャット / コマンド / 参加退出 / ラグ / その他）
 - [ ] TUI（統計ヘッダ + 3ペイン + 入力欄）
 - [ ] コマンド送信、restart / stop の矢印キー操作

--- a/internal/gclog/parser.go
+++ b/internal/gclog/parser.go
@@ -1,0 +1,131 @@
+package gclog
+
+import (
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	gcIDPattern   = regexp.MustCompile(`GC\(([0-9]+)\)`)
+	uptimePattern = regexp.MustCompile(
+		`\[([0-9]+(?:\.[0-9]+)?)s\]`,
+	)
+	transitionPattern = regexp.MustCompile(
+		`(?:^|\s)([0-9]+(?:\.[0-9]+)?)([KMGT]?)B?` +
+			`(?:\([0-9]+%\))?->` +
+			`([0-9]+(?:\.[0-9]+)?)([KMGT]?)B?` +
+			`(?:\([0-9]+%\))?` +
+			`(?:\(([0-9]+(?:\.[0-9]+)?)([KMGT]?)B?\))?`,
+	)
+	durationPattern = regexp.MustCompile(
+		`([0-9]+(?:\.[0-9]+)?)(ms|s)\s*$`,
+	)
+)
+
+type Bytes struct {
+	Value     uint64
+	Available bool
+}
+
+type Duration struct {
+	Value     time.Duration
+	Available bool
+}
+
+type Event struct {
+	ID       uint64
+	Uptime   Duration
+	Before   Bytes
+	After    Bytes
+	Capacity Bytes
+	Pause    Duration
+}
+
+func Parse(line string) (Event, bool) {
+	idMatch := gcIDPattern.FindStringSubmatch(line)
+	if idMatch == nil {
+		return Event{}, false
+	}
+	id, err := strconv.ParseUint(idMatch[1], 10, 64)
+	if err != nil {
+		return Event{}, false
+	}
+
+	event := Event{ID: id}
+	if match := uptimePattern.FindStringSubmatch(line); match != nil {
+		if value, ok := parseDuration(match[1], "s"); ok {
+			event.Uptime = Duration{Value: value, Available: true}
+		}
+	}
+
+	transition := transitionPattern.FindStringSubmatch(line)
+	if transition != nil {
+		event.Before = parseBytes(transition[1], transition[2])
+		event.After = parseBytes(transition[3], transition[4])
+		if transition[5] != "" {
+			event.Capacity = parseBytes(transition[5], transition[6])
+		}
+	}
+
+	if strings.Contains(line, " Pause ") {
+		if match := durationPattern.FindStringSubmatch(line); match != nil {
+			if value, ok := parseDuration(match[1], match[2]); ok {
+				event.Pause = Duration{Value: value, Available: true}
+			}
+		}
+	}
+
+	if !event.After.Available && !event.Pause.Available {
+		return Event{}, false
+	}
+	return event, true
+}
+
+func parseBytes(number, unit string) Bytes {
+	value, err := strconv.ParseFloat(number, 64)
+	if err != nil || value < 0 {
+		return Bytes{}
+	}
+
+	multiplier := float64(1)
+	switch unit {
+	case "K":
+		multiplier = 1 << 10
+	case "M":
+		multiplier = 1 << 20
+	case "G":
+		multiplier = 1 << 30
+	case "T":
+		multiplier = 1 << 40
+	case "":
+	default:
+		return Bytes{}
+	}
+	value *= multiplier
+	if value > math.MaxUint64 {
+		return Bytes{}
+	}
+	return Bytes{Value: uint64(math.Round(value)), Available: true}
+}
+
+func parseDuration(number, unit string) (time.Duration, bool) {
+	value, err := strconv.ParseFloat(number, 64)
+	if err != nil || value < 0 {
+		return 0, false
+	}
+	switch unit {
+	case "ms":
+		value *= float64(time.Millisecond)
+	case "s":
+		value *= float64(time.Second)
+	default:
+		return 0, false
+	}
+	if value > float64(math.MaxInt64) {
+		return 0, false
+	}
+	return time.Duration(math.Round(value)), true
+}

--- a/internal/gclog/parser_test.go
+++ b/internal/gclog/parser_test.go
@@ -1,0 +1,94 @@
+package gclog
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseG1Pause(t *testing.T) {
+	line := "[2026-07-27T12:00:00.000+0000][12.345s][info][gc] " +
+		"GC(7) Pause Young (Normal) (G1 Evacuation Pause) " +
+		"2048M->512M(4096M) 12.345ms"
+
+	event, ok := Parse(line)
+	if !ok {
+		t.Fatal("Parse did not recognize line")
+	}
+	if event.ID != 7 {
+		t.Fatalf("ID = %d", event.ID)
+	}
+	assertDuration(t, event.Uptime, 12_345*time.Millisecond)
+	assertBytes(t, event.Before, 2048<<20)
+	assertBytes(t, event.After, 512<<20)
+	assertBytes(t, event.Capacity, 4096<<20)
+	assertDuration(t, event.Pause, 12_345*time.Microsecond)
+}
+
+func TestParseSerialPauseWithDifferentUnits(t *testing.T) {
+	line := "[1.500s][info][gc] GC(1) Pause Full (System.gc()) " +
+		"1.5G->768M(2G) 0.25s"
+
+	event, ok := Parse(line)
+	if !ok {
+		t.Fatal("Parse did not recognize line")
+	}
+	assertBytes(t, event.Before, 1536<<20)
+	assertBytes(t, event.After, 768<<20)
+	assertBytes(t, event.Capacity, 2<<30)
+	assertDuration(t, event.Pause, 250*time.Millisecond)
+}
+
+func TestParseZGCTransitionWithoutCapacity(t *testing.T) {
+	line := "[3.000s][info][gc] GC(2) Garbage Collection (Warmup) " +
+		"14M(1%)->2M(0%)"
+
+	event, ok := Parse(line)
+	if !ok {
+		t.Fatal("Parse did not recognize line")
+	}
+	assertBytes(t, event.Before, 14<<20)
+	assertBytes(t, event.After, 2<<20)
+	if event.Capacity.Available || event.Pause.Available {
+		t.Fatalf("Event = %#v", event)
+	}
+}
+
+func TestParsePauseWithoutHeapTransition(t *testing.T) {
+	line := "[4.000s][info][gc] GC(3) Pause Final Mark 0.321ms"
+
+	event, ok := Parse(line)
+	if !ok {
+		t.Fatal("Parse did not recognize line")
+	}
+	if event.After.Available {
+		t.Fatalf("After = %#v", event.After)
+	}
+	assertDuration(t, event.Pause, 321*time.Microsecond)
+}
+
+func TestParseIgnoresConcurrentDurationAsPause(t *testing.T) {
+	line := "[4.000s][info][gc] GC(3) Concurrent Mark 12.000ms"
+	if _, ok := Parse(line); ok {
+		t.Fatal("Parse recognized concurrent duration")
+	}
+}
+
+func TestParseIgnoresUnrelatedLine(t *testing.T) {
+	if _, ok := Parse("[info][gc] Using G1"); ok {
+		t.Fatal("Parse recognized unrelated line")
+	}
+}
+
+func assertBytes(t *testing.T, got Bytes, want uint64) {
+	t.Helper()
+	if !got.Available || got.Value != want {
+		t.Fatalf("Bytes = %#v, want %d", got, want)
+	}
+}
+
+func assertDuration(t *testing.T, got Duration, want time.Duration) {
+	t.Helper()
+	if !got.Available || got.Value != want {
+		t.Fatalf("Duration = %#v, want %s", got, want)
+	}
+}

--- a/internal/gclog/stats.go
+++ b/internal/gclog/stats.go
@@ -1,0 +1,58 @@
+package gclog
+
+import "time"
+
+type Rate struct {
+	PerMinute float64
+	Available bool
+}
+
+type Stats struct {
+	Collections uint64
+	PostGC      Bytes
+	LastPause   Duration
+	TotalPause  time.Duration
+
+	highestCollectionID uint64
+	hasCollectionID     bool
+	firstTimedUptime    time.Duration
+	lastTimedUptime     time.Duration
+	timedCollections    uint64
+	hasFirstTimedUptime bool
+}
+
+func (s *Stats) Add(event Event) {
+	if !s.hasCollectionID || event.ID > s.highestCollectionID {
+		s.Collections++
+		s.highestCollectionID = event.ID
+		s.hasCollectionID = true
+
+		if event.Uptime.Available {
+			if !s.hasFirstTimedUptime {
+				s.firstTimedUptime = event.Uptime.Value
+				s.hasFirstTimedUptime = true
+			}
+			s.lastTimedUptime = event.Uptime.Value
+			s.timedCollections++
+		}
+	}
+	if event.After.Available {
+		s.PostGC = event.After
+	}
+	if event.Pause.Available {
+		s.LastPause = event.Pause
+		s.TotalPause += event.Pause.Value
+	}
+}
+
+func (s Stats) Frequency() Rate {
+	if s.timedCollections < 2 || s.lastTimedUptime <= s.firstTimedUptime {
+		return Rate{}
+	}
+	elapsed := s.lastTimedUptime - s.firstTimedUptime
+	return Rate{
+		PerMinute: float64(s.timedCollections-1) /
+			elapsed.Minutes(),
+		Available: true,
+	}
+}

--- a/internal/gclog/stats_test.go
+++ b/internal/gclog/stats_test.go
@@ -1,0 +1,74 @@
+package gclog
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestStatsTracksPostGCAndPauses(t *testing.T) {
+	var stats Stats
+	stats.Add(Event{
+		ID:     1,
+		Uptime: Duration{Value: 10 * time.Second, Available: true},
+		After:  Bytes{Value: 500, Available: true},
+		Pause:  Duration{Value: 10 * time.Millisecond, Available: true},
+	})
+	stats.Add(Event{
+		ID:     2,
+		Uptime: Duration{Value: 40 * time.Second, Available: true},
+		After:  Bytes{Value: 300, Available: true},
+		Pause:  Duration{Value: 20 * time.Millisecond, Available: true},
+	})
+
+	if stats.Collections != 2 {
+		t.Fatalf("Collections = %d", stats.Collections)
+	}
+	assertBytes(t, stats.PostGC, 300)
+	assertDuration(t, stats.LastPause, 20*time.Millisecond)
+	if stats.TotalPause != 30*time.Millisecond {
+		t.Fatalf("TotalPause = %s", stats.TotalPause)
+	}
+	rate := stats.Frequency()
+	if !rate.Available || math.Abs(rate.PerMinute-2) > 0.0001 {
+		t.Fatalf("Frequency = %#v", rate)
+	}
+}
+
+func TestStatsDoesNotCountSameCollectionTwice(t *testing.T) {
+	var stats Stats
+	stats.Add(Event{
+		ID:    1,
+		After: Bytes{Value: 500, Available: true},
+	})
+	stats.Add(Event{
+		ID:    1,
+		After: Bytes{Value: 400, Available: true},
+		Pause: Duration{Value: time.Millisecond, Available: true},
+	})
+
+	if stats.Collections != 1 {
+		t.Fatalf("Collections = %d", stats.Collections)
+	}
+	assertBytes(t, stats.PostGC, 400)
+	assertDuration(t, stats.LastPause, time.Millisecond)
+	if stats.Frequency().Available {
+		t.Fatalf("Frequency = %#v", stats.Frequency())
+	}
+}
+
+func TestStatsCountsPauseOnlyCollection(t *testing.T) {
+	var stats Stats
+	stats.Add(Event{
+		ID:     1,
+		Uptime: Duration{Value: time.Second, Available: true},
+		Pause:  Duration{Value: time.Millisecond, Available: true},
+	})
+
+	if stats.Collections != 1 {
+		t.Fatalf("Collections = %d", stats.Collections)
+	}
+	if stats.PostGC.Available {
+		t.Fatalf("PostGC = %#v", stats.PostGC)
+	}
+}

--- a/internal/gclog/tailer.go
+++ b/internal/gclog/tailer.go
@@ -1,0 +1,86 @@
+package gclog
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+type Tailer struct {
+	Path         string
+	PollInterval time.Duration
+}
+
+func (t Tailer) Run(ctx context.Context, events chan<- Event) error {
+	if strings.TrimSpace(t.Path) == "" {
+		return errors.New("GCログのパスが空です")
+	}
+
+	file, err := t.waitForFile(ctx)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	var partial string
+	for {
+		line, readErr := reader.ReadString('\n')
+		partial += line
+		switch {
+		case readErr == nil:
+			if event, ok := Parse(partial); ok {
+				select {
+				case events <- event:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			partial = ""
+		case errors.Is(readErr, io.EOF):
+			if err := wait(ctx, t.pollInterval()); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("GCログを読む: %w", readErr)
+		}
+	}
+}
+
+func (t Tailer) waitForFile(ctx context.Context) (*os.File, error) {
+	for {
+		file, err := os.Open(t.Path)
+		switch {
+		case err == nil:
+			return file, nil
+		case !errors.Is(err, os.ErrNotExist):
+			return nil, fmt.Errorf("GCログを開く: %w", err)
+		}
+		if err := wait(ctx, t.pollInterval()); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func (t Tailer) pollInterval() time.Duration {
+	if t.PollInterval <= 0 {
+		return 100 * time.Millisecond
+	}
+	return t.PollInterval
+}
+
+func wait(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/gclog/tailer_test.go
+++ b/internal/gclog/tailer_test.go
@@ -1,0 +1,78 @@
+package gclog
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestTailerWaitsForFileAndReadsCompleteLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gc.log")
+	events := make(chan Event, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- (Tailer{
+			Path:         path,
+			PollInterval: time.Millisecond,
+		}).Run(ctx, events)
+	}()
+
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString(
+		"[1.000s][info][gc] GC(0) Pause Young 10M->",
+	); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	select {
+	case event := <-events:
+		t.Fatalf("received partial event: %#v", event)
+	default:
+	}
+	if _, err := file.WriteString("2M(100M) 1.000ms\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case event := <-events:
+		assertBytes(t, event.After, 2<<20)
+		cancel()
+	case <-time.After(time.Second):
+		t.Fatal("event was not received")
+	}
+	if err := <-result; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error = %v", err)
+	}
+}
+
+func TestTailerCanBeCanceledBeforeFileExists(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := (Tailer{
+		Path:         filepath.Join(t.TempDir(), "missing.log"),
+		PollInterval: time.Millisecond,
+	}).Run(ctx, make(chan Event))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error = %v", err)
+	}
+}
+
+func TestTailerRejectsEmptyPath(t *testing.T) {
+	err := (Tailer{}).Run(context.Background(), make(chan Event))
+	if err == nil {
+		t.Fatal("Run succeeded")
+	}
+}

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -238,7 +238,8 @@ func withJavaToolOptions(extraEnv []string, gcLogPath string) []string {
 	env = append(env, extraEnv...)
 
 	const key = "JAVA_TOOL_OPTIONS"
-	flag := "-Xlog:gc:file=" + gcLogPath + ":time,uptime,level,tags"
+	flag := "-Xlog:gc:file=" + gcLogPath +
+		":time,uptime,level,tags:filecount=0"
 
 	value := ""
 	filtered := env[:0]

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -59,6 +59,9 @@ printf 'got:%s\n' "$line"
 	if !strings.Contains(output, "-Dexisting=true -Xlog:gc:file="+gcLogPath) {
 		t.Fatalf("JAVA_TOOL_OPTIONS was %q", output)
 	}
+	if !strings.Contains(output, ":time,uptime,level,tags:filecount=0") {
+		t.Fatalf("JAVA_TOOL_OPTIONS was %q", output)
+	}
 	if !strings.Contains(output, "got:say hello") {
 		t.Fatalf("stdout = %q", output)
 	}


### PR DESCRIPTION
## 概要

- `JAVA_TOOL_OPTIONS`で出力するGCログのローテーションを無効化
- GCログファイルの生成待ちと追記tailを実装
- G1/Serial系およびZGC形式からGC前後ヒープ・容量・停止時間・uptimeを解析
- GC後ヒープ、停止時間、GC回数・頻度を集計
- 部分行とキャンセルを含むtailテストを追加

## 検証

- go test ./...
- go test -race ./...
- go vet ./...
- CGO_ENABLED=0でlinux/amd64・linux/arm64ビルド