### PR TITLE
feat: 日本語版と英語版をビルドタグで分ける

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,10 @@ jobs:
           go-version-file: go.mod
 
       - name: go test
-        run: go test ./...
+        run: |
+          set -eu
+          go test ./...
+          go test -tags en ./...
 
       - name: バイナリのビルド
         env:
@@ -29,14 +32,22 @@ jobs:
           set -eu
           mkdir -p dist
           for arch in amd64 arm64; do
-            name="hso_${VERSION}_linux_${arch}"
-            mkdir -p "dist/$name"
-            CGO_ENABLED=0 GOOS=linux GOARCH="$arch" go build \
-              -trimpath -ldflags="-s -w" -o "dist/$name/hso" ./cmd/hso
-            cp hso.toml.example "dist/$name/hso.toml"
-            cp README.md "dist/$name/README.md"
-            tar -czf "dist/$name.tar.gz" -C dist "$name"
-            rm -rf "dist/$name"
+            for lang in ja en; do
+              # 日本語版はタグなし、英語版は -tags en。$tags は空になることが
+              # あるので意図的にクォートしない。
+              tags=""
+              if [ "$lang" = "en" ]; then
+                tags="-tags en"
+              fi
+              name="hso_${VERSION}_linux_${arch}_${lang}"
+              mkdir -p "dist/$name"
+              CGO_ENABLED=0 GOOS=linux GOARCH="$arch" go build \
+                $tags -trimpath -ldflags="-s -w" -o "dist/$name/hso" ./cmd/hso
+              cp hso.toml.example "dist/$name/hso.toml"
+              cp README.md "dist/$name/README.md"
+              tar -czf "dist/$name.tar.gz" -C dist "$name"
+              rm -rf "dist/$name"
+            done
           done
           (cd dist && sha256sum *.tar.gz > checksums.txt)
           ls -la dist
@@ -52,11 +63,16 @@ jobs:
 
           Linux のみ（\`/proc\`・cgroup に依存）。
 
+          ## 言語
+
+          表示言語ごとに別のバイナリを配布する。\`_ja\` が日本語版、\`_en\` が
+          英語版。中身は表示文字列だけが違い、実行ファイル名はどちらも \`hso\`。
+
           ## インストール
 
           \`\`\`sh
-          tar xzf hso_${VERSION}_linux_amd64.tar.gz
-          cd hso_${VERSION}_linux_amd64
+          tar xzf hso_${VERSION}_linux_amd64_ja.tar.gz
+          cd hso_${VERSION}_linux_amd64_ja
           # hso.toml の command を起動スクリプトのパスに書き換える
           ./hso
           \`\`\`
@@ -68,8 +84,10 @@ jobs:
 
           | ファイル | 対象 |
           | --- | --- |
-          | \`hso_${VERSION}_linux_amd64.tar.gz\` | Linux x86_64 |
-          | \`hso_${VERSION}_linux_arm64.tar.gz\` | Linux arm64 |
+          | \`hso_${VERSION}_linux_amd64_ja.tar.gz\` | Linux x86_64 / 日本語 |
+          | \`hso_${VERSION}_linux_amd64_en.tar.gz\` | Linux x86_64 / 英語 |
+          | \`hso_${VERSION}_linux_arm64_ja.tar.gz\` | Linux arm64 / 日本語 |
+          | \`hso_${VERSION}_linux_arm64_en.tar.gz\` | Linux arm64 / 英語 |
           | \`checksums.txt\` | SHA-256 チェックサム |
 
           \`CGO_ENABLED=0\` / \`-trimpath -ldflags="-s -w"\` でビルド。
@@ -81,7 +99,13 @@ jobs:
           VERSION: ${{ github.ref_name }}
         run: |
           set -eu
-          assets="dist/hso_${VERSION}_linux_amd64.tar.gz dist/hso_${VERSION}_linux_arm64.tar.gz dist/checksums.txt"
+          assets=""
+          for arch in amd64 arm64; do
+            for lang in ja en; do
+              assets="$assets dist/hso_${VERSION}_linux_${arch}_${lang}.tar.gz"
+            done
+          done
+          assets="$assets dist/checksums.txt"
           # v1.0.0-rc1 のようなハイフン付きタグはプレリリース扱いにする。
           case "$VERSION" in
             *-*) prerelease=true ;;

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /hso
+/hso_ja
+/hso_en
 /dist/
 /mc-server-test/
 *.test

--- a/cmd/hso/app.go
+++ b/cmd/hso/app.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -19,6 +18,7 @@ import (
 	"github.com/hijoushoku7/hijo-server-ops/internal/config"
 	"github.com/hijoushoku7/hijo-server-ops/internal/gclog"
 	"github.com/hijoushoku7/hijo-server-ops/internal/hsperfdata"
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
 	"github.com/hijoushoku7/hijo-server-ops/internal/process"
 	"github.com/hijoushoku7/hijo-server-ops/internal/procstats"
 	"github.com/hijoushoku7/hijo-server-ops/internal/serveraddr"
@@ -34,14 +34,6 @@ const (
 	gracefulStopWait   = 60 * time.Second
 	actionQueueSize    = 4
 	initialGeneration  = 1
-)
-
-var errHeapCountersUnavailable = errors.New(
-	"hsperfdataにヒープ使用量カウンタがありません",
-)
-
-var errRSSUnavailable = errors.New(
-	"/procのstatusにVmRSSがありません",
 )
 
 type stoppableServer interface {
@@ -260,7 +252,7 @@ func (controller *serverController) sendCommand(action ui.Action) {
 	if runtime == nil {
 		controller.program.Send(ui.ActionResultMsg{
 			Action: action,
-			Err:    errors.New("サーバーは停止しています"),
+			Err:    msg.ErrServerStopped,
 		})
 		return
 	}
@@ -283,14 +275,14 @@ func (controller *serverController) restart() {
 	if runtime == nil {
 		controller.program.Send(ui.ActionResultMsg{
 			Action: ui.Action{Kind: ui.ActionRestart},
-			Err:    errors.New("サーバーは停止しています"),
+			Err:    msg.ErrServerStopped,
 		})
 		return
 	}
 	if !runtime.javaFound.Load() {
 		controller.program.Send(ui.ActionResultMsg{
 			Action: ui.Action{Kind: ui.ActionRestart},
-			Err:    errors.New("javaプロセスの起動完了後に再起動できます"),
+			Err:    msg.ErrRestartBeforeJava,
 		})
 		return
 	}
@@ -317,7 +309,7 @@ func (controller *serverController) restart() {
 	nextGeneration := runtime.generation + 1
 	if err := controller.start(nextGeneration, true); err != nil {
 		controller.program.Send(ui.FatalMsg{
-			Err: fmt.Errorf("サーバーを再起動する: %w", err),
+			Err: msg.RestartFailed(err),
 		})
 	}
 }
@@ -364,9 +356,9 @@ func serverExitError(waitErr error, javaFound, expected bool) error {
 		return waitErr
 	}
 	if !javaFound {
-		return errors.New("起動スクリプトがjavaプロセスを開始せずに終了しました")
+		return msg.ErrScriptExitedWithoutJava
 	}
-	return errors.New("Minecraftサーバーが予期せず終了しました")
+	return msg.ErrServerExited
 }
 
 func (controller *serverController) currentRuntime() *serverRuntime {
@@ -417,7 +409,7 @@ func stopServer(server stoppableServer, javaFound bool, wait time.Duration) erro
 		case <-server.Done():
 			return nil
 		default:
-			return fmt.Errorf("サーバーを停止する: %w", err)
+			return msg.StopFailed(err)
 		}
 	}
 	<-server.Done()
@@ -450,7 +442,7 @@ func findJava(
 		}
 		program.Send(ui.FatalMsg{
 			Generation: generation,
-			Err:        fmt.Errorf("javaプロセスの特定: %w", err),
+			Err:        msg.FindJavaFailed(err),
 		})
 		_ = server.Signal(syscall.SIGTERM)
 		return
@@ -500,14 +492,14 @@ func collectMetrics(
 				metrics = snapshot.Metrics()
 				if !metrics.Heap.Used.Available ||
 					!metrics.Heap.Committed.Available {
-					jvmErr = errHeapCountersUnavailable
+					jvmErr = msg.ErrHeapCountersUnavailable
 				}
 			}
 		}
 
 		memory, memoryErr := procstats.ReadMemory(pid)
 		if memoryErr == nil && !memory.RSS.Available {
-			memoryErr = errRSSUnavailable
+			memoryErr = msg.ErrRSSUnavailable
 		}
 		cpuTime, _ := procstats.ReadCPUTime(pid)
 		sampledAt := time.Now()

--- a/cmd/hso/app_test.go
+++ b/cmd/hso/app_test.go
@@ -15,6 +15,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/hijoushoku7/hijo-server-ops/internal/config"
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
 	"github.com/hijoushoku7/hijo-server-ops/internal/process"
 	"github.com/hijoushoku7/hijo-server-ops/internal/procstats"
 	"github.com/hijoushoku7/hijo-server-ops/internal/serverlog"
@@ -141,7 +142,7 @@ func TestStopServerReturnsSignalError(t *testing.T) {
 
 func TestServerExitErrorRejectsUnexpectedCleanExit(t *testing.T) {
 	err := serverExitError(nil, true, false)
-	if err == nil || !strings.Contains(err.Error(), "予期せず終了") {
+	if !errors.Is(err, msg.ErrServerExited) {
 		t.Fatalf("err = %v", err)
 	}
 	if err := serverExitError(nil, true, true); err != nil {

--- a/cmd/hso/main.go
+++ b/cmd/hso/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/x/term"
 
 	"github.com/hijoushoku7/hijo-server-ops/internal/config"
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
 	"github.com/hijoushoku7/hijo-server-ops/internal/process"
 	"github.com/hijoushoku7/hijo-server-ops/internal/setup"
 )
@@ -25,7 +26,7 @@ func main() {
 }
 
 func run() error {
-	configPath := flag.String("config", "hso.toml", "設定ファイルのパス")
+	configPath := flag.String("config", "hso.toml", msg.ConfigFlagUsage)
 	flag.Parse()
 
 	// 設定ファイルがない初回はセットアップへ回し、作成できたらそのまま
@@ -37,7 +38,7 @@ func run() error {
 			return err
 		}
 		if created == "" {
-			fmt.Fprintln(os.Stderr, "hso: 中止しました")
+			fmt.Fprintln(os.Stderr, "hso: "+msg.Aborted)
 			return nil
 		}
 	}

--- a/docs/build.md
+++ b/docs/build.md
@@ -66,20 +66,29 @@ cd /path/to/hijo-server-ops
 スクリプトは次の処理を順番に実行する。
 
 1. PATHまたは`$HOME/.local/share/go-1.25.12/bin/go`からGoを検出
-2. `go test ./...`で全テストを実行
-3. `CGO_ENABLED=0`でLinux向けの静的バイナリをビルド
-4. `go version -m ./hso`でビルド情報を表示
+2. `go test ./...`と`go test -tags en ./...`で両言語のテストを実行
+3. `CGO_ENABLED=0`でLinux向けの静的バイナリを2本ビルド
+4. `go version -m ./hso_ja`でビルド情報を表示
+
+表示言語ごとにバイナリを分けているので、成果物は`hso_ja`（日本語版）と
+`hso_en`（英語版）の2本になる。詳細は[spec.md](spec.md)の配布節を参照。
 
 スクリプトを使わず、ビルドだけを直接実行する場合は次のコマンドを使う。
 
 ```bash
 CGO_ENABLED=0 go build \
   -ldflags="-s -w" \
-  -o hso \
+  -o hso_ja \
+  ./cmd/hso
+
+CGO_ENABLED=0 go build \
+  -tags en \
+  -ldflags="-s -w" \
+  -o hso_en \
   ./cmd/hso
 ```
 
-どちらの方法も、リポジトリ直下の既存`hso`を最新ソースからビルドした
+どちらの方法も、リポジトリ直下の既存バイナリを最新ソースからビルドした
 バイナリで置き換える。
 
 ## 起動
@@ -87,11 +96,14 @@ CGO_ENABLED=0 go build \
 設定ファイルを指定して起動する。
 
 ```bash
-./hso -config /path/to/hso.toml
+./hso_ja -config /path/to/hso.toml
 ```
 
 リポジトリ内の検証用Minecraftサーバーを使用する場合は、次のように起動する。
 
 ```bash
-./hso -config mc-server-test/hso.toml
+./hso_ja -config mc-server-test/hso.toml
 ```
+
+英語版を確認する場合は`./hso_en`に読み替える。設定ファイルの名前と中身は
+どちらの言語でも同じ`hso.toml`。

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -316,17 +316,28 @@ JVM 引数はここには書かせない。責務はユーザーの `user_jvm_ar
 
 ---
 
-## 配布
+## 表示言語
+
+**日本語版と英語版は別バイナリにする。単一バイナリに 2 言語を同居させない。**
 
 ```bash
-CGO_ENABLED=0 go build -ldflags="-s -w" -o hso ./cmd/hso
+CGO_ENABLED=0 go build -ldflags="-s -w" -o hso_ja          ./cmd/hso
+CGO_ENABLED=0 go build -ldflags="-s -w" -tags en -o hso_en ./cmd/hso
 ```
+
+- ユーザーに見せる文字列は `internal/msg` に集約する。`msg_ja.go`（`//go:build !en`、既定）と `msg_en.go`（`//go:build en`）が**同じ識別子を宣言する**ので、片方で書き忘れるとそのタグでコンパイルが落ちる。これが訳抜けの唯一の検出手段なので、map や実行時 fallback には**しない**
+- 値を埋め込むものは const の書式文字列ではなく関数にする。const にすると ja と en で verb がずれても気付けない。`%w` で包むものは `error` を返す
+- **実行時のロケール判定・言語フラグ・カタログ探索は持たない**。`-ldflags -X` での切り替えもしない（両言語の文字列が同じバイナリに入るため）
+- `internal/msg` に入れるのは設定モーダル・セットアップウィザード・設定ファイルの検証エラー・サーバー操作の結果など、**普通のユーザーが読む文字列だけ**。hsperfdata や `/proc` のパースエラーのような開発者向けの診断は、両言語で英語リテラルのまま各パッケージに置く（`scripts/build.sh` の出力も英語）
+- 設定ファイルの名前は両言語とも `hso.toml`。実行ファイル名もアーカイブ内では両言語とも `hso` にして、インストール手順を言語で分岐させない
+
+## 配布
 
 - **実行時依存ゼロ**。Go のインストールも不要。バイナリ1個を置いて実行するだけ
 - `CGO_ENABLED=0` で完全静的リンク。glibc に依存しないので Alpine（musl）でもそのまま動く。**リリースビルドでは必須**
 - サイズは 8〜15MB 程度
 - **`linux/amd64` と `linux/arm64` の両方を出す**（Oracle Cloud Ampere / Raspberry Pi でのホストが多いため）
-- 配布は GitHub Releases。`v*` タグの push で `.github/workflows/release.yml` が amd64 / arm64 の tar.gz を作って添付する（goreleaser は使わない）
+- 配布は GitHub Releases。`v*` タグの push で `.github/workflows/release.yml` が arch × lang の 4 本（amd64 / arm64 × ja / en）の tar.gz を作って添付する（goreleaser は使わない）。アーカイブ内の実行ファイル名はどれも `hso`
 - v2 の Fabric mod jar は `//go:embed` でバイナリに埋め込み、`hso install-mod` で `mods/` に書き出す。**ユーザーから見える成果物はバイナリ1個**に保つ
 
 ---

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,12 +2,13 @@ package config
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/BurntSushi/toml"
+
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
 )
 
 type Config struct {
@@ -43,24 +44,20 @@ func Load(path string) (Config, error) {
 
 	metadata, err := toml.DecodeFile(path, &cfg)
 	if err != nil {
-		return cfg, fmt.Errorf("設定ファイルを読む: %w%s", err, reinitialize(path))
+		return cfg, msg.ReadConfigFailed(err, path)
 	}
 	if undecoded := metadata.Undecoded(); len(undecoded) > 0 {
-		return cfg, fmt.Errorf(
-			"不明な設定項目: %s%s",
-			joinKeys(undecoded),
-			reinitialize(path),
-		)
+		return cfg, msg.UnknownConfigKeys(joinKeys(undecoded), path)
 	}
 
 	cfg.Server.Command = strings.TrimSpace(cfg.Server.Command)
 	if cfg.Server.Command == "" {
-		return cfg, errors.New("server.command は必須です")
+		return cfg, errors.New(msg.CommandRequired)
 	}
 
 	configPath, err := filepath.Abs(path)
 	if err != nil {
-		return cfg, fmt.Errorf("設定ファイルの絶対パスを求める: %w", err)
+		return cfg, msg.ConfigAbsPathFailed(err)
 	}
 	configDir := filepath.Dir(configPath)
 
@@ -74,10 +71,10 @@ func Load(path string) (Config, error) {
 
 	info, err := os.Stat(cfg.Server.WorkDir)
 	if err != nil {
-		return cfg, fmt.Errorf("server.workdir を確認する: %w", err)
+		return cfg, msg.WorkDirCheckFailed(err)
 	}
 	if !info.IsDir() {
-		return cfg, fmt.Errorf("server.workdir はディレクトリではありません: %s", cfg.Server.WorkDir)
+		return cfg, msg.WorkDirNotDirectory(cfg.Server.WorkDir)
 	}
 
 	return cfg, nil
@@ -106,15 +103,15 @@ func Save(path string, cfg Config) error {
 	permission := permissionOf(path)
 	temporary := path + ".tmp"
 	if err := os.WriteFile(temporary, []byte(render(cfg)), permission); err != nil {
-		return fmt.Errorf("設定ファイルを書く: %w", err)
+		return msg.WriteConfigFailed(err)
 	}
 	if err := os.Chmod(temporary, permission); err != nil {
 		os.Remove(temporary)
-		return fmt.Errorf("設定ファイルの権限を合わせる: %w", err)
+		return msg.ConfigPermissionFailed(err)
 	}
 	if err := os.Rename(temporary, path); err != nil {
 		os.Remove(temporary)
-		return fmt.Errorf("設定ファイルを置き換える: %w", err)
+		return msg.ReplaceConfigFailed(err)
 	}
 	return nil
 }
@@ -174,17 +171,6 @@ func quote(value string) string {
 		"\t", `\t`,
 	)
 	return `"` + replacer.Replace(value) + `"`
-}
-
-// reinitialize は設定ファイルが読めないときの直し方を添える。古い形式の
-// 項目が残っているのが主な原因で、消して起動し直せばセットアップから
-// 作り直せる、というところまで書かないと何をすればいいか分からない。
-func reinitialize(path string) string {
-	return fmt.Sprintf(
-		"\nhso.toml を初期化してください: %s を削除して hso を起動すると"+
-			"セットアップから作り直せます",
-		path,
-	)
 }
 
 func joinKeys(keys []toml.Key) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,7 +51,7 @@ func Load(path string) (Config, error) {
 
 	cfg.Server.Command = strings.TrimSpace(cfg.Server.Command)
 	if cfg.Server.Command == "" {
-		return cfg, errors.New(msg.CommandRequired)
+		return cfg, msg.CommandRequired()
 	}
 
 	configPath, err := filepath.Abs(path)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,7 +71,7 @@ func TestLoadRejectsUnknownKey(t *testing.T) {
 		t.Fatalf("err = %v", err)
 	}
 	// 何をすればいいか分かるよう、直し方とファイルの場所も添える。
-	if !strings.Contains(err.Error(), "hso.toml を初期化してください") ||
+	if !strings.Contains(err.Error(), "hso.toml") ||
 		!strings.Contains(err.Error(), path) {
 		t.Fatalf("err = %v", err)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,8 +71,7 @@ func TestLoadRejectsUnknownKey(t *testing.T) {
 		t.Fatalf("err = %v", err)
 	}
 	// 何をすればいいか分かるよう、直し方とファイルの場所も添える。
-	if !strings.Contains(err.Error(), "hso.toml") ||
-		!strings.Contains(err.Error(), path) {
+	if !strings.Contains(err.Error(), path) {
 		t.Fatalf("err = %v", err)
 	}
 }

--- a/internal/gclog/tailer.go
+++ b/internal/gclog/tailer.go
@@ -18,7 +18,7 @@ type Tailer struct {
 
 func (t Tailer) Run(ctx context.Context, events chan<- Event) error {
 	if strings.TrimSpace(t.Path) == "" {
-		return errors.New("GCログのパスが空です")
+		return errors.New("GC log path is empty")
 	}
 
 	file, err := t.waitForFile(ctx)
@@ -60,7 +60,7 @@ func (t Tailer) Run(ctx context.Context, events chan<- Event) error {
 				return err
 			}
 		default:
-			return fmt.Errorf("GCログを読む: %w", readErr)
+			return fmt.Errorf("read GC log: %w", readErr)
 		}
 	}
 }
@@ -68,21 +68,21 @@ func (t Tailer) Run(ctx context.Context, events chan<- Event) error {
 func (t Tailer) reopenIfRotated(current *os.File) (*os.File, bool, error) {
 	currentInfo, err := current.Stat()
 	if err != nil {
-		return nil, false, fmt.Errorf("GCログの状態を読む: %w", err)
+		return nil, false, fmt.Errorf("stat GC log: %w", err)
 	}
 	pathInfo, err := os.Stat(t.Path)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, false, nil
 	}
 	if err != nil {
-		return nil, false, fmt.Errorf("GCログの状態を読む: %w", err)
+		return nil, false, fmt.Errorf("stat GC log: %w", err)
 	}
 	if os.SameFile(currentInfo, pathInfo) {
 		return nil, false, nil
 	}
 	replacement, err := os.Open(t.Path)
 	if err != nil {
-		return nil, false, fmt.Errorf("ローテーション後のGCログを開く: %w", err)
+		return nil, false, fmt.Errorf("open rotated GC log: %w", err)
 	}
 	return replacement, true, nil
 }
@@ -94,7 +94,7 @@ func (t Tailer) waitForFile(ctx context.Context) (*os.File, error) {
 		case err == nil:
 			return file, nil
 		case !errors.Is(err, os.ErrNotExist):
-			return nil, fmt.Errorf("GCログを開く: %w", err)
+			return nil, fmt.Errorf("open GC log: %w", err)
 		}
 		if err := wait(ctx, t.pollInterval()); err != nil {
 			return nil, err

--- a/internal/hsperfdata/parser.go
+++ b/internal/hsperfdata/parser.go
@@ -14,8 +14,8 @@ const (
 )
 
 var (
-	ErrNotAccessible = errors.New("hsperfdataはまだ読み取り可能ではありません")
-	ErrUnsupported   = errors.New("未対応のhsperfdata形式です")
+	ErrNotAccessible = errors.New("hsperfdata is not readable yet")
+	ErrUnsupported   = errors.New("unsupported hsperfdata format")
 )
 
 type Counter struct {
@@ -55,7 +55,7 @@ func (s Snapshot) String(name string) (string, bool) {
 
 func Parse(data []byte) (Snapshot, error) {
 	if len(data) < prologueSize {
-		return Snapshot{}, errors.New("hsperfdataのプロローグが短すぎます")
+		return Snapshot{}, errors.New("hsperfdata prologue too short")
 	}
 
 	order, err := byteOrder(data[4])
@@ -63,10 +63,10 @@ func Parse(data []byte) (Snapshot, error) {
 		return Snapshot{}, err
 	}
 	if binary.BigEndian.Uint32(data[0:4]) != magic {
-		return Snapshot{}, errors.New("hsperfdataのマジック値が不正です")
+		return Snapshot{}, errors.New("invalid hsperfdata magic")
 	}
 	if data[5] != 2 {
-		return Snapshot{}, fmt.Errorf("%w: バージョン%d.%d", ErrUnsupported, data[5], data[6])
+		return Snapshot{}, fmt.Errorf("%w: version %d.%d", ErrUnsupported, data[5], data[6])
 	}
 	if data[7] == 0 {
 		return Snapshot{}, ErrNotAccessible
@@ -77,13 +77,13 @@ func Parse(data []byte) (Snapshot, error) {
 	entryOffset := int(order.Uint32(data[24:28]))
 	numEntries := int(order.Uint32(data[28:32]))
 	if used < prologueSize || used > len(data) {
-		return Snapshot{}, fmt.Errorf("hsperfdataの使用量が不正です: %d", used)
+		return Snapshot{}, fmt.Errorf("invalid hsperfdata used size: %d", used)
 	}
 	if entryOffset < prologueSize || entryOffset > used || entryOffset%4 != 0 {
-		return Snapshot{}, fmt.Errorf("hsperfdataのエントリ開始位置が不正です: %d", entryOffset)
+		return Snapshot{}, fmt.Errorf("invalid hsperfdata entry offset: %d", entryOffset)
 	}
 	if numEntries < 0 || numEntries > (used-entryOffset)/entrySize {
-		return Snapshot{}, fmt.Errorf("hsperfdataのエントリ数が不正です: %d", numEntries)
+		return Snapshot{}, fmt.Errorf("invalid hsperfdata entry count: %d", numEntries)
 	}
 
 	snapshot := Snapshot{
@@ -94,7 +94,7 @@ func Parse(data []byte) (Snapshot, error) {
 	for index := 0; index < numEntries; index++ {
 		name, counter, next, err := parseEntry(data[:used], offset, order)
 		if err != nil {
-			return Snapshot{}, fmt.Errorf("hsperfdataエントリ%d: %w", index, err)
+			return Snapshot{}, fmt.Errorf("hsperfdata entry %d: %w", index, err)
 		}
 		snapshot.Counters[name] = counter
 		offset = next
@@ -104,12 +104,12 @@ func Parse(data []byte) (Snapshot, error) {
 
 func parseEntry(data []byte, offset int, order binary.ByteOrder) (string, Counter, int, error) {
 	if offset < 0 || offset%4 != 0 || offset+entrySize > len(data) {
-		return "", Counter{}, 0, fmt.Errorf("開始位置が不正です: %d", offset)
+		return "", Counter{}, 0, fmt.Errorf("invalid offset: %d", offset)
 	}
 
 	entryLength := int(order.Uint32(data[offset : offset+4]))
 	if entryLength < entrySize || offset+entryLength > len(data) {
-		return "", Counter{}, 0, fmt.Errorf("長さが不正です: %d", entryLength)
+		return "", Counter{}, 0, fmt.Errorf("invalid entry length: %d", entryLength)
 	}
 
 	nameOffset := int(order.Uint32(data[offset+4 : offset+8]))
@@ -117,29 +117,29 @@ func parseEntry(data []byte, offset int, order binary.ByteOrder) (string, Counte
 	dataType := data[offset+12]
 	dataOffset := int(order.Uint32(data[offset+16 : offset+20]))
 	if nameOffset < entrySize || nameOffset >= entryLength {
-		return "", Counter{}, 0, fmt.Errorf("名前の位置が不正です: %d", nameOffset)
+		return "", Counter{}, 0, fmt.Errorf("invalid name offset: %d", nameOffset)
 	}
 	if dataOffset <= nameOffset || dataOffset >= entryLength {
-		return "", Counter{}, 0, fmt.Errorf("データの位置が不正です: %d", dataOffset)
+		return "", Counter{}, 0, fmt.Errorf("invalid data offset: %d", dataOffset)
 	}
 
 	nameBytes := data[offset+nameOffset : offset+dataOffset]
 	terminator := strings.IndexByte(string(nameBytes), 0)
 	if terminator <= 0 {
-		return "", Counter{}, 0, errors.New("名前がNUL終端されていません")
+		return "", Counter{}, 0, errors.New("name is not NUL terminated")
 	}
 	name := string(nameBytes[:terminator])
 
 	switch {
 	case vectorLength == 0 && dataType == 'J':
 		if dataOffset+8 > entryLength {
-			return "", Counter{}, 0, errors.New("long値がエントリ境界を越えています")
+			return "", Counter{}, 0, errors.New("long value crosses the entry boundary")
 		}
 		value := int64(order.Uint64(data[offset+dataOffset : offset+dataOffset+8]))
 		return name, Counter{long: value}, offset + entryLength, nil
 	case vectorLength > 0 && dataType == 'B':
 		if dataOffset+vectorLength > entryLength {
-			return "", Counter{}, 0, errors.New("文字列がエントリ境界を越えています")
+			return "", Counter{}, 0, errors.New("string crosses the entry boundary")
 		}
 		value := data[offset+dataOffset : offset+dataOffset+vectorLength]
 		if end := strings.IndexByte(string(value), 0); end >= 0 {
@@ -148,7 +148,7 @@ func parseEntry(data []byte, offset int, order binary.ByteOrder) (string, Counte
 		return name, Counter{text: string(value), isString: true}, offset + entryLength, nil
 	default:
 		return "", Counter{}, 0, fmt.Errorf(
-			"%w: 型=%q ベクタ長=%d",
+			"%w: type=%q vector length=%d",
 			ErrUnsupported,
 			dataType,
 			vectorLength,
@@ -163,6 +163,6 @@ func byteOrder(value byte) (binary.ByteOrder, error) {
 	case 1:
 		return binary.LittleEndian, nil
 	default:
-		return nil, fmt.Errorf("hsperfdataのバイトオーダーが不正です: %d", value)
+		return nil, fmt.Errorf("invalid hsperfdata byte order: %d", value)
 	}
 }

--- a/internal/hsperfdata/reader_linux.go
+++ b/internal/hsperfdata/reader_linux.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 )
 
-var ErrNotFound = errors.New("hsperfdataが見つかりません")
+var ErrNotFound = errors.New("hsperfdata not found")
 
 const hotSpotTempDir = "/tmp"
 
@@ -28,7 +28,7 @@ func openAt(tempDir string, pid int) (*Reader, error) {
 
 func openAtUID(tempDir string, pid int, uid uint32) (*Reader, error) {
 	if pid <= 0 {
-		return nil, fmt.Errorf("PIDが不正です: %d", pid)
+		return nil, fmt.Errorf("invalid PID: %d", pid)
 	}
 	matches, err := filepath.Glob(filepath.Join(
 		tempDir,
@@ -36,7 +36,7 @@ func openAtUID(tempDir string, pid int, uid uint32) (*Reader, error) {
 		strconv.Itoa(pid),
 	))
 	if err != nil {
-		return nil, fmt.Errorf("hsperfdataを探す: %w", err)
+		return nil, fmt.Errorf("look for hsperfdata: %w", err)
 	}
 	var candidateErr error
 	for _, path := range matches {
@@ -60,16 +60,16 @@ func openAtUID(tempDir string, pid int, uid uint32) (*Reader, error) {
 func openPath(path string, uid uint32) (*Reader, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("hsperfdataを開く: %w", err)
+		return nil, fmt.Errorf("open hsperfdata: %w", err)
 	}
 	info, err := file.Stat()
 	if err != nil {
 		_ = file.Close()
-		return nil, fmt.Errorf("hsperfdataのサイズを読む: %w", err)
+		return nil, fmt.Errorf("read hsperfdata size: %w", err)
 	}
 	if !info.Mode().IsRegular() || info.Size() < prologueSize || !fileInfoOwnedBy(info, uid) {
 		_ = file.Close()
-		return nil, errors.New("hsperfdataの種類、サイズ、所有者が不正です")
+		return nil, errors.New("unexpected hsperfdata type, size or owner")
 	}
 
 	data, err := syscall.Mmap(
@@ -81,14 +81,14 @@ func openPath(path string, uid uint32) (*Reader, error) {
 	)
 	if err != nil {
 		_ = file.Close()
-		return nil, fmt.Errorf("hsperfdataをmmapする: %w", err)
+		return nil, fmt.Errorf("mmap hsperfdata: %w", err)
 	}
 	return &Reader{file: file, data: data}, nil
 }
 
 func (r *Reader) Sample() (Snapshot, error) {
 	if r == nil || r.data == nil {
-		return Snapshot{}, errors.New("hsperfdataリーダーは閉じられています")
+		return Snapshot{}, errors.New("hsperfdata reader is closed")
 	}
 	return Parse(r.data)
 }

--- a/internal/hsperfdata/reader_linux_test.go
+++ b/internal/hsperfdata/reader_linux_test.go
@@ -64,7 +64,7 @@ func TestReaderPreservesCandidateError(t *testing.T) {
 	if err == nil || errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v", err)
 	}
-	if !strings.Contains(err.Error(), "種類、サイズ、所有者") {
+	if !strings.Contains(err.Error(), "type, size or owner") {
 		t.Fatalf("err = %v", err)
 	}
 }

--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -93,10 +93,13 @@ const (
 )
 
 // Setup input validation.
-const (
-	EnterCommand   = "enter a start script"
-	EnterDirectory = "enter a directory"
-)
+func EnterCommand() error {
+	return errors.New("enter a start script")
+}
+
+func EnterDirectory() error {
+	return errors.New("enter a directory")
+}
 
 func FileNotFound(path string) error {
 	return fmt.Errorf("no such file: %s", path)
@@ -119,7 +122,9 @@ func AbsPathFailed(err error) error {
 }
 
 // Reading and writing the config file.
-const CommandRequired = "server.command is required"
+func CommandRequired() error {
+	return errors.New("server.command is required")
+}
 
 func ReadConfigFailed(err error, path string) error {
 	return fmt.Errorf("read config file: %w%s", err, reinitialize(path))

--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -1,0 +1,223 @@
+//go:build en
+
+// Package msg collects every string shown to the user. Japanese is the
+// default build; the English build is produced with `-tags en`. The ja and en
+// files declare the same identifiers, so a missing translation fails to
+// compile.
+//
+// Only strings a normal user reads belong here: the settings modal, the setup
+// wizard, config validation errors. Developer-facing diagnostics such as
+// hsperfdata or /proc parse errors stay as English literals in their own
+// packages, identical in both builds.
+//
+// Anything with an embedded value is a function; a const format string would
+// let the verbs drift between ja and en unnoticed. Anything wrapped with %w
+// returns an error.
+package msg
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Settings modal item names.
+const (
+	LabelFrame     = "border"
+	LabelGraphLine = "graph line"
+	LabelMeterBar  = "meter bar"
+	LabelTitle     = "title"
+	LabelSelection = "selection"
+)
+
+// Color preset names.
+const (
+	OptDefault = "default"
+	OptMono    = "mono"
+	OptNeon    = "neon"
+	OptOcean   = "ocean"
+	OptForest  = "forest"
+	OptWarm    = "warm"
+	OptCool    = "cool"
+	OptSafe    = "simple"
+	OptSignal  = "signal"
+	OptFlat    = "flat"
+	OptCyan    = "cyan"
+	OptWhite   = "white"
+	OptAmber   = "amber"
+	OptViolet  = "violet"
+	OptQuiet   = "quiet"
+)
+
+// Status line.
+const StatusIdle = "idle"
+
+func SaveSettingsFailed(err error) string {
+	return "failed to save settings: " + err.Error()
+}
+
+func ActionFailed(err error) string {
+	return "operation failed: " + err.Error()
+}
+
+// Setup wizard screens.
+const (
+	SetupTitle            = "hijo-server-ops setup"
+	SetupStepWorkDir      = "1/3 Minecraft server directory"
+	SetupStepCommand      = "2/3 Choose the start script"
+	SetupStepCommandInput = "2/3 Start script path"
+	SetupStepConfirm      = "3/3 Create with these contents"
+	SetupManualEntry      = "enter a path directly"
+	SetupNotExecutable    = "(not executable)"
+	SetupNoCandidates     = "no start script candidates found"
+	SetupChmodGrant       = "[x] add execute permission (only for those who can already read it)"
+	SetupChmodDeny        = "[ ] leave execute permission off (hso cannot start as is)"
+)
+
+func SetupTarget(path string) string {
+	return "creating: " + path
+}
+
+func SetupRelativeHint(dir string) string {
+	return "a path relative to " + dir + " also works"
+}
+
+// Key bar descriptions.
+const (
+	KeyNext        = "next"
+	KeyAbort       = "abort"
+	KeySelect      = "select"
+	KeyConfirm     = "confirm"
+	KeyBack        = "back"
+	KeyCreate      = "create"
+	KeyToggleChmod = "toggle execute permission"
+)
+
+// Setup input validation.
+const (
+	EnterCommand   = "enter a start script"
+	EnterDirectory = "enter a directory"
+)
+
+func FileNotFound(path string) error {
+	return fmt.Errorf("no such file: %s", path)
+}
+
+func NotRegularFile(path string) error {
+	return fmt.Errorf("not a regular file: %s", path)
+}
+
+func DirectoryNotFound(path string) error {
+	return fmt.Errorf("no such directory: %s", path)
+}
+
+func NotDirectory(path string) error {
+	return fmt.Errorf("not a directory: %s", path)
+}
+
+func AbsPathFailed(err error) error {
+	return fmt.Errorf("resolve absolute path: %w", err)
+}
+
+// Reading and writing the config file.
+const CommandRequired = "server.command is required"
+
+func ReadConfigFailed(err error, path string) error {
+	return fmt.Errorf("read config file: %w%s", err, reinitialize(path))
+}
+
+func UnknownConfigKeys(keys, path string) error {
+	return fmt.Errorf("unknown config keys: %s%s", keys, reinitialize(path))
+}
+
+// reinitialize explains how to recover from an unreadable config file. Stale
+// keys from an older format are the usual cause, and without spelling out
+// that deleting the file brings the setup wizard back, there is no way to
+// know what to do.
+func reinitialize(path string) string {
+	return fmt.Sprintf(
+		"\nreinitialize hso.toml: delete %s and start hso to build it again"+
+			" from the setup wizard",
+		path,
+	)
+}
+
+func ConfigAbsPathFailed(err error) error {
+	return fmt.Errorf("resolve absolute path of config file: %w", err)
+}
+
+func ConfigAlreadyExists(path string) error {
+	return fmt.Errorf("config file already exists: %s", path)
+}
+
+func CreateConfigFailed(err error) error {
+	return fmt.Errorf("create config file: %w", err)
+}
+
+func WriteConfigFailed(err error) error {
+	return fmt.Errorf("write config file: %w", err)
+}
+
+func ConfigPermissionFailed(err error) error {
+	return fmt.Errorf("match config file permission: %w", err)
+}
+
+func ReplaceConfigFailed(err error) error {
+	return fmt.Errorf("replace config file: %w", err)
+}
+
+func WorkDirCheckFailed(err error) error {
+	return fmt.Errorf("check server.workdir: %w", err)
+}
+
+func WorkDirNotDirectory(path string) error {
+	return fmt.Errorf("server.workdir is not a directory: %s", path)
+}
+
+// Start script.
+func ScriptAbsPathFailed(err error) error {
+	return fmt.Errorf("resolve absolute path of start script: %w", err)
+}
+
+func ScriptStatFailed(err error) error {
+	return fmt.Errorf("check start script: %w", err)
+}
+
+func ScriptIsDirectory(path string) error {
+	return fmt.Errorf("start script is a directory: %s", path)
+}
+
+func ScriptNotExecutable(path string) error {
+	return fmt.Errorf("start script is not executable: %s", path)
+}
+
+func ChmodFailed(err error) error {
+	return fmt.Errorf("add execute permission: %w", err)
+}
+
+// Server operations.
+var (
+	ErrHeapCountersUnavailable = errors.New("hsperfdata has no heap usage counters")
+	ErrRSSUnavailable          = errors.New("/proc status has no VmRSS")
+	ErrServerStopped           = errors.New("server is not running")
+	ErrRestartBeforeJava       = errors.New("restart is available once the java process has started")
+	ErrScriptExitedWithoutJava = errors.New("start script exited without starting a java process")
+	ErrServerExited            = errors.New("Minecraft server exited unexpectedly")
+)
+
+func RestartFailed(err error) error {
+	return fmt.Errorf("restart server: %w", err)
+}
+
+func StopFailed(err error) error {
+	return fmt.Errorf("stop server: %w", err)
+}
+
+func FindJavaFailed(err error) error {
+	return fmt.Errorf("locate java process: %w", err)
+}
+
+// Command line.
+const (
+	ConfigFlagUsage = "path to the config file"
+	Aborted         = "aborted"
+)

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -1,0 +1,220 @@
+//go:build !en
+
+// Package msg はユーザーに見せる文字列を 1 箇所に集める。日本語版が既定で、
+// 英語版は `-tags en` でビルドする。ja と en は同じ識別子を宣言するので、
+// 片方で書き忘れるとコンパイルエラーになる。
+//
+// ここに入れるのは設定モーダル・セットアップウィザード・設定ファイルの
+// 検証エラーなど、普通のユーザーが読む文字列だけ。hsperfdata や /proc の
+// パースエラーのような開発者向けの診断メッセージは、両言語で英語リテラル
+// のまま各パッケージに置く。
+//
+// 埋め込む値があるものは関数にする。const の書式文字列にすると、ja と en で
+// verb がずれても気付けない。%w で包むものは error を返す。
+package msg
+
+import (
+	"errors"
+	"fmt"
+)
+
+// 設定モーダルの項目名。
+const (
+	LabelFrame     = "枠"
+	LabelGraphLine = "グラフの線"
+	LabelMeterBar  = "メーターの棒"
+	LabelTitle     = "タイトル"
+	LabelSelection = "選択行"
+)
+
+// 配色プリセットの表示名。
+const (
+	OptDefault = "既定"
+	OptMono    = "モノクロ"
+	OptNeon    = "ネオン"
+	OptOcean   = "海"
+	OptForest  = "森"
+	OptWarm    = "暖色"
+	OptCool    = "寒色"
+	OptSafe    = "シンプル"
+	OptSignal  = "信号"
+	OptFlat    = "単色"
+	OptCyan    = "シアン"
+	OptWhite   = "白"
+	OptAmber   = "黄"
+	OptViolet  = "紫"
+	OptQuiet   = "控えめ"
+)
+
+// ステータス行。
+const StatusIdle = "操作待ち"
+
+func SaveSettingsFailed(err error) string {
+	return "設定の保存に失敗: " + err.Error()
+}
+
+func ActionFailed(err error) string {
+	return "操作失敗: " + err.Error()
+}
+
+// セットアップウィザードの画面。
+const (
+	SetupTitle            = "hijo-server-ops セットアップ"
+	SetupStepWorkDir      = "1/3 Minecraft サーバーのディレクトリ"
+	SetupStepCommand      = "2/3 起動スクリプトを選ぶ"
+	SetupStepCommandInput = "2/3 起動スクリプトのパス"
+	SetupStepConfirm      = "3/3 この内容で作成する"
+	SetupManualEntry      = "パスを直接入力する"
+	SetupNotExecutable    = "(実行権限なし)"
+	SetupNoCandidates     = "起動スクリプトの候補が見つかりません"
+	SetupChmodGrant       = "[x] 実行権限を付ける（読める相手にだけ実行を許す）"
+	SetupChmodDeny        = "[ ] 実行権限を付けない（このままでは hso は起動できない）"
+)
+
+func SetupTarget(path string) string {
+	return "作成先: " + path
+}
+
+func SetupRelativeHint(dir string) string {
+	return dir + " からの相対パスも書ける"
+}
+
+// キーバーの説明。
+const (
+	KeyNext        = "次へ"
+	KeyAbort       = "中止"
+	KeySelect      = "選ぶ"
+	KeyConfirm     = "決定"
+	KeyBack        = "戻る"
+	KeyCreate      = "作成"
+	KeyToggleChmod = "実行権限の付与を切替"
+)
+
+// セットアップの入力検証。
+const (
+	EnterCommand   = "起動スクリプトを入力してください"
+	EnterDirectory = "ディレクトリを入力してください"
+)
+
+func FileNotFound(path string) error {
+	return fmt.Errorf("ファイルがありません: %s", path)
+}
+
+func NotRegularFile(path string) error {
+	return fmt.Errorf("通常のファイルではありません: %s", path)
+}
+
+func DirectoryNotFound(path string) error {
+	return fmt.Errorf("ディレクトリがありません: %s", path)
+}
+
+func NotDirectory(path string) error {
+	return fmt.Errorf("ディレクトリではありません: %s", path)
+}
+
+func AbsPathFailed(err error) error {
+	return fmt.Errorf("絶対パスを求める: %w", err)
+}
+
+// 設定ファイルの読み書き。
+const CommandRequired = "server.command は必須です"
+
+func ReadConfigFailed(err error, path string) error {
+	return fmt.Errorf("設定ファイルを読む: %w%s", err, reinitialize(path))
+}
+
+func UnknownConfigKeys(keys, path string) error {
+	return fmt.Errorf("不明な設定項目: %s%s", keys, reinitialize(path))
+}
+
+// reinitialize は設定ファイルが読めないときの直し方を添える。古い形式の
+// 項目が残っているのが主な原因で、消して起動し直せばセットアップから
+// 作り直せる、というところまで書かないと何をすればいいか分からない。
+func reinitialize(path string) string {
+	return fmt.Sprintf(
+		"\nhso.toml を初期化してください: %s を削除して hso を起動すると"+
+			"セットアップから作り直せます",
+		path,
+	)
+}
+
+func ConfigAbsPathFailed(err error) error {
+	return fmt.Errorf("設定ファイルの絶対パスを求める: %w", err)
+}
+
+func ConfigAlreadyExists(path string) error {
+	return fmt.Errorf("設定ファイルは既にあります: %s", path)
+}
+
+func CreateConfigFailed(err error) error {
+	return fmt.Errorf("設定ファイルを作る: %w", err)
+}
+
+func WriteConfigFailed(err error) error {
+	return fmt.Errorf("設定ファイルを書く: %w", err)
+}
+
+func ConfigPermissionFailed(err error) error {
+	return fmt.Errorf("設定ファイルの権限を合わせる: %w", err)
+}
+
+func ReplaceConfigFailed(err error) error {
+	return fmt.Errorf("設定ファイルを置き換える: %w", err)
+}
+
+func WorkDirCheckFailed(err error) error {
+	return fmt.Errorf("server.workdir を確認する: %w", err)
+}
+
+func WorkDirNotDirectory(path string) error {
+	return fmt.Errorf("server.workdir はディレクトリではありません: %s", path)
+}
+
+// 起動スクリプト。
+func ScriptAbsPathFailed(err error) error {
+	return fmt.Errorf("起動スクリプトの絶対パスを求める: %w", err)
+}
+
+func ScriptStatFailed(err error) error {
+	return fmt.Errorf("起動スクリプトを確認する: %w", err)
+}
+
+func ScriptIsDirectory(path string) error {
+	return fmt.Errorf("起動スクリプトはディレクトリです: %s", path)
+}
+
+func ScriptNotExecutable(path string) error {
+	return fmt.Errorf("起動スクリプトに実行権限がありません: %s", path)
+}
+
+func ChmodFailed(err error) error {
+	return fmt.Errorf("実行権限を付ける: %w", err)
+}
+
+// サーバー操作。
+var (
+	ErrHeapCountersUnavailable = errors.New("hsperfdataにヒープ使用量カウンタがありません")
+	ErrRSSUnavailable          = errors.New("/procのstatusにVmRSSがありません")
+	ErrServerStopped           = errors.New("サーバーは停止しています")
+	ErrRestartBeforeJava       = errors.New("javaプロセスの起動完了後に再起動できます")
+	ErrScriptExitedWithoutJava = errors.New("起動スクリプトがjavaプロセスを開始せずに終了しました")
+	ErrServerExited            = errors.New("Minecraftサーバーが予期せず終了しました")
+)
+
+func RestartFailed(err error) error {
+	return fmt.Errorf("サーバーを再起動する: %w", err)
+}
+
+func StopFailed(err error) error {
+	return fmt.Errorf("サーバーを停止する: %w", err)
+}
+
+func FindJavaFailed(err error) error {
+	return fmt.Errorf("javaプロセスの特定: %w", err)
+}
+
+// コマンドライン。
+const (
+	ConfigFlagUsage = "設定ファイルのパス"
+	Aborted         = "中止しました"
+)

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -91,10 +91,13 @@ const (
 )
 
 // セットアップの入力検証。
-const (
-	EnterCommand   = "起動スクリプトを入力してください"
-	EnterDirectory = "ディレクトリを入力してください"
-)
+func EnterCommand() error {
+	return errors.New("起動スクリプトを入力してください")
+}
+
+func EnterDirectory() error {
+	return errors.New("ディレクトリを入力してください")
+}
 
 func FileNotFound(path string) error {
 	return fmt.Errorf("ファイルがありません: %s", path)
@@ -117,7 +120,9 @@ func AbsPathFailed(err error) error {
 }
 
 // 設定ファイルの読み書き。
-const CommandRequired = "server.command は必須です"
+func CommandRequired() error {
+	return errors.New("server.command は必須です")
+}
 
 func ReadConfigFailed(err error, path string) error {
 	return fmt.Errorf("設定ファイルを読む: %w%s", err, reinitialize(path))

--- a/internal/process/java.go
+++ b/internal/process/java.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	ErrJavaNotFound     = errors.New("javaプロセスがまだ見つかりません")
-	ErrDetachedTerminal = errors.New("screen/tmuxを使う起動スクリプトには対応していません")
-	ErrRootPIDReused    = errors.New("起動スクリプトのPIDが再利用されました")
+	ErrJavaNotFound     = errors.New("java process not found yet")
+	ErrDetachedTerminal = errors.New("start scripts using screen/tmux are not supported")
+	ErrRootPIDReused    = errors.New("start script PID was reused")
 )
 
 type JavaFinder struct {
@@ -35,7 +35,7 @@ func (f JavaFinder) Find(rootPID int) (int, error) {
 func readProcesses(procRoot string) (map[int]procEntry, error) {
 	entries, err := os.ReadDir(procRoot)
 	if err != nil {
-		return nil, fmt.Errorf("%sを読む: %w", procRoot, err)
+		return nil, fmt.Errorf("read %s: %w", procRoot, err)
 	}
 	processes := make(map[int]procEntry)
 	for _, entry := range entries {
@@ -169,24 +169,24 @@ func parseProcStat(data []byte) (procEntry, error) {
 	open := strings.IndexByte(line, '(')
 	close := strings.LastIndexByte(line, ')')
 	if open < 0 || close <= open {
-		return procEntry{}, errors.New("不正な/proc stat形式")
+		return procEntry{}, errors.New("malformed /proc stat")
 	}
 
 	fields := strings.Fields(line[close+1:])
 	if len(fields) < 20 {
-		return procEntry{}, errors.New("不正な/proc statフィールド")
+		return procEntry{}, errors.New("malformed /proc stat fields")
 	}
 	ppid, err := strconv.Atoi(fields[1])
 	if err != nil {
-		return procEntry{}, fmt.Errorf("PPIDを読む: %w", err)
+		return procEntry{}, fmt.Errorf("read PPID: %w", err)
 	}
 	pgrp, err := strconv.Atoi(fields[2])
 	if err != nil {
-		return procEntry{}, fmt.Errorf("プロセスグループIDを読む: %w", err)
+		return procEntry{}, fmt.Errorf("read process group ID: %w", err)
 	}
 	startTime, err := strconv.ParseUint(fields[19], 10, 64)
 	if err != nil {
-		return procEntry{}, fmt.Errorf("開始時刻を読む: %w", err)
+		return procEntry{}, fmt.Errorf("read start time: %w", err)
 	}
 
 	return procEntry{

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
 )
 
 type Options struct {
@@ -43,14 +45,14 @@ func Start(options Options) (*Process, error) {
 
 	gcLogDir, err := os.MkdirTemp("", "hso-")
 	if err != nil {
-		return nil, fmt.Errorf("GCログ用ディレクトリを作る: %w", err)
+		return nil, fmt.Errorf("create GC log directory: %w", err)
 	}
 	gcLogPath := filepath.Join(gcLogDir, "gc.log")
 
 	executable, err := os.Executable()
 	if err != nil {
 		_ = os.RemoveAll(gcLogDir)
-		return nil, fmt.Errorf("hsoの実行ファイルを確認する: %w", err)
+		return nil, fmt.Errorf("resolve hso executable: %w", err)
 	}
 	cmd := exec.Command(executable, supervisorArgument, command)
 	cmd.Dir = options.WorkDir
@@ -62,14 +64,14 @@ func Start(options Options) (*Process, error) {
 	stdinReader, stdinWriter, err := os.Pipe()
 	if err != nil {
 		_ = os.RemoveAll(gcLogDir)
-		return nil, fmt.Errorf("サーバーstdinを開く: %w", err)
+		return nil, fmt.Errorf("open server stdin: %w", err)
 	}
 	controlReader, controlWriter, err := os.Pipe()
 	if err != nil {
 		_ = stdinReader.Close()
 		_ = stdinWriter.Close()
 		_ = os.RemoveAll(gcLogDir)
-		return nil, fmt.Errorf("supervisor制御パイプを開く: %w", err)
+		return nil, fmt.Errorf("open supervisor control pipe: %w", err)
 	}
 	cmd.Stdin = stdinReader
 	cmd.Stdout = options.Stdout
@@ -82,7 +84,7 @@ func Start(options Options) (*Process, error) {
 		_ = controlReader.Close()
 		_ = controlWriter.Close()
 		_ = os.RemoveAll(gcLogDir)
-		return nil, fmt.Errorf("supervisorを開始する: %w", err)
+		return nil, fmt.Errorf("start supervisor: %w", err)
 	}
 	_ = stdinReader.Close()
 	_ = controlWriter.Close()
@@ -94,7 +96,7 @@ func Start(options Options) (*Process, error) {
 		_ = cmd.Process.Signal(syscall.SIGTERM)
 		_ = cmd.Wait()
 		_ = os.RemoveAll(gcLogDir)
-		return nil, fmt.Errorf("supervisorの開始時刻を読む: %w", err)
+		return nil, fmt.Errorf("read supervisor start time: %w", err)
 	}
 
 	serverPID, err := readSupervisorPID(controlReader)
@@ -128,17 +130,17 @@ func resolveCommand(command, workDir string) (string, error) {
 	}
 	path, err := filepath.Abs(path)
 	if err != nil {
-		return "", fmt.Errorf("起動スクリプトの絶対パスを求める: %w", err)
+		return "", msg.ScriptAbsPathFailed(err)
 	}
 	info, err := os.Stat(path)
 	if err != nil {
-		return "", fmt.Errorf("起動スクリプトを確認する: %w", err)
+		return "", msg.ScriptStatFailed(err)
 	}
 	if info.IsDir() {
-		return "", fmt.Errorf("起動スクリプトはディレクトリです: %s", path)
+		return "", msg.ScriptIsDirectory(path)
 	}
 	if info.Mode().Perm()&0o111 == 0 {
-		return "", fmt.Errorf("起動スクリプトに実行権限がありません: %s", path)
+		return "", msg.ScriptNotExecutable(path)
 	}
 	return path, nil
 }
@@ -174,7 +176,7 @@ func (p *Process) Write(data []byte) (int, error) {
 
 	select {
 	case <-p.done:
-		return 0, errors.New("サーバープロセスは終了しています")
+		return 0, errors.New("server process has exited")
 	default:
 		return p.stdin.Write(data)
 	}
@@ -189,10 +191,10 @@ func (p *Process) Send(command string) error {
 func (p *Process) Signal(signal os.Signal) error {
 	value, ok := signal.(syscall.Signal)
 	if !ok {
-		return fmt.Errorf("未対応のシグナル: %v", signal)
+		return fmt.Errorf("unsupported signal: %v", signal)
 	}
 	if err := p.cmd.Process.Signal(value); err != nil {
-		return fmt.Errorf("supervisorへ%sを送る: %w", signal, err)
+		return fmt.Errorf("send %s to supervisor: %w", signal, err)
 	}
 	return nil
 }
@@ -207,21 +209,21 @@ func (p *Process) reap() {
 func readSupervisorPID(control *os.File) (int, error) {
 	line, err := bufio.NewReader(control).ReadString('\n')
 	if err != nil {
-		return 0, fmt.Errorf("supervisorの応答を読む: %w", err)
+		return 0, fmt.Errorf("read supervisor reply: %w", err)
 	}
 	line = strings.TrimSpace(line)
 	if strings.HasPrefix(line, "ERR ") {
 		return 0, errors.New(strings.TrimPrefix(line, "ERR "))
 	}
 	if !strings.HasPrefix(line, "PID ") {
-		return 0, fmt.Errorf("不正なsupervisor応答: %q", line)
+		return 0, fmt.Errorf("malformed supervisor reply: %q", line)
 	}
 	pid, err := strconv.Atoi(strings.TrimPrefix(line, "PID "))
 	if err != nil {
-		return 0, fmt.Errorf("supervisor応答のPIDを読む: %w", err)
+		return 0, fmt.Errorf("read PID from supervisor reply: %w", err)
 	}
 	if pid <= 0 {
-		return 0, fmt.Errorf("supervisor応答のPIDが不正です: %d", pid)
+		return 0, fmt.Errorf("invalid PID in supervisor reply: %d", pid)
 	}
 	return pid, nil
 }

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -78,7 +79,8 @@ func TestProcessReportsStartError(t *testing.T) {
 		Command: filepath.Join(t.TempDir(), "missing"),
 		WorkDir: t.TempDir(),
 	})
-	if err == nil || !strings.Contains(err.Error(), "起動スクリプトを確認する") {
+	// 起動スクリプトが見つからないことが呼び出し側まで伝わるかどうか。
+	if !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("err = %v", err)
 	}
 }

--- a/internal/process/supervisor.go
+++ b/internal/process/supervisor.go
@@ -23,7 +23,7 @@ func SupervisorCommand(args []string) (string, bool) {
 func RunSupervisor(command string) int {
 	control := os.NewFile(3, "hso-supervisor-control")
 	if control == nil {
-		fmt.Fprintln(os.Stderr, "hso supervisor: 制御パイプがありません")
+		fmt.Fprintln(os.Stderr, "hso supervisor: no control pipe")
 		return 1
 	}
 	defer control.Close()
@@ -45,7 +45,7 @@ func RunSupervisor(command string) int {
 	server.Env = os.Environ()
 	server.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := server.Start(); err != nil {
-		writeSupervisorError(control, fmt.Errorf("起動スクリプトを開始する: %w", err))
+		writeSupervisorError(control, fmt.Errorf("start the start script: %w", err))
 		return 1
 	}
 	serverPID := server.Process.Pid
@@ -71,7 +71,7 @@ func RunSupervisor(command string) int {
 			reapAdoptedChildren()
 			alive, err := managedProcessesAlive("/proc", os.Getpid(), serverPID)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "hso supervisor: プロセス確認: %v\n", err)
+				fmt.Fprintf(os.Stderr, "hso supervisor: check process: %v\n", err)
 				return 1
 			}
 			if !alive {
@@ -115,7 +115,7 @@ func becomeSubreaper() error {
 		0,
 	)
 	if errno != 0 {
-		return fmt.Errorf("subreaperを有効化する: %w", errno)
+		return fmt.Errorf("enable subreaper: %w", errno)
 	}
 	return nil
 }
@@ -199,7 +199,7 @@ func commandExitCode(err error) int {
 		}
 		return exitErr.ExitCode()
 	}
-	fmt.Fprintf(os.Stderr, "hso supervisor: 起動スクリプトを待つ: %v\n", err)
+	fmt.Fprintf(os.Stderr, "hso supervisor: wait for the start script: %v\n", err)
 	return 1
 }
 

--- a/internal/procstats/procstats_linux.go
+++ b/internal/procstats/procstats_linux.go
@@ -57,11 +57,11 @@ func ReadCPUTime(pid int) (Duration, error) {
 
 func readCPUTimeAt(procRoot string, pid int) (Duration, error) {
 	if pid <= 0 {
-		return Duration{}, fmt.Errorf("PIDが不正です: %d", pid)
+		return Duration{}, fmt.Errorf("invalid PID: %d", pid)
 	}
 	data, err := os.ReadFile(filepath.Join(procRoot, strconv.Itoa(pid), "stat"))
 	if err != nil {
-		return Duration{}, fmt.Errorf("プロセスのstatを読む: %w", err)
+		return Duration{}, fmt.Errorf("read process stat: %w", err)
 	}
 	return parseCPUTime(data)
 }
@@ -70,29 +70,29 @@ func parseCPUTime(data []byte) (Duration, error) {
 	line := strings.TrimSpace(string(data))
 	close := strings.LastIndexByte(line, ')')
 	if close < 0 {
-		return Duration{}, errors.New("プロセスのstat形式が不正です")
+		return Duration{}, errors.New("malformed process stat")
 	}
 	fields := strings.Fields(line[close+1:])
 	if len(fields) < 13 {
-		return Duration{}, errors.New("プロセスのstatフィールドが不足しています")
+		return Duration{}, errors.New("process stat has too few fields")
 	}
 	user, err := strconv.ParseUint(fields[11], 10, 64)
 	if err != nil {
-		return Duration{}, fmt.Errorf("プロセスのuser CPU時間を読む: %w", err)
+		return Duration{}, fmt.Errorf("read process user CPU time: %w", err)
 	}
 	system, err := strconv.ParseUint(fields[12], 10, 64)
 	if err != nil {
-		return Duration{}, fmt.Errorf("プロセスのsystem CPU時間を読む: %w", err)
+		return Duration{}, fmt.Errorf("read process system CPU time: %w", err)
 	}
 	if user > ^uint64(0)-system {
-		return Duration{}, errors.New("プロセスのCPU時間が大きすぎます")
+		return Duration{}, errors.New("process CPU time is too large")
 	}
 	// Linuxのamd64/arm64では/procのCPU時間にUSER_HZ=100を使う。
 	const clockTicksPerSecond = uint64(100)
 	ticks := user + system
 	seconds := ticks / clockTicksPerSecond
 	if seconds > uint64((1<<63-1)/int64(time.Second)) {
-		return Duration{}, errors.New("プロセスのCPU時間が大きすぎます")
+		return Duration{}, errors.New("process CPU time is too large")
 	}
 	value := time.Duration(seconds)*time.Second +
 		time.Duration(ticks%clockTicksPerSecond)*time.Second/
@@ -102,12 +102,12 @@ func parseCPUTime(data []byte) (Duration, error) {
 
 func readMemoryAt(procRoot, mountInfoPath string, pid int) (Memory, error) {
 	if pid <= 0 {
-		return Memory{}, fmt.Errorf("PIDが不正です: %d", pid)
+		return Memory{}, fmt.Errorf("invalid PID: %d", pid)
 	}
 
 	status, err := os.Open(filepath.Join(procRoot, strconv.Itoa(pid), "status"))
 	if err != nil {
-		return Memory{}, fmt.Errorf("プロセスのstatusを開く: %w", err)
+		return Memory{}, fmt.Errorf("open process status: %w", err)
 	}
 	rss, err := parseRSS(status)
 	closeErr := status.Close()
@@ -115,7 +115,7 @@ func readMemoryAt(procRoot, mountInfoPath string, pid int) (Memory, error) {
 		return Memory{}, err
 	}
 	if closeErr != nil {
-		return Memory{}, fmt.Errorf("プロセスのstatusを閉じる: %w", closeErr)
+		return Memory{}, fmt.Errorf("close process status: %w", closeErr)
 	}
 
 	memory := Memory{
@@ -194,16 +194,16 @@ func parseRSS(status *os.File) (Number, error) {
 			continue
 		}
 		if len(fields) != 3 || fields[2] != "kB" {
-			return Number{}, fmt.Errorf("VmRSSの形式が不正です: %q", scanner.Text())
+			return Number{}, fmt.Errorf("malformed VmRSS: %q", scanner.Text())
 		}
 		kibibytes, err := strconv.ParseUint(fields[1], 10, 64)
 		if err != nil {
-			return Number{}, fmt.Errorf("VmRSSを読む: %w", err)
+			return Number{}, fmt.Errorf("read VmRSS: %w", err)
 		}
 		return Number{Value: kibibytes * 1024, Available: true}, nil
 	}
 	if err := scanner.Err(); err != nil {
-		return Number{}, fmt.Errorf("プロセスのstatusを読む: %w", err)
+		return Number{}, fmt.Errorf("read process status: %w", err)
 	}
 	return Number{}, nil
 }
@@ -233,7 +233,7 @@ func readCgroups(path string) ([]cgroupMembership, error) {
 		return nil, err
 	}
 	if len(memberships) == 0 {
-		return nil, errors.New("memory cgroupに所属していません")
+		return nil, errors.New("not a member of a memory cgroup")
 	}
 	return memberships, nil
 }
@@ -276,7 +276,7 @@ func readCgroupMounts(path string) ([]cgroupMount, error) {
 		return nil, err
 	}
 	if len(mounts) == 0 {
-		return nil, errors.New("memory cgroupのマウントがありません")
+		return nil, errors.New("no memory cgroup mount")
 	}
 	return mounts, nil
 }

--- a/internal/serveraddr/address.go
+++ b/internal/serveraddr/address.go
@@ -5,6 +5,7 @@ package serveraddr
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -49,31 +50,31 @@ func fetchPublicIPv4(
 ) (netip.Addr, error) {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return netip.Addr{}, fmt.Errorf("公開IPv4のリクエストを作る: %w", err)
+		return netip.Addr{}, fmt.Errorf("build public IPv4 request: %w", err)
 	}
 	response, err := client.Do(request)
 	if err != nil {
-		return netip.Addr{}, fmt.Errorf("公開IPv4を取得する: %w", err)
+		return netip.Addr{}, fmt.Errorf("fetch public IPv4: %w", err)
 	}
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
 		return netip.Addr{}, fmt.Errorf(
-			"公開IPv4の取得に失敗しました: HTTP %d",
+			"failed to fetch public IPv4: HTTP %d",
 			response.StatusCode,
 		)
 	}
 	body, err := io.ReadAll(io.LimitReader(response.Body, maxIPAddressBytes+1))
 	if err != nil {
-		return netip.Addr{}, fmt.Errorf("公開IPv4の応答を読む: %w", err)
+		return netip.Addr{}, fmt.Errorf("read public IPv4 response: %w", err)
 	}
 	if len(body) > maxIPAddressBytes {
-		return netip.Addr{}, fmt.Errorf("公開IPv4の応答が長すぎます")
+		return netip.Addr{}, errors.New("public IPv4 response is too long")
 	}
 
 	ip, err := netip.ParseAddr(strings.TrimSpace(string(body)))
 	if err != nil || !ip.Is4() {
-		return netip.Addr{}, fmt.Errorf("公開IPv4の応答がIPv4アドレスではありません")
+		return netip.Addr{}, errors.New("public IPv4 response is not an IPv4 address")
 	}
 	return ip, nil
 }
@@ -83,7 +84,7 @@ func fetchPublicIPv4(
 func ReadPort(path string) (uint16, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return 0, fmt.Errorf("server.propertiesを開く: %w", err)
+		return 0, fmt.Errorf("open server.properties: %w", err)
 	}
 	defer file.Close()
 
@@ -104,15 +105,15 @@ func ReadPort(path string) (uint16, error) {
 		found = true
 	}
 	if err := scanner.Err(); err != nil {
-		return 0, fmt.Errorf("server.propertiesを読む: %w", err)
+		return 0, fmt.Errorf("read server.properties: %w", err)
 	}
 	if !found {
-		return 0, fmt.Errorf("server.propertiesにserver-portがありません")
+		return 0, errors.New("server.properties has no server-port")
 	}
 
 	parsed, err := strconv.ParseUint(value, 10, 16)
 	if err != nil || parsed == 0 {
-		return 0, fmt.Errorf("server-portが不正です: %q", value)
+		return 0, fmt.Errorf("invalid server-port: %q", value)
 	}
 	return uint16(parsed), nil
 }

--- a/internal/setup/model.go
+++ b/internal/setup/model.go
@@ -7,6 +7,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
 )
 
 var (
@@ -29,7 +31,6 @@ var (
 const (
 	maxInputRunes = 512
 	listViewport  = 10
-	manualEntry   = "パスを直接入力する"
 )
 
 type step uint8
@@ -112,7 +113,7 @@ func (m *model) updateWorkDir(key tea.Key) (tea.Model, tea.Cmd) {
 		m.step = stepCommand
 		if len(m.candidates) == 0 {
 			// 候補がないなら選ばせる画面に意味がないので入力へ送る。
-			m.message = "起動スクリプトの候補が見つかりません"
+			m.message = msg.SetupNoCandidates
 			m.input = []rune("./run.sh")
 			m.step = stepCommandInput
 		}
@@ -250,8 +251,8 @@ func (m *model) preview() string {
 
 func (m *model) View() tea.View {
 	lines := []string{
-		titleStyle.Render("hijo-server-ops セットアップ"),
-		dimStyle.Render("作成先: " + m.configPath),
+		titleStyle.Render(msg.SetupTitle),
+		dimStyle.Render(msg.SetupTarget(m.configPath)),
 		"",
 	}
 	lines = append(lines, m.body()...)
@@ -266,25 +267,25 @@ func (m *model) body() []string {
 	switch m.step {
 	case stepWorkDir:
 		return []string{
-			"1/3 Minecraft サーバーのディレクトリ",
+			msg.SetupStepWorkDir,
 			"",
 			"  " + string(m.input) + "█",
 		}
 	case stepCommand:
 		lines := []string{
-			"2/3 起動スクリプトを選ぶ",
+			msg.SetupStepCommand,
 			"",
 		}
 		return append(lines, m.candidateLines()...)
 	case stepCommandInput:
 		return []string{
-			"2/3 起動スクリプトのパス",
-			dimStyle.Render("  " + m.workDir + " からの相対パスも書ける"),
+			msg.SetupStepCommandInput,
+			dimStyle.Render("  " + msg.SetupRelativeHint(m.workDir)),
 			"",
 			"  " + string(m.input) + "█",
 		}
 	default:
-		lines := []string{"3/3 この内容で作成する", ""}
+		lines := []string{msg.SetupStepConfirm, ""}
 		for _, line := range strings.Split(strings.TrimRight(m.preview(), "\n"), "\n") {
 			lines = append(lines, "  "+line)
 		}
@@ -301,9 +302,9 @@ func (m *model) body() []string {
 // 起動できないので、断ったときはその結果も出す。
 func (m *model) chmodLine() string {
 	if m.grantChmod {
-		return "[x] 実行権限を付ける（読める相手にだけ実行を許す）"
+		return msg.SetupChmodGrant
 	}
-	return errorStyle.Render("[ ] 実行権限を付けない（このままでは hso は起動できない）")
+	return errorStyle.Render(msg.SetupChmodDeny)
 }
 
 func (m *model) candidateLines() []string {
@@ -311,7 +312,7 @@ func (m *model) candidateLines() []string {
 	for _, item := range m.candidates {
 		labels = append(labels, item.label())
 	}
-	labels = append(labels, manualEntry)
+	labels = append(labels, msg.SetupManualEntry)
 
 	start := windowStart(m.cursor, len(labels), listViewport)
 	end := min(start+listViewport, len(labels))
@@ -350,28 +351,28 @@ func (m *model) keybar() string {
 	case stepWorkDir:
 		// 最初の画面には戻り先がないので、Esc は Ctrl+C と同じく中止。
 		return renderKeys([][2]string{
-			{"Enter", "次へ"},
-			{"Esc / Ctrl+C", "中止"},
+			{"Enter", msg.KeyNext},
+			{"Esc / Ctrl+C", msg.KeyAbort},
 		})
 	case stepCommand:
 		keys = append(keys,
-			[2]string{"↑↓", "選ぶ"},
-			[2]string{"Enter", "決定"},
-			[2]string{"Esc", "戻る"},
+			[2]string{"↑↓", msg.KeySelect},
+			[2]string{"Enter", msg.KeyConfirm},
+			[2]string{"Esc", msg.KeyBack},
 		)
 	case stepCommandInput:
 		keys = append(keys,
-			[2]string{"Enter", "次へ"},
-			[2]string{"Esc", "戻る"},
+			[2]string{"Enter", msg.KeyNext},
+			[2]string{"Esc", msg.KeyBack},
 		)
 	default:
-		keys = append(keys, [2]string{"Enter", "作成"})
+		keys = append(keys, [2]string{"Enter", msg.KeyCreate})
 		if m.needsChmod {
-			keys = append(keys, [2]string{"c", "実行権限の付与を切替"})
+			keys = append(keys, [2]string{"c", msg.KeyToggleChmod})
 		}
-		keys = append(keys, [2]string{"Esc", "戻る"})
+		keys = append(keys, [2]string{"Esc", msg.KeyBack})
 	}
-	keys = append(keys, [2]string{"Ctrl+C", "中止"})
+	keys = append(keys, [2]string{"Ctrl+C", msg.KeyAbort})
 	return renderKeys(keys)
 }
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -2,7 +2,6 @@
 package setup
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -106,7 +105,7 @@ func scanCommands(dir string) []candidate {
 func resolveCommand(input, workDir string) (command string, path string, err error) {
 	input = strings.TrimSpace(expandHome(input))
 	if input == "" {
-		return "", "", errors.New(msg.EnterCommand)
+		return "", "", msg.EnterCommand()
 	}
 
 	path = input
@@ -134,7 +133,7 @@ func resolveCommand(input, workDir string) (command string, path string, err err
 func resolveWorkDir(input string) (string, error) {
 	input = strings.TrimSpace(expandHome(input))
 	if input == "" {
-		return "", errors.New(msg.EnterDirectory)
+		return "", msg.EnterDirectory()
 	}
 	path, err := filepath.Abs(input)
 	if err != nil {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -2,13 +2,15 @@
 package setup
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
 )
 
 // Run は設定ファイルを対話的に作る。作成したら作成先のパスを返す。
@@ -16,10 +18,10 @@ import (
 func Run(configPath string) (string, error) {
 	path, err := filepath.Abs(configPath)
 	if err != nil {
-		return "", fmt.Errorf("設定ファイルの絶対パスを求める: %w", err)
+		return "", msg.ConfigAbsPathFailed(err)
 	}
 	if _, err := os.Stat(path); err == nil {
-		return "", fmt.Errorf("設定ファイルは既にあります: %s", path)
+		return "", msg.ConfigAlreadyExists(path)
 	}
 
 	model := newModel(path)
@@ -47,7 +49,7 @@ func (item candidate) label() string {
 	if item.executable {
 		return item.name
 	}
-	return item.name + "  (実行権限なし)"
+	return item.name + "  " + msg.SetupNotExecutable
 }
 
 // isCandidate は起動スクリプトになりうるファイルかどうか。.sh は権限に
@@ -104,7 +106,7 @@ func scanCommands(dir string) []candidate {
 func resolveCommand(input, workDir string) (command string, path string, err error) {
 	input = strings.TrimSpace(expandHome(input))
 	if input == "" {
-		return "", "", fmt.Errorf("起動スクリプトを入力してください")
+		return "", "", errors.New(msg.EnterCommand)
 	}
 
 	path = input
@@ -115,10 +117,10 @@ func resolveCommand(input, workDir string) (command string, path string, err err
 
 	info, err := os.Stat(path)
 	if err != nil {
-		return "", "", fmt.Errorf("ファイルがありません: %s", path)
+		return "", "", msg.FileNotFound(path)
 	}
 	if !info.Mode().IsRegular() {
-		return "", "", fmt.Errorf("通常のファイルではありません: %s", path)
+		return "", "", msg.NotRegularFile(path)
 	}
 
 	command = path
@@ -132,18 +134,18 @@ func resolveCommand(input, workDir string) (command string, path string, err err
 func resolveWorkDir(input string) (string, error) {
 	input = strings.TrimSpace(expandHome(input))
 	if input == "" {
-		return "", fmt.Errorf("ディレクトリを入力してください")
+		return "", errors.New(msg.EnterDirectory)
 	}
 	path, err := filepath.Abs(input)
 	if err != nil {
-		return "", fmt.Errorf("絶対パスを求める: %w", err)
+		return "", msg.AbsPathFailed(err)
 	}
 	info, err := os.Stat(path)
 	if err != nil {
-		return "", fmt.Errorf("ディレクトリがありません: %s", path)
+		return "", msg.DirectoryNotFound(path)
 	}
 	if !info.IsDir() {
-		return "", fmt.Errorf("ディレクトリではありません: %s", path)
+		return "", msg.NotDirectory(path)
 	}
 	return path, nil
 }
@@ -187,11 +189,11 @@ func quote(value string) string {
 func writeConfig(path, content string) error {
 	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
-		return fmt.Errorf("設定ファイルを作る: %w", err)
+		return msg.CreateConfigFailed(err)
 	}
 	if _, err := file.WriteString(content); err != nil {
 		file.Close()
-		return fmt.Errorf("設定ファイルを書く: %w", err)
+		return msg.WriteConfigFailed(err)
 	}
 	return file.Close()
 }
@@ -201,12 +203,12 @@ func writeConfig(path, content string) error {
 func grantExecute(path string) error {
 	info, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("起動スクリプトを確認する: %w", err)
+		return msg.ScriptStatFailed(err)
 	}
 	mode := info.Mode().Perm()
 	mode |= (mode & 0o444) >> 2
 	if err := os.Chmod(path, mode); err != nil {
-		return fmt.Errorf("実行権限を付ける: %w", err)
+		return msg.ChmodFailed(err)
 	}
 	return nil
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hijoushoku7/hijo-server-ops/internal/gclog"
 	"github.com/hijoushoku7/hijo-server-ops/internal/hsperfdata"
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
 	"github.com/hijoushoku7/hijo-server-ops/internal/procstats"
 	"github.com/hijoushoku7/hijo-server-ops/internal/serverlog"
 )
@@ -244,7 +245,7 @@ func (model *Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	case ActionResultMsg:
 		model.busy = false
 		if message.Err != nil {
-			model.status = "操作失敗: " + message.Err.Error()
+			model.status = msg.ActionFailed(message.Err)
 			break
 		}
 		if message.Action.Kind == ActionSendCommand {
@@ -566,7 +567,7 @@ func (model *Model) offer(action Action) bool {
 		}
 		return true
 	default:
-		model.status = "操作待ち"
+		model.status = msg.StatusIdle
 		return false
 	}
 }

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -5,6 +5,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
 )
 
 // Settings は設定モーダルで変更できる値。項目を増やすときは、ここへ
@@ -133,13 +135,13 @@ type settingItem struct {
 
 var settingItems = []settingItem{
 	{
-		label: "枠",
+		label: msg.LabelFrame,
 		options: []settingOption{
-			{label: "既定", value: "dracula"},
-			{label: "モノクロ", value: "mono"},
-			{label: "ネオン", value: "neon"},
-			{label: "海", value: "ocean"},
-			{label: "森", value: "forest"},
+			{label: msg.OptDefault, value: "dracula"},
+			{label: msg.OptMono, value: "mono"},
+			{label: msg.OptNeon, value: "neon"},
+			{label: msg.OptOcean, value: "ocean"},
+			{label: msg.OptForest, value: "forest"},
 		},
 		get: func(settings Settings) string { return settings.FramePreset },
 		set: func(settings *Settings, value string) {
@@ -147,13 +149,13 @@ var settingItems = []settingItem{
 		},
 	},
 	{
-		label: "グラフの線",
+		label: msg.LabelGraphLine,
 		options: []settingOption{
-			{label: "既定", value: "dracula"},
-			{label: "モノクロ", value: "mono"},
-			{label: "暖色", value: "warm"},
-			{label: "寒色", value: "cool"},
-			{label: "シンプル", value: "safe"},
+			{label: msg.OptDefault, value: "dracula"},
+			{label: msg.OptMono, value: "mono"},
+			{label: msg.OptWarm, value: "warm"},
+			{label: msg.OptCool, value: "cool"},
+			{label: msg.OptSafe, value: "safe"},
 		},
 		get: func(settings Settings) string { return settings.GraphPreset },
 		set: func(settings *Settings, value string) {
@@ -161,12 +163,12 @@ var settingItems = []settingItem{
 		},
 	},
 	{
-		label: "メーターの棒",
+		label: msg.LabelMeterBar,
 		options: []settingOption{
-			{label: "信号", value: "signal"},
-			{label: "モノクロ", value: "mono"},
-			{label: "シンプル", value: "safe"},
-			{label: "単色", value: "flat"},
+			{label: msg.OptSignal, value: "signal"},
+			{label: msg.OptMono, value: "mono"},
+			{label: msg.OptSafe, value: "safe"},
+			{label: msg.OptFlat, value: "flat"},
 		},
 		get: func(settings Settings) string { return settings.MeterPreset },
 		set: func(settings *Settings, value string) {
@@ -174,13 +176,13 @@ var settingItems = []settingItem{
 		},
 	},
 	{
-		label: "タイトル",
+		label: msg.LabelTitle,
 		options: []settingOption{
-			{label: "シアン", value: "cyan"},
-			{label: "白", value: "white"},
-			{label: "黄", value: "amber"},
-			{label: "紫", value: "violet"},
-			{label: "控えめ", value: "quiet"},
+			{label: msg.OptCyan, value: "cyan"},
+			{label: msg.OptWhite, value: "white"},
+			{label: msg.OptAmber, value: "amber"},
+			{label: msg.OptViolet, value: "violet"},
+			{label: msg.OptQuiet, value: "quiet"},
 		},
 		get: func(settings Settings) string { return settings.TitlePreset },
 		set: func(settings *Settings, value string) {
@@ -188,12 +190,12 @@ var settingItems = []settingItem{
 		},
 	},
 	{
-		label: "選択行",
+		label: msg.LabelSelection,
 		options: []settingOption{
-			{label: "黄", value: "amber"},
-			{label: "シアン", value: "cyan"},
-			{label: "紫", value: "violet"},
-			{label: "モノクロ", value: "mono"},
+			{label: msg.OptAmber, value: "amber"},
+			{label: msg.OptCyan, value: "cyan"},
+			{label: msg.OptViolet, value: "violet"},
+			{label: msg.OptMono, value: "mono"},
 		},
 		get: func(settings Settings) string { return settings.SelectionPreset },
 		set: func(settings *Settings, value string) {
@@ -319,7 +321,7 @@ func (model *Model) saveSettings() {
 		return
 	}
 	if err := model.save(model.settings); err != nil {
-		model.status = "設定の保存に失敗: " + err.Error()
+		model.status = msg.SaveSettingsFailed(err)
 	}
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,19 +10,30 @@ if command -v go >/dev/null 2>&1; then
 elif [ -x "$HOME/.local/share/go-$go_version/bin/go" ]; then
 	go_command="$HOME/.local/share/go-$go_version/bin/go"
 else
-	echo "Goが見つかりません。docs/build.mdの手順でGo $go_versionを導入してください。" >&2
+	echo "go not found. Install Go $go_version by following docs/build.md." >&2
 	exit 1
 fi
 
 cd "$project_dir"
 
 "$go_command" version
-echo "ビルド開始: $project_dir"
+echo "build started: $project_dir"
+
+# 日本語版はタグなし、英語版は -tags en。テストも両方のタグで回す。片方の
+# 言語ファイルでキーを書き忘れると、そちらのタグでだけコンパイルが落ちる。
 "$go_command" test ./...
+"$go_command" test -tags en ./...
+
 CGO_ENABLED=0 "$go_command" build \
 	-ldflags="-s -w" \
-	-o hso \
+	-o hso_ja \
 	./cmd/hso
-echo "依存関係のバージョン情報:"
-"$go_command" version -m ./hso
-echo "ビルド完了: $project_dir/hso"
+CGO_ENABLED=0 "$go_command" build \
+	-tags en \
+	-ldflags="-s -w" \
+	-o hso_en \
+	./cmd/hso
+
+echo "dependency versions:"
+"$go_command" version -m ./hso_ja
+echo "build finished: $project_dir/hso_ja, $project_dir/hso_en"


### PR DESCRIPTION
## 概要

同一バイナリに 2 言語を同居させず、`hso_ja` / `hso_en` を別々に吐く。ソースは 1 本のまま、build tag で言語ファイルを切り替える。

## 設計

- `internal/msg` にユーザーが読む文字列を集約。`msg_ja.go`（`//go:build !en`、既定）と `msg_en.go`（`//go:build en`）が同じ識別子を宣言する。片方で書き忘れるとコンパイルエラーになるのが唯一の抜け漏れ検出手段。
- 値を埋め込むものは const の書式文字列にせず関数にした。ja と en で verb がずれても気付けないため。`%w` で包むものは `error` を返す。
- 実行時のロケール判定・カタログ探索はなし。片方の言語の文字列はもう片方のバイナリに 1 バイトも入らない（`grep -a` で確認済み）。
- この方針を `docs/spec.md` に「表示言語」節として記録した。

## 開発者向けエラーの扱い

hsperfdata・procstats・gclog・serveraddr・process の内部エラーと supervisor の stderr は、両言語で英語リテラルに統一した。`scripts/build.sh` の出力も英語。msg に入るのは設定モーダル・セットアップウィザード・設定ファイル検証・サーバー操作の結果など、普通のユーザーが読む文字列だけ。

なおダッシュボード本体は元から英語なので、ja 版で新たに日本語化した箇所はない。

## ビルドと配布

```sh
CGO_ENABLED=0 go build -ldflags="-s -w" -o hso_ja          ./cmd/hso
CGO_ENABLED=0 go build -ldflags="-s -w" -tags en -o hso_en ./cmd/hso
```

`scripts/build.sh` は `go test ./...` と `go test -tags en ./...` の両方を回してから 2 本ビルドする。`release.yml` は arch × lang の 4 成果物（`hso_${VERSION}_linux_${arch}_${lang}.tar.gz`）を作る。アーカイブ内の実行ファイル名はどちらの言語も `hso` にして、インストール手順を言語で分岐させない。`docs/build.md` の手順も新しい成果物名に合わせた。

## テスト

日本語リテラルをアサートしていた 4 箇所を、言語非依存の検証に置き換えた（`errors.Is(msg.ErrServerExited)`、`errors.Is(fs.ErrNotExist)` など。前 2 者は文字列一致より強くなっている）。両タグで `go test ./...` と `go vet ./...` が通る。

## 未対応

- `README.md` / `hso.toml.example` は日本語版を整えてから翻訳する方針なので未着手。そのため `_en` のアーカイブにも当面は日本語の README と設定テンプレートが入る（既知の穴）

🤖 Generated with [Claude Code](https://claude.com/claude-code)