### PR TITLE
fix: go 1.25.12 へ引き上げ、PR でも govulncheck を失敗扱いにする

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -33,7 +33,5 @@ jobs:
             exit 1
           fi
 
-      # 新しい CVE の公表で無関係な PR が落ちないよう、PR では失敗させない。
       - name: govulncheck
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hijoushoku7/hijo-server-ops
 
-go 1.25.0
+go 1.25.12
 
 require (
 	charm.land/bubbletea/v2 v2.0.8


### PR DESCRIPTION
## 問題

main の `deps` が失敗している（run 30517479389）。

```
Vulnerability #1: GO-2026-4602  FileInfo can escape from a Root in os
  Found in: os@go1.25 / Fixed in: os@go1.25.8
  #1: internal/process/java.go:36:28: process.readProcesses calls os.ReadDir
```

依存ライブラリではなく Go 標準ライブラリ由来。`go-version-file: go.mod` が
`go 1.25.0` を読むため、CI だけ 1.25.0 でビルドしていた（ローカルは 1.25.12）。

PR #14 の時点で同じ検出が出ていたが、`continue-on-error` が失敗を握り潰して
チェックが緑に見えていた。

## 修正

- `go.mod` の go ディレクティブを `1.25.12` に引き上げ。CI とローカルの
  ビルドバージョンが揃い、リリースバイナリも修正済みの標準ライブラリで
  ビルドされる
- `deps` の `continue-on-error` を削除。PR でも govulncheck の失敗で落とす

## 確認済み

Go 1.25.12 / `GOTOOLCHAIN=local` で `go test ./...` 全パス、
`govulncheck ./...` は `No vulnerabilities found.`、`go mod tidy` 差分なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)