### PR TITLE
Java 26のメモリメトリクス取得を修正

### DIFF
--- a/cmd/hso/app.go
+++ b/cmd/hso/app.go
@@ -34,6 +34,14 @@ const (
 	initialGeneration  = 1
 )
 
+var errHeapCountersUnavailable = errors.New(
+	"hsperfdataにヒープ使用量カウンタがありません",
+)
+
+var errRSSUnavailable = errors.New(
+	"/procのstatusにVmRSSがありません",
+)
+
 type stoppableServer interface {
 	Done() <-chan struct{}
 	Send(string) error
@@ -400,10 +408,13 @@ func collectMetrics(
 
 	for {
 		var metrics hsperfdata.Metrics
+		var jvmErr error
 		if reader == nil {
 			opened, err := hsperfdata.Open(pid)
 			if err == nil {
 				reader = opened
+			} else {
+				jvmErr = err
 			}
 		}
 		if reader != nil {
@@ -411,16 +422,26 @@ func collectMetrics(
 			if err != nil {
 				_ = reader.Close()
 				reader = nil
+				jvmErr = err
 			} else {
 				metrics = snapshot.Metrics()
+				if !metrics.Heap.Used.Available ||
+					!metrics.Heap.Committed.Available {
+					jvmErr = errHeapCountersUnavailable
+				}
 			}
 		}
 
-		memory, _ := procstats.ReadMemory(pid)
+		memory, memoryErr := procstats.ReadMemory(pid)
+		if memoryErr == nil && !memory.RSS.Available {
+			memoryErr = errRSSUnavailable
+		}
 		program.Send(ui.MetricsMsg{
-			Generation: generation,
-			JVM:        metrics,
-			Memory:     memory,
+			Generation:  generation,
+			JVM:         metrics,
+			Memory:      memory,
+			JVMError:    errorText(jvmErr),
+			MemoryError: errorText(memoryErr),
 		})
 
 		select {
@@ -429,6 +450,13 @@ func collectMetrics(
 		case <-ticker.C:
 		}
 	}
+}
+
+func errorText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 func streamGC(

--- a/internal/hsperfdata/metrics.go
+++ b/internal/hsperfdata/metrics.go
@@ -45,7 +45,7 @@ type Metrics struct {
 func (s Snapshot) Metrics() Metrics {
 	var metrics Metrics
 
-	generationCount, generationsAvailable := s.Long("sun.gc.generations")
+	generationCount, generationsAvailable := s.Long("sun.gc.policy.generations")
 	var (
 		heapUsed      []Number
 		heapCommitted []Number
@@ -100,7 +100,7 @@ func (s Snapshot) Metrics() Metrics {
 
 	metrics.Threads = number(s, "java.threads.live")
 
-	collectorCount, _ := s.Long("sun.gc.collectors")
+	collectorCount, _ := s.Long("sun.gc.policy.collectors")
 	for index := int64(0); index < collectorCount; index++ {
 		prefix := fmt.Sprintf("sun.gc.collector.%d", index)
 		name, _ := s.String(prefix + ".name")

--- a/internal/hsperfdata/metrics_test.go
+++ b/internal/hsperfdata/metrics_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestMetrics(t *testing.T) {
 	snapshot := Snapshot{Counters: map[string]Counter{
-		"sun.gc.generations":                      {long: 2},
+		"sun.gc.policy.generations":               {long: 2},
 		"sun.gc.generation.0.name":                {text: "young", isString: true},
 		"sun.gc.generation.0.spaces":              {long: 2},
 		"sun.gc.generation.0.capacity":            {long: 300},
@@ -26,7 +26,7 @@ func TestMetrics(t *testing.T) {
 		"sun.gc.compressedclassspace.used":        {long: 10},
 		"sun.gc.compressedclassspace.capacity":    {long: 20},
 		"sun.gc.compressedclassspace.maxCapacity": {long: 100},
-		"sun.gc.collectors":                       {long: 1},
+		"sun.gc.policy.collectors":                {long: 1},
 		"sun.gc.collector.0.name":                 {text: "young GC", isString: true},
 		"sun.gc.collector.0.invocations":          {long: 12},
 		"sun.gc.collector.0.time":                 {long: 1250},
@@ -76,7 +76,7 @@ func TestMetricsKeepsUnavailableValuesExplicit(t *testing.T) {
 
 func TestMetricsRejectsPartialSpaceSum(t *testing.T) {
 	snapshot := Snapshot{Counters: map[string]Counter{
-		"sun.gc.generations":               {long: 1},
+		"sun.gc.policy.generations":        {long: 1},
 		"sun.gc.generation.0.spaces":       {long: 2},
 		"sun.gc.generation.0.capacity":     {long: 300},
 		"sun.gc.generation.0.maxCapacity":  {long: 600},
@@ -92,7 +92,7 @@ func TestMetricsRejectsPartialSpaceSum(t *testing.T) {
 
 func TestMetricsRejectsPartialGenerationSum(t *testing.T) {
 	snapshot := Snapshot{Counters: map[string]Counter{
-		"sun.gc.generations":               {long: 2},
+		"sun.gc.policy.generations":        {long: 2},
 		"sun.gc.generation.0.spaces":       {long: 1},
 		"sun.gc.generation.0.capacity":     {long: 300},
 		"sun.gc.generation.0.maxCapacity":  {long: 600},

--- a/internal/hsperfdata/parser.go
+++ b/internal/hsperfdata/parser.go
@@ -62,7 +62,7 @@ func Parse(data []byte) (Snapshot, error) {
 	if err != nil {
 		return Snapshot{}, err
 	}
-	if order.Uint32(data[0:4]) != magic {
+	if binary.BigEndian.Uint32(data[0:4]) != magic {
 		return Snapshot{}, errors.New("hsperfdataのマジック値が不正です")
 	}
 	if data[5] != 2 {

--- a/internal/hsperfdata/parser_test.go
+++ b/internal/hsperfdata/parser_test.go
@@ -89,7 +89,7 @@ func perfData(t *testing.T, order binary.ByteOrder, entries ...testEntry) []byte
 	}
 	data[5] = 2
 	data[7] = 1
-	order.PutUint32(data[0:4], magic)
+	binary.BigEndian.PutUint32(data[0:4], magic)
 	order.PutUint32(data[24:28], prologueSize)
 	order.PutUint32(data[28:32], uint32(len(entries)))
 

--- a/internal/hsperfdata/reader_linux.go
+++ b/internal/hsperfdata/reader_linux.go
@@ -38,6 +38,7 @@ func openAtUID(tempDir string, pid int, uid uint32) (*Reader, error) {
 	if err != nil {
 		return nil, fmt.Errorf("hsperfdataを探す: %w", err)
 	}
+	var candidateErr error
 	for _, path := range matches {
 		if !ownedBy(filepath.Dir(path), uid) {
 			continue
@@ -46,6 +47,12 @@ func openAtUID(tempDir string, pid int, uid uint32) (*Reader, error) {
 		if err == nil {
 			return reader, nil
 		}
+		if candidateErr == nil {
+			candidateErr = err
+		}
+	}
+	if candidateErr != nil {
+		return nil, candidateErr
 	}
 	return nil, fmt.Errorf("%w: PID %d", ErrNotFound, pid)
 }

--- a/internal/hsperfdata/reader_linux_test.go
+++ b/internal/hsperfdata/reader_linux_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -45,6 +46,25 @@ func TestHotSpotTempDirDoesNotFollowTMPDIR(t *testing.T) {
 func TestReaderReportsMissingFile(t *testing.T) {
 	_, err := openAt(t.TempDir(), 123)
 	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestReaderPreservesCandidateError(t *testing.T) {
+	tempDir := t.TempDir()
+	perfDir := filepath.Join(tempDir, "hsperfdata_test")
+	if err := os.Mkdir(perfDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(perfDir, "123"), []byte("short"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := openAt(tempDir, 123)
+	if err == nil || errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "種類、サイズ、所有者") {
 		t.Fatalf("err = %v", err)
 	}
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -31,7 +31,10 @@ var (
 			Bold(true)
 )
 
-const maxInputRunes = 512
+const (
+	maxInputRunes       = 512
+	maxMetricErrorRunes = 256
+)
 
 type ActionKind uint8
 
@@ -51,9 +54,11 @@ type LogMsg struct {
 }
 
 type MetricsMsg struct {
-	Generation uint64
-	JVM        hsperfdata.Metrics
-	Memory     procstats.Memory
+	Generation  uint64
+	JVM         hsperfdata.Metrics
+	Memory      procstats.Memory
+	JVMError    string
+	MemoryError string
 }
 
 type GCMsg struct {
@@ -96,23 +101,25 @@ const (
 )
 
 type Model struct {
-	layout     layout
-	status     string
-	runErr     error
-	actions    chan<- Action
-	input      []rune
-	focus      focus
-	busy       bool
-	generation uint64
-	metrics    hsperfdata.Metrics
-	memory     procstats.Memory
-	gcStats    gclog.Stats
-	tracker    serverlog.Tracker
-	players    string
-	chat       lineBuffer
-	commands   lineBuffer
-	logs       lineBuffer
-	samples    sampleBuffer
+	layout            layout
+	status            string
+	runErr            error
+	actions           chan<- Action
+	input             []rune
+	focus             focus
+	busy              bool
+	generation        uint64
+	metrics           hsperfdata.Metrics
+	memory            procstats.Memory
+	jvmMetricError    string
+	memoryMetricError string
+	gcStats           gclog.Stats
+	tracker           serverlog.Tracker
+	players           string
+	chat              lineBuffer
+	commands          lineBuffer
+	logs              lineBuffer
+	samples           sampleBuffer
 }
 
 func New(actions chan<- Action, generation uint64) *Model {
@@ -148,6 +155,8 @@ func (model *Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			Threads: message.JVM.Threads,
 		}
 		model.memory = message.Memory
+		model.updateMetricError("heap", &model.jvmMetricError, message.JVMError)
+		model.updateMetricError("RSS", &model.memoryMetricError, message.MemoryError)
 		model.addSample(message)
 	case GCMsg:
 		if !model.accepts(message.Generation) {
@@ -341,6 +350,8 @@ func (model *Model) offer(action Action) bool {
 func (model *Model) resetServerState() {
 	model.metrics = hsperfdata.Metrics{}
 	model.memory = procstats.Memory{}
+	model.jvmMetricError = ""
+	model.memoryMetricError = ""
 	model.gcStats = gclog.Stats{}
 	model.tracker = serverlog.Tracker{}
 	model.players = ""
@@ -441,12 +452,48 @@ func (model *Model) addSample(message MetricsMsg) {
 	model.samples.Add(sample)
 }
 
+func (model *Model) updateMetricError(source string, current *string, next string) {
+	if next == *current {
+		return
+	}
+	next = truncateRunes(next, maxMetricErrorRunes)
+	if next == *current {
+		return
+	}
+	if next == "" {
+		if *current != "" {
+			model.addLog(serverlog.Entry{
+				Kind:    serverlog.KindOther,
+				Message: "metrics: " + source + " recovered",
+			})
+		}
+	} else {
+		model.addLog(serverlog.Entry{
+			Kind:    serverlog.KindOther,
+			Message: "metrics: " + source + " unavailable: " + next,
+		})
+	}
+	*current = next
+}
+
+func truncateRunes(value string, limit int) string {
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	return string(runes[:limit])
+}
+
 func (model *Model) statsTitle() string {
-	return fmt.Sprintf(
+	title := fmt.Sprintf(
 		"hijo-server-ops · %s · uptime %s",
 		model.status,
 		formatUptime(model.metrics.Uptime),
 	)
+	if model.jvmMetricError != "" || model.memoryMetricError != "" {
+		title += " · metrics degraded"
+	}
+	return title
 }
 
 func (model *Model) statsLines() []string {
@@ -515,6 +562,20 @@ func (model *Model) statsLines() []string {
 		2,
 		maximum,
 	)
+	if model.jvmMetricError != "" {
+		heap[0] = truncate(
+			"unavailable: "+model.jvmMetricError,
+			model.layout.graphWidth,
+		)
+		heap[1] = ""
+	}
+	if model.memoryMetricError != "" {
+		rss[0] = truncate(
+			"unavailable: "+model.memoryMetricError,
+			model.layout.graphWidth,
+		)
+		rss[1] = ""
+	}
 	for index, graphLine := range heap {
 		label := "     "
 		if index == 0 {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -135,6 +135,45 @@ func TestModelDoesNotRetainMetricsThatAreNotDisplayed(t *testing.T) {
 	}
 }
 
+func TestModelReportsMetricFailureOnceAndRecovery(t *testing.T) {
+	model := newTestModel()
+	_, _ = model.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
+
+	failure := MetricsMsg{JVMError: "hsperfdataが見つかりません"}
+	_, _ = model.Update(failure)
+	_, _ = model.Update(failure)
+
+	if model.logs.Len() != 1 {
+		t.Fatalf("failure logs = %d", model.logs.Len())
+	}
+	if !strings.Contains(model.statsTitle(), "metrics degraded") {
+		t.Fatalf("title = %q", model.statsTitle())
+	}
+	if !strings.Contains(strings.Join(model.statsLines(), "\n"), failure.JVMError) {
+		t.Fatalf("stats = %q", model.statsLines())
+	}
+
+	_, _ = model.Update(MetricsMsg{})
+	if model.logs.Len() != 2 ||
+		!strings.Contains(model.logs.At(1), "heap recovered") {
+		t.Fatalf("logs = %q, %q", model.logs.At(0), model.logs.At(1))
+	}
+	if strings.Contains(model.statsTitle(), "metrics degraded") {
+		t.Fatalf("title = %q", model.statsTitle())
+	}
+}
+
+func TestModelBoundsCurrentMetricError(t *testing.T) {
+	model := newTestModel()
+	_, _ = model.Update(MetricsMsg{
+		JVMError: strings.Repeat("あ", maxMetricErrorRunes+10),
+	})
+
+	if len([]rune(model.jvmMetricError)) != maxMetricErrorRunes {
+		t.Fatalf("error runes = %d", len([]rune(model.jvmMetricError)))
+	}
+}
+
 func TestModelReturnsProcessError(t *testing.T) {
 	model := newTestModel()
 	want := errors.New("server failed")


### PR DESCRIPTION
## 変更内容
- hsperfdata のマジック値を仕様どおりビッグエンディアンで検証
- Java 26 が公開する GC policy カウンタ名に修正
- Heap/RSS の取得失敗理由を現在状態として表示し、状態変化時だけログへ記録
- hsperfdata 候補ファイルの実エラーを保持
- 診断文字列と画面内ログ・グラフ履歴を固定上限に維持

## 検証
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- Java 26 / Minecraft 26.2 の実起動で Heap used/committed/max と RSS の更新を確認