### PR TITLE
docs: Go導入とビルド手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,5 @@ CGO_ENABLED=0 go build -ldflags="-s -w" -o hso ./cmd/hso
 
 ## ドキュメント
 
-詳細な仕様・技術調査は [docs/spec.md](docs/spec.md) を参照。
+- [ビルド手順](docs/build.md)
+- [仕様・技術調査](docs/spec.md)

--- a/docs/build.md
+++ b/docs/build.md
@@ -12,10 +12,10 @@
 curl -fsSLo /tmp/go1.25.12.linux-amd64.tar.gz \
   https://go.dev/dl/go1.25.12.linux-amd64.tar.gz
 
-mkdir -p /home/hijoushoku9/.local/share/go-1.25.12
+mkdir -p "$HOME/.local/share/go-1.25.12"
 
 tar -xzf /tmp/go1.25.12.linux-amd64.tar.gz \
-  -C /home/hijoushoku9/.local/share/go-1.25.12 \
+  -C "$HOME/.local/share/go-1.25.12" \
   --strip-components=1
 ```
 
@@ -25,7 +25,7 @@ arm64環境では、ファイル名とURLの`linux-amd64`を`linux-arm64`へ
 現在のシェルでGoを使えるようにする。
 
 ```bash
-export PATH="/home/hijoushoku9/.local/share/go-1.25.12/bin:$PATH"
+export PATH="$HOME/.local/share/go-1.25.12/bin:$PATH"
 ```
 
 `export`は現在のシェルにしか反映されない。ログイン後も有効にする場合は、
@@ -54,7 +54,7 @@ rm /tmp/go1.25.12.linux-amd64.tar.gz
 リポジトリ直下へ移動する。
 
 ```bash
-cd /home/hijoushoku9/projects/hijo-server-ops
+cd /path/to/hijo-server-ops
 ```
 
 テストを実行する。

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,96 @@
+# ビルド手順
+
+`hijo-server-ops` は Go 1.25 以上でビルドする。対象OSは Linux のみ。
+
+## Goの導入
+
+ここでは Go 1.25.12 をユーザー領域へインストールする。管理者権限は不要。
+
+### amd64
+
+```bash
+curl -fsSLo /tmp/go1.25.12.linux-amd64.tar.gz \
+  https://go.dev/dl/go1.25.12.linux-amd64.tar.gz
+
+mkdir -p /home/hijoushoku9/.local/share/go-1.25.12
+
+tar -xzf /tmp/go1.25.12.linux-amd64.tar.gz \
+  -C /home/hijoushoku9/.local/share/go-1.25.12 \
+  --strip-components=1
+```
+
+arm64環境では、ファイル名とURLの`linux-amd64`を`linux-arm64`へ
+置き換える。
+
+現在のシェルでGoを使えるようにする。
+
+```bash
+export PATH="/home/hijoushoku9/.local/share/go-1.25.12/bin:$PATH"
+```
+
+`export`は現在のシェルにしか反映されない。ログイン後も有効にする場合は、
+同じ行を`~/.profile`など、使用しているシェルの設定ファイルへ追加する。
+
+導入結果を確認する。
+
+```bash
+go version
+```
+
+次のように表示されれば導入完了。
+
+```text
+go version go1.25.12 linux/amd64
+```
+
+ダウンロードしたアーカイブが不要になったら削除できる。
+
+```bash
+rm /tmp/go1.25.12.linux-amd64.tar.gz
+```
+
+## hsoのビルド
+
+リポジトリ直下へ移動する。
+
+```bash
+cd /home/hijoushoku9/projects/hijo-server-ops
+```
+
+テストを実行する。
+
+```bash
+go test ./...
+```
+
+Linux向けの静的バイナリをビルドする。
+
+```bash
+CGO_ENABLED=0 go build \
+  -ldflags="-s -w" \
+  -o hso \
+  ./cmd/hso
+```
+
+このコマンドは、リポジトリ直下の既存`hso`を最新ソースからビルドした
+バイナリで置き換える。
+
+ビルド情報を確認する。
+
+```bash
+go version -m ./hso
+```
+
+## 起動
+
+設定ファイルを指定して起動する。
+
+```bash
+./hso -config /path/to/hso.toml
+```
+
+リポジトリ内の検証用Minecraftサーバーを使用する場合は、次のように起動する。
+
+```bash
+./hso -config mc-server-test/hso.toml
+```


### PR DESCRIPTION
## 概要
- Go 1.25.12をユーザー領域へ導入する手順を追加
- テスト、静的ビルド、ビルド情報確認、起動手順を追加
- READMEからビルド手順へリンク

## 確認
- `go test ./...`
- `git diff --check`