### PR TITLE
Minecraftサーバーログの分類と状態追跡を実装

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -227,7 +227,7 @@ mod が開ける扉は TPS だけではなく、MSPT 分布（p95/最大）・�
 - [x] hsperfdata パーサ
 - [x] `/proc` RSS + cgroup 取得
 - [x] `JAVA_TOOL_OPTIONS` 注入と GC ログ tail
-- [ ] ログ分類パーサ（チャット / コマンド / 参加退出 / ラグ / その他）
+- [x] ログ分類パーサ（チャット / コマンド / 参加退出 / ラグ / その他）
 - [ ] TUI（統計ヘッダ + 3ペイン + 入力欄）
 - [ ] コマンド送信、restart / stop の矢印キー操作
 - [ ] goreleaser で amd64 / arm64 リリース

--- a/internal/serverlog/parser.go
+++ b/internal/serverlog/parser.go
@@ -1,0 +1,185 @@
+package serverlog
+
+import (
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Kind uint8
+
+const (
+	KindOther Kind = iota
+	KindChat
+	KindCommand
+	KindPlayerJoin
+	KindPlayerLeave
+	KindLag
+	KindIgnored
+)
+
+func (kind Kind) String() string {
+	switch kind {
+	case KindChat:
+		return "chat"
+	case KindCommand:
+		return "command"
+	case KindPlayerJoin:
+		return "player_join"
+	case KindPlayerLeave:
+		return "player_leave"
+	case KindLag:
+		return "lag"
+	case KindIgnored:
+		return "ignored"
+	default:
+		return "other"
+	}
+}
+
+type Lag struct {
+	Behind      time.Duration
+	BehindKnown bool
+	TicksBehind uint64
+	TicksKnown  bool
+}
+
+type Entry struct {
+	Kind    Kind
+	Raw     string
+	Message string
+	Player  string
+	Chat    string
+	Command string
+	Reason  string
+	Lag     Lag
+}
+
+var (
+	ansiPattern = regexp.MustCompile(
+		"\x1b\\[[0-?]*[ -/]*[@-~]",
+	)
+	logPrefixPattern = regexp.MustCompile(
+		`^\[[^\]\r\n]+\]\s+` +
+			`\[[^\]\r\n]+/(?:TRACE|DEBUG|INFO|WARN|ERROR|FATAL)\]` +
+			`(?:\s+\[[^\]\r\n]+\])*\s*:\s?(.*)$`,
+	)
+	chatPattern = regexp.MustCompile(
+		`^(?:\[Not Secure\]\s+)?<([^<>\s]+)>\s?(.*)$`,
+	)
+	commandPattern = regexp.MustCompile(
+		`^(\S+)\s+issued server command:\s+(.+)$`,
+	)
+	joinPattern = regexp.MustCompile(
+		`^(\S+)\s+joined the game$`,
+	)
+	leavePattern = regexp.MustCompile(
+		`^(\S+)\s+left the game$`,
+	)
+	lostConnectionPattern = regexp.MustCompile(
+		`^(\S+)\s+lost connection:\s*(.*)$`,
+	)
+	modernLagPattern = regexp.MustCompile(
+		`Running\s+([0-9]+)ms\s+or\s+([0-9]+)\s+ticks?\s+behind`,
+	)
+	legacyLagPattern = regexp.MustCompile(
+		`Running\s+([0-9]+)ms\s+behind,\s+skipping\s+` +
+			`([0-9]+)\s+tick(?:s|\(s\))?`,
+	)
+)
+
+func Parse(line string) Entry {
+	raw := strings.TrimRight(line, "\r\n")
+	normalized := ansiPattern.ReplaceAllString(raw, "")
+	message := extractMessage(normalized)
+	entry := Entry{
+		Kind:    KindOther,
+		Raw:     raw,
+		Message: message,
+	}
+
+	if strings.HasPrefix(strings.TrimSpace(message), "Picked up JAVA_TOOL_OPTIONS:") {
+		entry.Kind = KindIgnored
+		return entry
+	}
+
+	if match := chatPattern.FindStringSubmatch(message); match != nil {
+		entry.Kind = KindChat
+		entry.Player = match[1]
+		entry.Chat = match[2]
+		return entry
+	}
+	if match := commandPattern.FindStringSubmatch(message); match != nil {
+		entry.Kind = KindCommand
+		entry.Player = match[1]
+		entry.Command = match[2]
+		return entry
+	}
+	if match := joinPattern.FindStringSubmatch(message); match != nil {
+		entry.Kind = KindPlayerJoin
+		entry.Player = match[1]
+		return entry
+	}
+	if match := leavePattern.FindStringSubmatch(message); match != nil {
+		entry.Kind = KindPlayerLeave
+		entry.Player = match[1]
+		return entry
+	}
+	if match := lostConnectionPattern.FindStringSubmatch(message); match != nil {
+		entry.Kind = KindPlayerLeave
+		entry.Player = match[1]
+		entry.Reason = match[2]
+		return entry
+	}
+	if strings.Contains(message, "Can't keep up!") {
+		entry.Kind = KindLag
+		entry.Lag = parseLag(message)
+	}
+	return entry
+}
+
+func SentCommand(command string) Entry {
+	command = strings.TrimRight(command, "\r\n")
+	return Entry{
+		Kind:    KindCommand,
+		Message: command,
+		Command: command,
+	}
+}
+
+func extractMessage(line string) string {
+	match := logPrefixPattern.FindStringSubmatch(line)
+	if match == nil {
+		return line
+	}
+	return match[1]
+}
+
+func parseLag(message string) Lag {
+	match := modernLagPattern.FindStringSubmatch(message)
+	if match == nil {
+		match = legacyLagPattern.FindStringSubmatch(message)
+	}
+	if match == nil {
+		return Lag{}
+	}
+
+	var lag Lag
+	if milliseconds, ok := parseUint(match[1]); ok &&
+		milliseconds <= uint64(math.MaxInt64/int64(time.Millisecond)) {
+		lag.Behind = time.Duration(milliseconds) * time.Millisecond
+		lag.BehindKnown = true
+	}
+	if ticks, ok := parseUint(match[2]); ok {
+		lag.TicksBehind = ticks
+		lag.TicksKnown = true
+	}
+	return lag
+}
+
+func parseUint(value string) (uint64, bool) {
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	return parsed, err == nil
+}

--- a/internal/serverlog/parser_test.go
+++ b/internal/serverlog/parser_test.go
@@ -1,0 +1,204 @@
+package serverlog
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseVanillaChat(t *testing.T) {
+	line := "[12:34:56] [Server thread/INFO]: <alice> hello world"
+
+	entry := Parse(line)
+
+	assertKind(t, entry, KindChat)
+	if entry.Player != "alice" || entry.Chat != "hello world" {
+		t.Fatalf("Entry = %#v", entry)
+	}
+	if entry.Message != "<alice> hello world" || entry.Raw != line {
+		t.Fatalf("Entry = %#v", entry)
+	}
+}
+
+func TestParseNotSecureChat(t *testing.T) {
+	entry := Parse(
+		"[12:34:56] [Server thread/INFO]: [Not Secure] <alice> hello",
+	)
+
+	assertKind(t, entry, KindChat)
+	if entry.Player != "alice" || entry.Chat != "hello" {
+		t.Fatalf("Entry = %#v", entry)
+	}
+}
+
+func TestParseForgeCommand(t *testing.T) {
+	entry := Parse(
+		"[27Jul2026 12:34:56.123] [Server thread/INFO] " +
+			"[net.minecraft.server.MinecraftServer/]: " +
+			"alice issued server command: /time set day",
+	)
+
+	assertKind(t, entry, KindCommand)
+	if entry.Player != "alice" || entry.Command != "/time set day" {
+		t.Fatalf("Entry = %#v", entry)
+	}
+}
+
+func TestParsePlayerChanges(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		kind    Kind
+		player  string
+		reason  string
+	}{
+		{
+			name:    "join",
+			message: "alice joined the game",
+			kind:    KindPlayerJoin,
+			player:  "alice",
+		},
+		{
+			name:    "leave",
+			message: "alice left the game",
+			kind:    KindPlayerLeave,
+			player:  "alice",
+		},
+		{
+			name:    "lost connection",
+			message: "alice lost connection: Timed out",
+			kind:    KindPlayerLeave,
+			player:  "alice",
+			reason:  "Timed out",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entry := Parse(
+				"[12:34:56] [Server thread/INFO]: " + test.message,
+			)
+			assertKind(t, entry, test.kind)
+			if entry.Player != test.player || entry.Reason != test.reason {
+				t.Fatalf("Entry = %#v", entry)
+			}
+		})
+	}
+}
+
+func TestParseModernLag(t *testing.T) {
+	entry := Parse(
+		"[12:34:56] [Server thread/WARN]: Can't keep up! " +
+			"Is the server overloaded? Running 2531ms or 50 ticks behind",
+	)
+
+	assertLag(t, entry, 2531*time.Millisecond, 50)
+}
+
+func TestParseLegacyLag(t *testing.T) {
+	entry := Parse(
+		"[12:34:56] [Server thread/WARN]: Can't keep up! " +
+			"Running 2531ms behind, skipping 50 tick(s)",
+	)
+
+	assertLag(t, entry, 2531*time.Millisecond, 50)
+}
+
+func TestParseLagWithoutDetails(t *testing.T) {
+	entry := Parse(
+		"[12:34:56] [Server thread/WARN]: Can't keep up! unknown format",
+	)
+
+	assertKind(t, entry, KindLag)
+	if entry.Lag.BehindKnown || entry.Lag.TicksKnown {
+		t.Fatalf("Lag = %#v", entry.Lag)
+	}
+}
+
+func TestParseStripsANSIForClassification(t *testing.T) {
+	entry := Parse(
+		"\x1b[32m[12:34:56] [Server thread/INFO]: " +
+			"<alice> green\x1b[0m",
+	)
+
+	assertKind(t, entry, KindChat)
+	if entry.Chat != "green" {
+		t.Fatalf("Entry = %#v", entry)
+	}
+}
+
+func TestParseIgnoresJavaToolOptionsNotice(t *testing.T) {
+	entry := Parse(
+		"Picked up JAVA_TOOL_OPTIONS: -Xlog:gc:file=/tmp/hso/gc.log",
+	)
+
+	assertKind(t, entry, KindIgnored)
+}
+
+func TestParseKeepsOtherLines(t *testing.T) {
+	line := "[12:34:56] [Server thread/INFO]: Done (1.234s)! For help, type \"help\""
+	entry := Parse(line)
+
+	assertKind(t, entry, KindOther)
+	if entry.Raw != line ||
+		entry.Message != "Done (1.234s)! For help, type \"help\"" {
+		t.Fatalf("Entry = %#v", entry)
+	}
+}
+
+func TestParseDoesNotTreatChatContentsAsLag(t *testing.T) {
+	entry := Parse(
+		"[12:34:56] [Server thread/INFO]: <alice> Can't keep up!",
+	)
+
+	assertKind(t, entry, KindChat)
+}
+
+func TestSentCommand(t *testing.T) {
+	entry := SentCommand("say hello\n")
+
+	assertKind(t, entry, KindCommand)
+	if entry.Command != "say hello" || entry.Message != "say hello" {
+		t.Fatalf("Entry = %#v", entry)
+	}
+}
+
+func TestKindString(t *testing.T) {
+	tests := map[Kind]string{
+		KindOther:       "other",
+		KindChat:        "chat",
+		KindCommand:     "command",
+		KindPlayerJoin:  "player_join",
+		KindPlayerLeave: "player_leave",
+		KindLag:         "lag",
+		KindIgnored:     "ignored",
+		Kind(255):       "other",
+	}
+	for kind, want := range tests {
+		if got := kind.String(); got != want {
+			t.Errorf("Kind(%d).String() = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func assertKind(t *testing.T, entry Entry, want Kind) {
+	t.Helper()
+	if entry.Kind != want {
+		t.Fatalf("Kind = %s, want %s; Entry = %#v", entry.Kind, want, entry)
+	}
+}
+
+func assertLag(
+	t *testing.T,
+	entry Entry,
+	wantBehind time.Duration,
+	wantTicks uint64,
+) {
+	t.Helper()
+	assertKind(t, entry, KindLag)
+	if !entry.Lag.BehindKnown || entry.Lag.Behind != wantBehind {
+		t.Fatalf("Lag.Behind = %#v, want %s", entry.Lag, wantBehind)
+	}
+	if !entry.Lag.TicksKnown || entry.Lag.TicksBehind != wantTicks {
+		t.Fatalf("Lag.TicksBehind = %#v, want %d", entry.Lag, wantTicks)
+	}
+}

--- a/internal/serverlog/tracker.go
+++ b/internal/serverlog/tracker.go
@@ -1,0 +1,39 @@
+package serverlog
+
+import "sort"
+
+type Tracker struct {
+	players   map[string]struct{}
+	lagEvents uint64
+}
+
+func (tracker *Tracker) Apply(entry Entry) {
+	switch entry.Kind {
+	case KindPlayerJoin:
+		if tracker.players == nil {
+			tracker.players = make(map[string]struct{})
+		}
+		tracker.players[entry.Player] = struct{}{}
+	case KindPlayerLeave:
+		delete(tracker.players, entry.Player)
+	case KindLag:
+		tracker.lagEvents++
+	}
+}
+
+func (tracker *Tracker) Players() []string {
+	players := make([]string, 0, len(tracker.players))
+	for player := range tracker.players {
+		players = append(players, player)
+	}
+	sort.Strings(players)
+	return players
+}
+
+func (tracker *Tracker) PlayerCount() int {
+	return len(tracker.players)
+}
+
+func (tracker *Tracker) LagEvents() uint64 {
+	return tracker.lagEvents
+}

--- a/internal/serverlog/tracker_test.go
+++ b/internal/serverlog/tracker_test.go
@@ -1,0 +1,59 @@
+package serverlog
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTrackerTracksPlayersAndLagEvents(t *testing.T) {
+	var tracker Tracker
+	entries := []Entry{
+		Parse("[12:00:00] [Server thread/INFO]: zoe joined the game"),
+		Parse("[12:00:01] [Server thread/INFO]: alice joined the game"),
+		Parse("[12:00:02] [Server thread/INFO]: zoe joined the game"),
+		Parse("[12:00:03] [Server thread/WARN]: Can't keep up!"),
+		Parse("[12:00:04] [Server thread/INFO]: zoe left the game"),
+	}
+	for _, entry := range entries {
+		tracker.Apply(entry)
+	}
+
+	if got, want := tracker.Players(), []string{"alice"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Players = %v, want %v", got, want)
+	}
+	if tracker.PlayerCount() != 1 {
+		t.Fatalf("PlayerCount = %d", tracker.PlayerCount())
+	}
+	if tracker.LagEvents() != 1 {
+		t.Fatalf("LagEvents = %d", tracker.LagEvents())
+	}
+}
+
+func TestTrackerLostConnectionRemovesPlayer(t *testing.T) {
+	var tracker Tracker
+	tracker.Apply(Parse(
+		"[12:00:00] [Server thread/INFO]: alice joined the game",
+	))
+	tracker.Apply(Parse(
+		"[12:00:01] [Server thread/INFO]: " +
+			"alice lost connection: Disconnected",
+	))
+
+	if tracker.PlayerCount() != 0 {
+		t.Fatalf("Players = %v", tracker.Players())
+	}
+}
+
+func TestTrackerPlayersReturnsCopy(t *testing.T) {
+	var tracker Tracker
+	tracker.Apply(Parse(
+		"[12:00:00] [Server thread/INFO]: alice joined the game",
+	))
+
+	players := tracker.Players()
+	players[0] = "changed"
+
+	if got := tracker.Players(); !reflect.DeepEqual(got, []string{"alice"}) {
+		t.Fatalf("Players = %v", got)
+	}
+}


### PR DESCRIPTION
## 概要
- バニラ / Forge / NeoForge の標準ログ接頭辞を除去して分類
- チャット、コマンド、参加・退出、lost connection、ラグイベントを構造化
- JAVA_TOOL_OPTIONS 通知の除外とANSI制御シーケンスへの対応
- プレイヤー一覧とラグイベント数の状態追跡を追加

## 検証
- go test ./...
- go vet ./...
- CGO_ENABLED=0 linux/amd64 静的ビルド
- CGO_ENABLED=0 linux/arm64 クロスビルド