### PR TITLE
実サーバー検証で見つかった監視不具合を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /hso
 /dist/
+/mc-server-test/
 *.test
 *.out
 

--- a/cmd/hso/app.go
+++ b/cmd/hso/app.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -83,6 +84,7 @@ type serverRuntime struct {
 	server       *process.Process
 	generation   uint64
 	javaFound    atomic.Bool
+	expectedExit atomic.Bool
 	cancel       context.CancelFunc
 	stdoutReader *io.PipeReader
 	stdoutWriter *io.PipeWriter
@@ -210,10 +212,15 @@ func (controller *serverController) sendCommand(action ui.Action) {
 		})
 		return
 	}
-	controller.program.Send(ui.ActionResultMsg{
-		Action: action,
-		Err:    runtime.server.Send(action.Command),
-	})
+	isStop := strings.EqualFold(strings.TrimSpace(action.Command), "stop")
+	if isStop {
+		runtime.expectedExit.Store(true)
+	}
+	err := runtime.server.Send(action.Command)
+	if err != nil && isStop {
+		runtime.expectedExit.Store(false)
+	}
+	controller.program.Send(ui.ActionResultMsg{Action: action, Err: err})
 }
 
 func (controller *serverController) restart() {
@@ -289,13 +296,25 @@ func (controller *serverController) waitForServer(runtime *serverRuntime) {
 	if !controller.detach(runtime) {
 		return
 	}
-	if !runtime.javaFound.Load() && waitErr == nil {
-		waitErr = errors.New("起動スクリプトがjavaプロセスを開始せずに終了しました")
-	}
+	waitErr = serverExitError(
+		waitErr,
+		runtime.javaFound.Load(),
+		runtime.expectedExit.Load(),
+	)
 	controller.program.Send(ui.ProcessExitedMsg{
 		Generation: runtime.generation,
 		Err:        waitErr,
 	})
+}
+
+func serverExitError(waitErr error, javaFound, expected bool) error {
+	if waitErr != nil || expected {
+		return waitErr
+	}
+	if !javaFound {
+		return errors.New("起動スクリプトがjavaプロセスを開始せずに終了しました")
+	}
+	return errors.New("Minecraftサーバーが予期せず終了しました")
 }
 
 func (controller *serverController) currentRuntime() *serverRuntime {
@@ -400,6 +419,8 @@ func collectMetrics(
 	defer ticker.Stop()
 
 	var reader *hsperfdata.Reader
+	var previousCPU procstats.Duration
+	var previousSample time.Time
 	defer func() {
 		if reader != nil {
 			_ = reader.Close()
@@ -436,12 +457,23 @@ func collectMetrics(
 		if memoryErr == nil && !memory.RSS.Available {
 			memoryErr = errRSSUnavailable
 		}
+		cpuTime, _ := procstats.ReadCPUTime(pid)
+		sampledAt := time.Now()
+		cpu, cpuAvailable := calculateCPU(
+			previousCPU,
+			cpuTime,
+			sampledAt.Sub(previousSample),
+		)
+		previousCPU = cpuTime
+		previousSample = sampledAt
 		program.Send(ui.MetricsMsg{
-			Generation:  generation,
-			JVM:         metrics,
-			Memory:      memory,
-			JVMError:    errorText(jvmErr),
-			MemoryError: errorText(memoryErr),
+			Generation:   generation,
+			JVM:          metrics,
+			Memory:       memory,
+			CPU:          cpu,
+			CPUAvailable: cpuAvailable,
+			JVMError:     errorText(jvmErr),
+			MemoryError:  errorText(memoryErr),
 		})
 
 		select {
@@ -450,6 +482,19 @@ func collectMetrics(
 		case <-ticker.C:
 		}
 	}
+}
+
+func calculateCPU(
+	previous procstats.Duration,
+	current procstats.Duration,
+	elapsed time.Duration,
+) (float64, bool) {
+	if !previous.Available || !current.Available ||
+		current.Value < previous.Value || elapsed <= 0 {
+		return 0, false
+	}
+	used := current.Value - previous.Value
+	return float64(used) / float64(elapsed) * 100, true
 }
 
 func errorText(err error) string {
@@ -466,13 +511,25 @@ func streamGC(
 	generation uint64,
 ) {
 	events := make(chan gclog.Event, 4)
+	result := make(chan error, 1)
 	go func() {
-		_ = (gclog.Tailer{Path: path}).Run(ctx, events)
+		result <- (gclog.Tailer{Path: path}).Run(ctx, events)
 	}()
 
 	for {
 		select {
 		case <-ctx.Done():
+			return
+		case err := <-result:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				program.Send(ui.LogMsg{
+					Generation: generation,
+					Entry: serverlog.Entry{
+						Kind:    serverlog.KindOther,
+						Message: "GC metrics unavailable: " + err.Error(),
+					},
+				})
+			}
 			return
 		case event := <-events:
 			program.Send(ui.GCMsg{Generation: generation, Event: event})

--- a/cmd/hso/app_test.go
+++ b/cmd/hso/app_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hijoushoku7/hijo-server-ops/internal/config"
 	"github.com/hijoushoku7/hijo-server-ops/internal/process"
+	"github.com/hijoushoku7/hijo-server-ops/internal/procstats"
 	"github.com/hijoushoku7/hijo-server-ops/internal/serverlog"
 	"github.com/hijoushoku7/hijo-server-ops/internal/ui"
 )
@@ -135,6 +136,29 @@ func TestStopServerReturnsSignalError(t *testing.T) {
 
 	if err := stopServer(server, false, time.Second); err == nil {
 		t.Fatal("expected an error")
+	}
+}
+
+func TestServerExitErrorRejectsUnexpectedCleanExit(t *testing.T) {
+	err := serverExitError(nil, true, false)
+	if err == nil || !strings.Contains(err.Error(), "予期せず終了") {
+		t.Fatalf("err = %v", err)
+	}
+	if err := serverExitError(nil, true, true); err != nil {
+		t.Fatalf("expected exit error = %v", err)
+	}
+}
+
+func TestCalculateCPU(t *testing.T) {
+	previous := procstats.Duration{Value: time.Second, Available: true}
+	current := procstats.Duration{Value: 2500 * time.Millisecond, Available: true}
+
+	got, ok := calculateCPU(previous, current, time.Second)
+	if !ok || got != 150 {
+		t.Fatalf("CPU = %f, available = %t", got, ok)
+	}
+	if _, ok := calculateCPU(procstats.Duration{}, current, time.Second); ok {
+		t.Fatal("first CPU sample was available")
 	}
 }
 

--- a/internal/gclog/tailer.go
+++ b/internal/gclog/tailer.go
@@ -25,7 +25,9 @@ func (t Tailer) Run(ctx context.Context, events chan<- Event) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	reader := bufio.NewReader(file)
 	var partial string
@@ -43,6 +45,17 @@ func (t Tailer) Run(ctx context.Context, events chan<- Event) error {
 			}
 			partial = ""
 		case errors.Is(readErr, io.EOF):
+			replacement, replaced, err := t.reopenIfRotated(file)
+			if err != nil {
+				return err
+			}
+			if replaced {
+				_ = file.Close()
+				file = replacement
+				reader.Reset(file)
+				partial = ""
+				continue
+			}
 			if err := wait(ctx, t.pollInterval()); err != nil {
 				return err
 			}
@@ -50,6 +63,28 @@ func (t Tailer) Run(ctx context.Context, events chan<- Event) error {
 			return fmt.Errorf("GCログを読む: %w", readErr)
 		}
 	}
+}
+
+func (t Tailer) reopenIfRotated(current *os.File) (*os.File, bool, error) {
+	currentInfo, err := current.Stat()
+	if err != nil {
+		return nil, false, fmt.Errorf("GCログの状態を読む: %w", err)
+	}
+	pathInfo, err := os.Stat(t.Path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("GCログの状態を読む: %w", err)
+	}
+	if os.SameFile(currentInfo, pathInfo) {
+		return nil, false, nil
+	}
+	replacement, err := os.Open(t.Path)
+	if err != nil {
+		return nil, false, fmt.Errorf("ローテーション後のGCログを開く: %w", err)
+	}
+	return replacement, true, nil
 }
 
 func (t Tailer) waitForFile(ctx context.Context) (*os.File, error) {

--- a/internal/gclog/tailer_test.go
+++ b/internal/gclog/tailer_test.go
@@ -70,9 +70,73 @@ func TestTailerCanBeCanceledBeforeFileExists(t *testing.T) {
 	}
 }
 
+func TestTailerFollowsRotatedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gc.log")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	events := make(chan Event, 2)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- (Tailer{
+			Path:         path,
+			PollInterval: time.Millisecond,
+		}).Run(ctx, events)
+	}()
+
+	appendGCLine(t, path, "[1.000s][info][gc] GC(0) Pause Young 10M->2M(100M) 1.000ms\n")
+	waitForEvent(t, events, 0)
+
+	if err := os.Rename(path, path+".0"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		path,
+		[]byte("[2.000s][info][gc] GC(1) Pause Young 20M->3M(100M) 2.000ms\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	waitForEvent(t, events, 1)
+	cancel()
+	if err := <-result; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error = %v", err)
+	}
+}
+
 func TestTailerRejectsEmptyPath(t *testing.T) {
 	err := (Tailer{}).Run(context.Background(), make(chan Event))
 	if err == nil {
 		t.Fatal("Run succeeded")
+	}
+}
+
+func appendGCLine(t *testing.T, path, line string) {
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString(line); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitForEvent(t *testing.T, events <-chan Event, id uint64) {
+	t.Helper()
+	select {
+	case event := <-events:
+		if event.ID != id {
+			t.Fatalf("event ID = %d, want %d", event.ID, id)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("event %d was not received", id)
 	}
 }

--- a/internal/hsperfdata/metrics.go
+++ b/internal/hsperfdata/metrics.go
@@ -2,6 +2,8 @@ package hsperfdata
 
 import (
 	"fmt"
+	"math"
+	"strings"
 	"time"
 )
 
@@ -43,9 +45,14 @@ type Metrics struct {
 }
 
 func (s Snapshot) Metrics() Metrics {
+	return s.metricsAt(time.Now())
+}
+
+func (s Snapshot) metricsAt(now time.Time) Metrics {
 	var metrics Metrics
 
 	generationCount, generationsAvailable := s.Long("sun.gc.policy.generations")
+	policyName, _ := s.String("sun.gc.policy.name")
 	var (
 		heapUsed      []Number
 		heapCommitted []Number
@@ -81,7 +88,7 @@ func (s Snapshot) Metrics() Metrics {
 	if generationsAvailable {
 		metrics.Heap.Used = sumNumbers(heapUsed)
 		metrics.Heap.Committed = sumNumbers(heapCommitted)
-		metrics.Heap.Max = sumNumbers(heapMax)
+		metrics.Heap.Max = heapMaximum(heapMax, policyName)
 	}
 	if maximum, ok := s.Long("sun.gc.policy.maxCapacity"); ok {
 		metrics.Heap.Max = Number{Value: maximum, Available: true}
@@ -96,6 +103,8 @@ func (s Snapshot) Metrics() Metrics {
 			Value:     ticksToDuration(ticks, frequency),
 			Available: true,
 		}
+	} else if started, ok := s.Long("sun.rt.createVmBeginTime"); ok {
+		metrics.Uptime = uptimeSince(started, now)
 	}
 
 	metrics.Threads = number(s, "java.threads.live")
@@ -118,6 +127,39 @@ func (s Snapshot) Metrics() Metrics {
 	}
 
 	return metrics
+}
+
+func heapMaximum(values []Number, policyName string) Number {
+	if strings.Contains(policyName, "GarbageFirst") ||
+		strings.Contains(policyName, "ZGC") ||
+		strings.Contains(policyName, "Shenandoah") {
+		var maximum Number
+		for _, value := range values {
+			if !value.Available || value.Value < 0 {
+				return Number{}
+			}
+			if !maximum.Available || value.Value > maximum.Value {
+				maximum = value
+			}
+		}
+		return maximum
+	}
+	return sumNumbers(values)
+}
+
+func uptimeSince(startedMillis int64, now time.Time) Duration {
+	nowMillis := now.UnixMilli()
+	if startedMillis < 0 || nowMillis < startedMillis {
+		return Duration{}
+	}
+	elapsedMillis := nowMillis - startedMillis
+	if elapsedMillis > math.MaxInt64/int64(time.Millisecond) {
+		return Duration{}
+	}
+	return Duration{
+		Value:     time.Duration(elapsedMillis) * time.Millisecond,
+		Available: true,
+	}
 }
 
 func memory(snapshot Snapshot, prefix string) Memory {

--- a/internal/hsperfdata/metrics_test.go
+++ b/internal/hsperfdata/metrics_test.go
@@ -8,6 +8,7 @@ import (
 func TestMetrics(t *testing.T) {
 	snapshot := Snapshot{Counters: map[string]Counter{
 		"sun.gc.policy.generations":               {long: 2},
+		"sun.gc.policy.name":                      {text: "Parallel", isString: true},
 		"sun.gc.generation.0.name":                {text: "young", isString: true},
 		"sun.gc.generation.0.spaces":              {long: 2},
 		"sun.gc.generation.0.capacity":            {long: 300},
@@ -59,6 +60,39 @@ func TestMetrics(t *testing.T) {
 	if !metrics.Collectors[0].Time.Available ||
 		metrics.Collectors[0].Time.Value != 1250*time.Millisecond {
 		t.Fatalf("collector time = %#v", metrics.Collectors[0].Time)
+	}
+}
+
+func TestMetricsUsesOneOverlappingHeapMaximumForG1(t *testing.T) {
+	snapshot := Snapshot{Counters: map[string]Counter{
+		"sun.gc.policy.generations":        {long: 2},
+		"sun.gc.policy.name":               {text: "GarbageFirst", isString: true},
+		"sun.gc.generation.0.spaces":       {long: 1},
+		"sun.gc.generation.0.capacity":     {long: 300},
+		"sun.gc.generation.0.maxCapacity":  {long: 1400},
+		"sun.gc.generation.0.space.0.used": {long: 100},
+		"sun.gc.generation.1.spaces":       {long: 1},
+		"sun.gc.generation.1.capacity":     {long: 700},
+		"sun.gc.generation.1.maxCapacity":  {long: 1400},
+		"sun.gc.generation.1.space.0.used": {long: 400},
+	}}
+
+	metrics := snapshot.Metrics()
+
+	assertNumber(t, metrics.Heap.Max, 1400)
+}
+
+func TestMetricsFallsBackToVMStartTimeForUptime(t *testing.T) {
+	now := time.UnixMilli(1_700_000_012_500)
+	snapshot := Snapshot{Counters: map[string]Counter{
+		"sun.rt.createVmBeginTime": {long: 1_700_000_000_000},
+	}}
+
+	metrics := snapshot.metricsAt(now)
+
+	if !metrics.Uptime.Available ||
+		metrics.Uptime.Value != 12_500*time.Millisecond {
+		t.Fatalf("Uptime = %#v", metrics.Uptime)
 	}
 }
 

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -36,7 +36,8 @@ type Process struct {
 }
 
 func Start(options Options) (*Process, error) {
-	if err := validateCommand(options.Command, options.WorkDir); err != nil {
+	command, err := resolveCommand(options.Command, options.WorkDir)
+	if err != nil {
 		return nil, err
 	}
 
@@ -51,7 +52,7 @@ func Start(options Options) (*Process, error) {
 		_ = os.RemoveAll(gcLogDir)
 		return nil, fmt.Errorf("hsoの実行ファイルを確認する: %w", err)
 	}
-	cmd := exec.Command(executable, supervisorArgument, options.Command)
+	cmd := exec.Command(executable, supervisorArgument, command)
 	cmd.Dir = options.WorkDir
 	cmd.Env = withJavaToolOptions(options.Env, gcLogPath)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
@@ -120,22 +121,26 @@ func Start(options Options) (*Process, error) {
 	return process, nil
 }
 
-func validateCommand(command, workDir string) error {
+func resolveCommand(command, workDir string) (string, error) {
 	path := command
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(workDir, path)
 	}
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("起動スクリプトの絶対パスを求める: %w", err)
+	}
 	info, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("起動スクリプトを確認する: %w", err)
+		return "", fmt.Errorf("起動スクリプトを確認する: %w", err)
 	}
 	if info.IsDir() {
-		return fmt.Errorf("起動スクリプトはディレクトリです: %s", path)
+		return "", fmt.Errorf("起動スクリプトはディレクトリです: %s", path)
 	}
 	if info.Mode().Perm()&0o111 == 0 {
-		return fmt.Errorf("起動スクリプトに実行権限がありません: %s", path)
+		return "", fmt.Errorf("起動スクリプトに実行権限がありません: %s", path)
 	}
-	return nil
+	return path, nil
 }
 
 func (p *Process) PID() int {
@@ -239,7 +244,7 @@ func withJavaToolOptions(extraEnv []string, gcLogPath string) []string {
 
 	const key = "JAVA_TOOL_OPTIONS"
 	flag := "-Xlog:gc:file=" + gcLogPath +
-		":time,uptime,level,tags:filecount=0"
+		":time,uptime,level,tags:filesize=8M,filecount=2"
 
 	value := ""
 	filtered := env[:0]

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -59,7 +59,7 @@ printf 'got:%s\n' "$line"
 	if !strings.Contains(output, "-Dexisting=true -Xlog:gc:file="+gcLogPath) {
 		t.Fatalf("JAVA_TOOL_OPTIONS was %q", output)
 	}
-	if !strings.Contains(output, ":time,uptime,level,tags:filecount=0") {
+	if !strings.Contains(output, ":time,uptime,level,tags:filesize=8M,filecount=2") {
 		t.Fatalf("JAVA_TOOL_OPTIONS was %q", output)
 	}
 	if !strings.Contains(output, "got:say hello") {
@@ -80,6 +80,22 @@ func TestProcessReportsStartError(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "起動スクリプトを確認する") {
 		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestProcessRunsRelativeCommandWithoutSlash(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "run.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	server, err := Start(Options{Command: "run.sh", WorkDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.Wait(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/procstats/procstats_linux.go
+++ b/internal/procstats/procstats_linux.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type Number struct {
@@ -27,6 +28,11 @@ type Memory struct {
 	CgroupLimit   Limit
 }
 
+type Duration struct {
+	Value     time.Duration
+	Available bool
+}
+
 type cgroupMembership struct {
 	version int
 	path    string
@@ -40,6 +46,55 @@ type cgroupMount struct {
 
 func ReadMemory(pid int) (Memory, error) {
 	return readMemoryAt("/proc", "/proc/self/mountinfo", pid)
+}
+
+func ReadCPUTime(pid int) (Duration, error) {
+	return readCPUTimeAt("/proc", pid)
+}
+
+func readCPUTimeAt(procRoot string, pid int) (Duration, error) {
+	if pid <= 0 {
+		return Duration{}, fmt.Errorf("PIDが不正です: %d", pid)
+	}
+	data, err := os.ReadFile(filepath.Join(procRoot, strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return Duration{}, fmt.Errorf("プロセスのstatを読む: %w", err)
+	}
+	return parseCPUTime(data)
+}
+
+func parseCPUTime(data []byte) (Duration, error) {
+	line := strings.TrimSpace(string(data))
+	close := strings.LastIndexByte(line, ')')
+	if close < 0 {
+		return Duration{}, errors.New("プロセスのstat形式が不正です")
+	}
+	fields := strings.Fields(line[close+1:])
+	if len(fields) < 13 {
+		return Duration{}, errors.New("プロセスのstatフィールドが不足しています")
+	}
+	user, err := strconv.ParseUint(fields[11], 10, 64)
+	if err != nil {
+		return Duration{}, fmt.Errorf("プロセスのuser CPU時間を読む: %w", err)
+	}
+	system, err := strconv.ParseUint(fields[12], 10, 64)
+	if err != nil {
+		return Duration{}, fmt.Errorf("プロセスのsystem CPU時間を読む: %w", err)
+	}
+	if user > ^uint64(0)-system {
+		return Duration{}, errors.New("プロセスのCPU時間が大きすぎます")
+	}
+	// Linuxのamd64/arm64では/procのCPU時間にUSER_HZ=100を使う。
+	const clockTicksPerSecond = uint64(100)
+	ticks := user + system
+	seconds := ticks / clockTicksPerSecond
+	if seconds > uint64((1<<63-1)/int64(time.Second)) {
+		return Duration{}, errors.New("プロセスのCPU時間が大きすぎます")
+	}
+	value := time.Duration(seconds)*time.Second +
+		time.Duration(ticks%clockTicksPerSecond)*time.Second/
+			time.Duration(clockTicksPerSecond)
+	return Duration{Value: value, Available: true}, nil
 }
 
 func readMemoryAt(procRoot, mountInfoPath string, pid int) (Memory, error) {

--- a/internal/procstats/procstats_linux_test.go
+++ b/internal/procstats/procstats_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestReadMemoryCgroupV2FromNonstandardMount(t *testing.T) {
@@ -43,6 +44,36 @@ func TestReadMemoryCurrentProcess(t *testing.T) {
 	}
 	if !memory.RSS.Available || memory.RSS.Value == 0 {
 		t.Fatalf("RSS = %#v", memory.RSS)
+	}
+}
+
+func TestReadCPUTimeCurrentProcess(t *testing.T) {
+	cpuTime, err := ReadCPUTime(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cpuTime.Available || cpuTime.Value < 0 {
+		t.Fatalf("CPU time = %#v", cpuTime)
+	}
+}
+
+func TestParseCPUTimeAllowsParenthesesInCommand(t *testing.T) {
+	fields := make([]string, 13)
+	for index := range fields {
+		fields[index] = "0"
+	}
+	fields[0] = "S"
+	fields[11] = "125"
+	fields[12] = "75"
+
+	cpuTime, err := parseCPUTime([]byte(
+		"123 (server ) name) " + strings.Join(fields, " ") + "\n",
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cpuTime.Available || cpuTime.Value != 2*time.Second {
+		t.Fatalf("CPU time = %#v", cpuTime)
 	}
 }
 

--- a/internal/ui/format.go
+++ b/internal/ui/format.go
@@ -106,6 +106,13 @@ func formatFrequency(value float64, available bool) string {
 	return fmt.Sprintf("%.2f/min", value)
 }
 
+func formatCPU(value float64, available bool) string {
+	if !available || math.IsNaN(value) || math.IsInf(value, 0) || value < 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.0f%%", value)
+}
+
 func fitLine(value string, width int) string {
 	value = truncate(value, width)
 	visible := stringWidth(value)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -54,11 +54,13 @@ type LogMsg struct {
 }
 
 type MetricsMsg struct {
-	Generation  uint64
-	JVM         hsperfdata.Metrics
-	Memory      procstats.Memory
-	JVMError    string
-	MemoryError string
+	Generation   uint64
+	JVM          hsperfdata.Metrics
+	Memory       procstats.Memory
+	CPU          float64
+	CPUAvailable bool
+	JVMError     string
+	MemoryError  string
 }
 
 type GCMsg struct {
@@ -111,6 +113,8 @@ type Model struct {
 	generation        uint64
 	metrics           hsperfdata.Metrics
 	memory            procstats.Memory
+	cpu               float64
+	cpuAvailable      bool
 	jvmMetricError    string
 	memoryMetricError string
 	gcStats           gclog.Stats
@@ -155,6 +159,8 @@ func (model *Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			Threads: message.JVM.Threads,
 		}
 		model.memory = message.Memory
+		model.cpu = message.CPU
+		model.cpuAvailable = message.CPUAvailable
 		model.updateMetricError("heap", &model.jvmMetricError, message.JVMError)
 		model.updateMetricError("RSS", &model.memoryMetricError, message.MemoryError)
 		model.addSample(message)
@@ -350,6 +356,8 @@ func (model *Model) offer(action Action) bool {
 func (model *Model) resetServerState() {
 	model.metrics = hsperfdata.Metrics{}
 	model.memory = procstats.Memory{}
+	model.cpu = 0
+	model.cpuAvailable = false
 	model.jvmMetricError = ""
 	model.memoryMetricError = ""
 	model.gcStats = gclog.Stats{}
@@ -522,7 +530,7 @@ func (model *Model) statsLines() []string {
 			formatDelta(model.memory.RSS, model.metrics.Heap.Committed),
 		),
 		fmt.Sprintf(
-			"GC   %d collections  total %s  last %s  freq %s  threads %s",
+			"GC   %d collections  total %s  last %s  freq %s",
 			model.gcStats.Collections,
 			formatPause(
 				model.gcStats.TotalPause,
@@ -533,13 +541,14 @@ func (model *Model) statsLines() []string {
 				model.gcStats.LastPause.Available,
 			),
 			formatFrequency(frequency.PerMinute, frequency.Available),
-			threads,
 		),
 		fmt.Sprintf(
-			"Players %d [%s]  Lag events: %d",
+			"Players %d [%s]  Lag events: %d  CPU %s  threads %s",
 			model.tracker.PlayerCount(),
 			model.players,
 			model.tracker.LagEvents(),
+			formatCPU(model.cpu, model.cpuAvailable),
+			threads,
 		),
 	}
 

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -81,10 +81,14 @@ func TestModelViewContainsBrailleGraphs(t *testing.T) {
 		Memory: procstats.Memory{
 			RSS: procstats.Number{Value: 3 << 30, Available: true},
 		},
+		CPU:          125,
+		CPUAvailable: true,
 	})
 
 	content := model.View().Content
-	if !strings.Contains(content, "Heap") || !strings.Contains(content, "RSS") {
+	if !strings.Contains(content, "Heap") ||
+		!strings.Contains(content, "RSS") ||
+		!strings.Contains(content, "CPU 125%") {
 		t.Fatalf("view does not contain metrics:\n%s", content)
 	}
 	if !containsBraille(content) {


### PR DESCRIPTION
## 概要

Minecraft 26.2 / Temurin Java 26.0.1をmc-server-testで実際に起動し、監視表示、コマンド送信、再起動、正常停止、異常終了を検証した結果に基づく修正です。

## 修正

- Java 26 + G1で最大ヒープが実値の2倍になる問題を修正
- Java 26で削除されたhsperfdata ticksにVM開始時刻フォールバックを追加
- /procのCPU時間からCPU使用率を表示
- command = "run.sh" が検証後にPATH探索で失敗する問題を修正
- Minecraftがexit 0でクラッシュしてもhsoが成功扱いする問題を修正
- GCログを8MiB x 2へローテーションし、tail追従とエラー表示を追加
- mc-server-testをgit管理対象外に追加

## 検証

- Go 1.25.12: go test ./...
- go vet ./...
- go test -race ./...
- 主要パッケージを20回反復テスト
- CGO_ENABLED=0でlinux/amd64・linux/arm64を静的ビルド
- Minecraft 26.2実機: 起動、Heap/RSS/Delta/GC/post-GC/uptime/CPU/threads表示、list送信、restart、stop、ワールド保存を確認
- ネットワーク禁止環境でのサーバークラッシュをhso終了コード1として確認