### PR TITLE
build: ビルド手順をスクリプト化

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -57,13 +57,20 @@ rm /tmp/go1.25.12.linux-amd64.tar.gz
 cd /path/to/hijo-server-ops
 ```
 
-テストを実行する。
+ビルドスクリプトを実行する。
 
 ```bash
-go test ./...
+./scripts/build.sh
 ```
 
-Linux向けの静的バイナリをビルドする。
+スクリプトは次の処理を順番に実行する。
+
+1. PATHまたは`$HOME/.local/share/go-1.25.12/bin/go`からGoを検出
+2. `go test ./...`で全テストを実行
+3. `CGO_ENABLED=0`でLinux向けの静的バイナリをビルド
+4. `go version -m ./hso`でビルド情報を表示
+
+スクリプトを使わず、ビルドだけを直接実行する場合は次のコマンドを使う。
 
 ```bash
 CGO_ENABLED=0 go build \
@@ -72,14 +79,8 @@ CGO_ENABLED=0 go build \
   ./cmd/hso
 ```
 
-このコマンドは、リポジトリ直下の既存`hso`を最新ソースからビルドした
+どちらの方法も、リポジトリ直下の既存`hso`を最新ソースからビルドした
 バイナリで置き換える。
-
-ビルド情報を確認する。
-
-```bash
-go version -m ./hso
-```
 
 ## 起動
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -eu
+
+go_version=1.25.12
+project_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+if command -v go >/dev/null 2>&1; then
+	go_command=go
+elif [ -x "$HOME/.local/share/go-$go_version/bin/go" ]; then
+	go_command="$HOME/.local/share/go-$go_version/bin/go"
+else
+	echo "Goが見つかりません。docs/build.mdの手順でGo $go_versionを導入してください。" >&2
+	exit 1
+fi
+
+cd "$project_dir"
+
+"$go_command" version
+"$go_command" test ./...
+CGO_ENABLED=0 "$go_command" build \
+	-ldflags="-s -w" \
+	-o hso \
+	./cmd/hso
+
+echo "ビルド完了: $project_dir/hso"
+"$go_command" version -m ./hso


### PR DESCRIPTION
## 概要
- GoをPATHまたはユーザー領域から検出するビルドスクリプトを追加
- 全Goテスト、CGO無効の静的ビルド、ビルド情報表示を一括実行
- ビルドドキュメントをスクリプト利用手順へ更新

## 確認
- `sh -n scripts/build.sh`
- `./scripts/build.sh`
- `git diff --check`