### PR TITLE
公開サーバーアドレスをStatsに表示する

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,11 @@ Minecraft サーバー用のラッパー型 TUI コンソール。**Linux 専用
 
 ```
 ┌─ hijo-server-ops · uptime 3d 04:12:33 ─┐┌─ Meters · RSS/cgroup ─┐┌─ Players 3 ──┐
-│ Heap 2.1G / 3.2G committed (max 4.0G)  ││ CPU  ███░░░░░░░  82%  ││ alice        │
-│ RSS  5.4G / 8.0G limit  Δ +3.3G        ││ Heap █████▏░░░░  52%  ││ bob          │
-│ GC   142 collections  last 12.3ms      ││ RSS  ███████░░░  67%  ││ carol        │
+│ Server 203.0.113.10:25565               ││ CPU  ███░░░░░░░  82%  ││ alice        │
+│ Heap 2.1G / 3.2G committed (max 4.0G)  ││ Heap █████▏░░░░  52%  ││ bob          │
+│ RSS  5.4G / 8.0G limit  Δ +3.3G        ││ RSS  ███████░░░  67%  ││ carol        │
+│ GC   142 collections  last 12.3ms      ││                       ││              │
 │ Players 3  Lag events: 2  CPU 82%      ││                       ││              │
-│ Heap ⡀⡠⡴⡿⠋⢀⡠⡴⡿⠋                        ││                       ││              │
-│ RSS  ⣀⣀⣤⣤⣶⣶⣿⣿                          ││                       ││              │
 └────────────────────────────────────────┘└───────────────────────┘└──────────────┘
 ┌─ Chat ─────────────────┐┌─ Log ─────────────────────────────────┐
 │                        ││                                       │
@@ -54,10 +53,20 @@ hso
      ├─ hsperfdata を mmap 直読み        → ヒープ / 世代別 / GC 統計
      ├─ /proc/<pid>/status + cgroup      → RSS / メモリ上限
      ├─ GC ログを tail                   → GC 後の谷の値、停止時間
+     ├─ api.ipify.org + server.properties → 公開IPv4とポート
      └─ stdout をパース                  → チャット / コマンド / 参加退出 / ラグ
 ```
 
 サーバー側にプラグインも MOD も不要（TPS 表示のみ将来 Fabric mod を使用）。JVM 引数は管理せず、ユーザーの `user_jvm_args.txt` / 起動スクリプトの記述をそのまま尊重する。
+
+Stats の `Server` 行は、`api.ipify.org` から取得した公開 IPv4 と、
+`server.workdir/server.properties` の `server-port` を組み合わせて表示する。
+取得はサーバー起動・再起動ごとに非同期で一度だけ行い、ネットワーク障害、
+設定ファイルなし、不正なポートでは `Server n/a` と表示する。取得失敗で
+Minecraft サーバーを停止することはない。
+
+この値は外部からの疎通を確認したものではない。NAT の外部ポートが異なる、
+CGNAT、HTTP プロキシ経由などの環境では、実際の接続先と異なる場合がある。
 
 ## 設定
 

--- a/cmd/hso/app.go
+++ b/cmd/hso/app.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hijoushoku7/hijo-server-ops/internal/hsperfdata"
 	"github.com/hijoushoku7/hijo-server-ops/internal/process"
 	"github.com/hijoushoku7/hijo-server-ops/internal/procstats"
+	"github.com/hijoushoku7/hijo-server-ops/internal/serveraddr"
 	"github.com/hijoushoku7/hijo-server-ops/internal/serverlog"
 	"github.com/hijoushoku7/hijo-server-ops/internal/ui"
 )
@@ -206,6 +207,12 @@ func (controller *serverController) start(
 	go streamGC(
 		runtimeCtx,
 		server.GCLogPath(),
+		controller.program,
+		generation,
+	)
+	go resolveServerAddress(
+		runtimeCtx,
+		controller.cfg.Server.WorkDir,
 		controller.program,
 		generation,
 	)
@@ -547,6 +554,29 @@ func errorText(err error) string {
 		return ""
 	}
 	return err.Error()
+}
+
+func resolveServerAddress(
+	ctx context.Context,
+	workDir string,
+	program *tea.Program,
+	generation uint64,
+) {
+	result := serveraddr.Resolve(ctx, workDir)
+	if ctx.Err() != nil {
+		return
+	}
+	ip := ""
+	if result.IP.IsValid() {
+		ip = result.IP.String()
+	}
+	program.Send(ui.ServerAddressMsg{
+		Generation: generation,
+		IP:         ip,
+		Port:       result.Port,
+		IPErr:      errorText(result.IPErr),
+		PortErr:    errorText(result.PortErr),
+	})
 }
 
 func streamGC(

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -39,6 +39,7 @@
 | メモリ | **ヒープ（hsperfdata）と RSS（/proc）を両方取得して並べて表示** |
 | TPS | v1 は対象外（ラグイベント検知のみ）。v2 で Fabric mod により対応 |
 | プレイヤー一覧 | ログの `joined the game` / `left the game` を追跡 |
+| サーバーアドレス | `api.ipify.org` の公開 IPv4 と `server.properties` の `server-port` を Stats に表示 |
 | 操作 | ほぼ表示専用。**矢印でパネル選択 / Enter でフォーカス**、restart / stop、コマンド送信 |
 | ログ | **チャット / その他** に分類して別ペインに表示（コマンド使用履歴は Log に混ぜる） |
 | 将来 | 表示要素・レイアウトのカスタマイズ |
@@ -80,6 +81,22 @@ OS側(1s)     : /proc/<pid>/status の VmRSS、/proc/<pid>/stat の CPU
                ＋ cgroup memory.current / memory.max（Docker/systemd 下）
 フォールバック: hsperfdata が読めない場合は RSS のみ表示し、heap: n/a と正直に出す
 ```
+
+### サーバーアドレス取得
+
+サーバーの起動・再起動ごとに、`https://api.ipify.org` から公開 IPv4 を
+非同期で一度取得し、`server.workdir/server.properties` の `server-port` と
+組み合わせて Stats の先頭へ `Server 203.0.113.10:25565` の形で表示する。
+HTTP は 3 秒でタイムアウトし、応答は長さを制限して IPv4 として検証する。
+
+`server.properties` は読み取り専用とし、通常の `server-port=<10進整数>`
+形式だけを扱う。ポートは 1..65535 を許可する。ファイル、キー、公開 IPv4 の
+どれかを取得できない場合は `Server n/a` とし、理由を Log へ出す。アドレス
+取得の失敗は Minecraft の起動や監視を止めない。再起動前の非同期結果は
+generation 番号で破棄する。
+
+表示値は疎通確認済みの接続先ではない。NAT の外部ポート、CGNAT、HTTP
+プロキシ、起動引数によるポート上書きがある環境では実際の接続先と異なりうる。
 
 ### ログ処理
 
@@ -390,6 +407,7 @@ mod が開ける扉は TPS だけではなく、MSPT 分布（p95/最大）・�
 - [x] パネル選択 / フォーカスとスクロール、キー説明行
 - [x] CPU / Heap / RSS のメーター表示、プレイヤー一覧パネル
 - [x] プレイヤー選択からのコマンド組み立て（モーダル）
+- [x] 公開 IPv4 と `server-port` の表示
 - [x] GitHub Actions で amd64 / arm64 リリース
 
 **v2**

--- a/internal/serveraddr/address.go
+++ b/internal/serveraddr/address.go
@@ -1,0 +1,118 @@
+// Package serveraddr は、Minecraft サーバーの公開アドレス表示に必要な
+// 公開 IPv4 と server-port を取得する。
+package serveraddr
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	publicIPv4URL     = "https://api.ipify.org"
+	requestTimeout    = 3 * time.Second
+	maxIPAddressBytes = 64
+)
+
+type Result struct {
+	IP      netip.Addr
+	Port    uint16
+	IPErr   error
+	PortErr error
+}
+
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// Resolve は公開 IPv4 と server.properties の server-port を取得する。
+// ネットワーク障害は呼び出し側で非致命として扱えるよう Result に残す。
+func Resolve(ctx context.Context, workDir string) Result {
+	port, portErr := ReadPort(filepath.Join(workDir, "server.properties"))
+	client := &http.Client{Timeout: requestTimeout}
+	ip, ipErr := fetchPublicIPv4(ctx, client, publicIPv4URL)
+	return Result{IP: ip, Port: port, IPErr: ipErr, PortErr: portErr}
+}
+
+func fetchPublicIPv4(
+	ctx context.Context,
+	client httpDoer,
+	endpoint string,
+) (netip.Addr, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("公開IPv4のリクエストを作る: %w", err)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("公開IPv4を取得する: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return netip.Addr{}, fmt.Errorf(
+			"公開IPv4の取得に失敗しました: HTTP %d",
+			response.StatusCode,
+		)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxIPAddressBytes+1))
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("公開IPv4の応答を読む: %w", err)
+	}
+	if len(body) > maxIPAddressBytes {
+		return netip.Addr{}, fmt.Errorf("公開IPv4の応答が長すぎます")
+	}
+
+	ip, err := netip.ParseAddr(strings.TrimSpace(string(body)))
+	if err != nil || !ip.Is4() {
+		return netip.Addr{}, fmt.Errorf("公開IPv4の応答がIPv4アドレスではありません")
+	}
+	return ip, nil
+}
+
+// ReadPort は server.properties から server-port を読む。Minecraft が通常
+// 出力する key=value 形式だけを対象にし、ファイル全体を書き換えない。
+func ReadPort(path string) (uint16, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("server.propertiesを開く: %w", err)
+	}
+	defer file.Close()
+
+	var value string
+	found := false
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") ||
+			strings.HasPrefix(line, "!") {
+			continue
+		}
+		key, candidate, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "server-port" {
+			continue
+		}
+		value = strings.TrimSpace(candidate)
+		found = true
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("server.propertiesを読む: %w", err)
+	}
+	if !found {
+		return 0, fmt.Errorf("server.propertiesにserver-portがありません")
+	}
+
+	parsed, err := strconv.ParseUint(value, 10, 16)
+	if err != nil || parsed == 0 {
+		return 0, fmt.Errorf("server-portが不正です: %q", value)
+	}
+	return uint16(parsed), nil
+}

--- a/internal/serveraddr/address_test.go
+++ b/internal/serveraddr/address_test.go
@@ -1,0 +1,108 @@
+package serveraddr
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFetchPublicIPv4(t *testing.T) {
+	client := fakeHTTPClient{response: response(http.StatusOK, "203.0.113.10\n")}
+	ip, err := fetchPublicIPv4(context.Background(), client, "https://example.test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ip.String(); got != "203.0.113.10" {
+		t.Fatalf("IP = %q", got)
+	}
+}
+
+func TestFetchPublicIPv4RejectsInvalidResponses(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "status", status: http.StatusServiceUnavailable, body: "unavailable"},
+		{name: "invalid", status: http.StatusOK, body: "not-an-ip"},
+		{name: "ipv6", status: http.StatusOK, body: "2001:db8::1"},
+		{name: "oversized", status: http.StatusOK, body: strings.Repeat("1", maxIPAddressBytes+1)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := fetchPublicIPv4(
+				context.Background(),
+				fakeHTTPClient{response: response(test.status, test.body)},
+				"https://example.test",
+			); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}
+
+type fakeHTTPClient struct {
+	response *http.Response
+}
+
+func (client fakeHTTPClient) Do(*http.Request) (*http.Response, error) {
+	return client.response, nil
+}
+
+func response(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestReadPort(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "server.properties")
+	content := "# Minecraft server properties\r\n" +
+		" server-port = 25565 \r\n" +
+		"motd=test\r\n" +
+		"server-port=25566\r\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	port, err := ReadPort(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port != 25566 {
+		t.Fatalf("port = %d", port)
+	}
+}
+
+func TestReadPortRejectsUnavailableAndInvalidValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "missing", content: "motd=test\n"},
+		{name: "empty", content: "server-port=\n"},
+		{name: "zero", content: "server-port=0\n"},
+		{name: "overflow", content: "server-port=65536\n"},
+		{name: "text", content: "server-port=minecraft\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "server.properties")
+			if err := os.WriteFile(path, []byte(test.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := ReadPort(path); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+
+	if _, err := ReadPort(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("missing file was accepted")
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -95,6 +95,14 @@ type ServerStartedMsg struct {
 	Generation uint64
 }
 
+type ServerAddressMsg struct {
+	Generation uint64
+	IP         string
+	Port       uint16
+	IPErr      string
+	PortErr    string
+}
+
 type ActionResultMsg struct {
 	Action Action
 	Err    error
@@ -118,6 +126,8 @@ type Model struct {
 	cpuAvailable      bool
 	jvmMetricError    string
 	memoryMetricError string
+	serverIP          string
+	serverPort        uint16
 	gcStats           gclog.Stats
 	tracker           serverlog.Tracker
 	playerList        []string
@@ -202,6 +212,35 @@ func (model *Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		model.resetServerState()
 		model.status = "starting"
 		model.busy = false
+	case ServerAddressMsg:
+		if !model.accepts(message.Generation) {
+			break
+		}
+		model.serverIP = message.IP
+		model.serverPort = message.Port
+		if message.IPErr != "" {
+			model.serverIP = ""
+		}
+		if message.PortErr != "" {
+			model.serverPort = 0
+		}
+		for _, failure := range []struct {
+			source string
+			err    string
+		}{
+			{"public IPv4", message.IPErr},
+			{"server-port", message.PortErr},
+		} {
+			if failure.err == "" {
+				continue
+			}
+			model.addLog(serverlog.Entry{
+				Kind: serverlog.KindOther,
+				Message: "server address: " + failure.source +
+					" unavailable: " + truncateRunes(
+					failure.err, maxMetricErrorRunes),
+			})
+		}
 	case ActionResultMsg:
 		model.busy = false
 		if message.Err != nil {
@@ -539,6 +578,8 @@ func (model *Model) resetServerState() {
 	model.cpuAvailable = false
 	model.jvmMetricError = ""
 	model.memoryMetricError = ""
+	model.serverIP = ""
+	model.serverPort = 0
 	model.gcStats = gclog.Stats{}
 	model.tracker = serverlog.Tracker{}
 	model.playerList = nil
@@ -708,8 +749,10 @@ func (model *Model) statsLines() []string {
 		threads = fmt.Sprintf("%d", model.metrics.Threads.Value)
 	}
 
-	// グラフは Graph パネルへ移したので、ここは数値だけ。行間を空けて読む。
+	// グラフは Graph パネルへ移したので、ここは数値だけ。Server と Heap は
+	// 続けて置き、その後は行間を空けると既存の高さ 8 行に収まる。
 	rows := []string{
+		model.serverAddressLine(),
 		fmt.Sprintf(
 			"Heap %s / %s committed (max %s)  post-GC %s",
 			formatJVMBytes(model.metrics.Heap.Used),
@@ -745,14 +788,21 @@ func (model *Model) statsLines() []string {
 		),
 	}
 
-	lines := make([]string, 0, len(rows)*2-1)
+	lines := make([]string, 0, len(rows)*2-2)
 	for index, row := range rows {
-		if index > 0 {
+		if index > 1 {
 			lines = append(lines, "")
 		}
 		lines = append(lines, row)
 	}
 	return lines
+}
+
+func (model *Model) serverAddressLine() string {
+	if model.serverIP == "" || model.serverPort == 0 {
+		return "Server n/a"
+	}
+	return fmt.Sprintf("Server %s:%d", model.serverIP, model.serverPort)
 }
 
 // rssLine は Stats の RSS 行。パーセントは必ず使った分母の隣に置く。

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -180,6 +180,61 @@ func TestModelReportsMetricFailureOnceAndRecovery(t *testing.T) {
 	}
 }
 
+func TestModelDisplaysServerAddressAndReportsFailure(t *testing.T) {
+	model := newTestModel()
+	model.generation = 2
+	model.resize(minimumWidth, minimumHeight)
+
+	_, _ = model.Update(ServerAddressMsg{
+		Generation: 2,
+		IP:         "203.0.113.10",
+		Port:       25565,
+	})
+	if got := model.serverAddressLine(); got != "Server 203.0.113.10:25565" {
+		t.Fatalf("address = %q", got)
+	}
+	if width := stringWidth(model.serverAddressLine()); width > model.layout.statsWidth-2 {
+		t.Fatalf("address width = %d", width)
+	}
+
+	// 前の世代から遅れて届いた結果で、再起動後の表示を上書きしない。
+	_, _ = model.Update(ServerAddressMsg{
+		Generation: 1,
+		IP:         "198.51.100.1",
+		Port:       25566,
+	})
+	if got := model.serverAddressLine(); got != "Server 203.0.113.10:25565" {
+		t.Fatalf("stale address was accepted: %q", got)
+	}
+
+	_, _ = model.Update(ServerAddressMsg{
+		Generation: 2,
+		IP:         "invalid IP",
+		Port:       25565,
+		IPErr:      "request failed",
+	})
+	if got := model.serverAddressLine(); got != "Server n/a" {
+		t.Fatalf("failed address = %q", got)
+	}
+	if model.logs.Len() != 1 || !strings.Contains(
+		model.logs.At(0), "public IPv4 unavailable",
+	) {
+		t.Fatalf("logs = %q", model.logs.At(0))
+	}
+}
+
+func TestModelClearsServerAddressOnRestart(t *testing.T) {
+	model := newTestModel()
+	_, _ = model.Update(ServerAddressMsg{
+		IP:   "203.0.113.10",
+		Port: 25565,
+	})
+	_, _ = model.Update(ServerStartedMsg{Generation: 2})
+	if got := model.serverAddressLine(); got != "Server n/a" {
+		t.Fatalf("address = %q", got)
+	}
+}
+
 func TestModelBoundsCurrentMetricError(t *testing.T) {
 	model := newTestModel()
 	_, _ = model.Update(MetricsMsg{


### PR DESCRIPTION
## 概要
- api.ipify.orgから公開IPv4を非同期取得
- server.propertiesからserver-portを読み取り
- Stats先頭へServer IPv4:portを表示
- 取得失敗はServer n/aとLogへの理由表示に縮退

## 設計上の扱い
- server.propertiesや起動スクリプトは書き換えない
- 3秒タイムアウトでMinecraft起動をブロックしない
- generationで再起動前の結果を破棄
- NAT/CGNAT等で疎通可能性までは保証しない

## 検証
- go test ./...
- go vet ./...
- CGO_ENABLED=0 go build -ldflags="-s -w" -o /tmp/hso-issue20 ./cmd/hso

Closes #20