### PR TITLE
feat: ログにタイムスタンプと色分けを追加

### DIFF
--- a/cmd/hso/app.go
+++ b/cmd/hso/app.go
@@ -64,6 +64,9 @@ func settingsFrom(cfg config.Config) ui.Settings {
 	if value := cfg.UI.Theme.Selection; value != "" {
 		settings.SelectionPreset = value
 	}
+	if value := cfg.UI.Theme.Log; value != "" {
+		settings.LogPreset = value
+	}
 	return settings
 }
 
@@ -74,6 +77,7 @@ func saveSettings(configPath string, cfg config.Config, settings ui.Settings) er
 		Meter:     settings.MeterPreset,
 		Title:     settings.TitlePreset,
 		Selection: settings.SelectionPreset,
+		Log:       settings.LogPreset,
 	}
 	return config.Save(configPath, cfg)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ type Theme struct {
 	Meter     string `toml:"meter"`
 	Title     string `toml:"title"`
 	Selection string `toml:"selection"`
+	Log       string `toml:"log"`
 }
 
 func Load(path string) (Config, error) {
@@ -150,6 +151,7 @@ func render(cfg Config) string {
 			{"meter", cfg.UI.Theme.Meter},
 			{"title", cfg.UI.Theme.Title},
 			{"selection", cfg.UI.Theme.Selection},
+			{"log", cfg.UI.Theme.Log},
 		} {
 			if preset[1] != "" {
 				out.WriteString(preset[0] + " = " + quote(preset[1]) + "\n")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -88,7 +88,7 @@ func TestSaveWritesReloadableConfig(t *testing.T) {
 	path := filepath.Join(dir, "hso.toml")
 	cfg := Config{
 		Server: Server{Command: "./run.sh", WorkDir: dir},
-		UI:     UI{Theme: Theme{Frame: "neon", Graph: "safe"}},
+		UI:     UI{Theme: Theme{Frame: "neon", Graph: "safe", Log: "cool"}},
 	}
 
 	if err := Save(path, cfg); err != nil {

--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -27,6 +27,7 @@ const (
 	LabelMeterBar  = "meter bar"
 	LabelTitle     = "title"
 	LabelSelection = "selection"
+	LabelLog       = "log"
 )
 
 // Color preset names.

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -25,6 +25,7 @@ const (
 	LabelMeterBar  = "メーターの棒"
 	LabelTitle     = "タイトル"
 	LabelSelection = "選択行"
+	LabelLog       = "ログ"
 )
 
 // 配色プリセットの表示名。

--- a/internal/ui/log_render.go
+++ b/internal/ui/log_render.go
@@ -1,0 +1,87 @@
+package ui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/hijoushoku7/hijo-server-ops/internal/serverlog"
+)
+
+const timestampGutterWidth = 6
+
+func renderLogRecord(record logRecord, width int) string {
+	if width <= 0 {
+		return ""
+	}
+
+	body := record.line()
+	prefix := ""
+	if width >= timestampGutterWidth {
+		prefix = formatLogTimestamp(record) + " "
+	}
+	// 切り詰めは ANSI を含まない状態で済ませ、色は残った範囲へ最後に付ける。
+	plain := truncate(prefix+body, width)
+
+	var result strings.Builder
+	prefixEnd := min(len(prefix), len(plain))
+	if prefixEnd > 0 {
+		result.WriteString(timestampStyle(record.timestampSource).Render(plain[:prefixEnd]))
+	}
+
+	bodyStart := prefixEnd
+	playerStart := -1
+	if record.player != "" {
+		if position := strings.Index(body, record.player); position >= 0 {
+			playerStart = len(prefix) + position
+		}
+	}
+	kindStyle := styleForLogKind(record.kind)
+	if playerStart < bodyStart || playerStart >= len(plain) {
+		result.WriteString(kindStyle.Render(plain[bodyStart:]))
+	} else {
+		playerEnd := min(playerStart+len(record.player), len(plain))
+		result.WriteString(kindStyle.Render(plain[bodyStart:playerStart]))
+		result.WriteString(styleForPlayer(record.player).Render(plain[playerStart:playerEnd]))
+		result.WriteString(kindStyle.Render(plain[playerEnd:]))
+	}
+
+	if padding := width - stringWidth(plain); padding > 0 {
+		result.WriteString(strings.Repeat(" ", padding))
+	}
+	return result.String()
+}
+
+func formatLogTimestamp(record logRecord) string {
+	if record.timestamp.IsZero() || record.timestampSource == serverlog.TimestampUnknown {
+		return "n/a  "
+	}
+	return record.timestamp.Format("15:04")
+}
+
+func timestampStyle(source serverlog.TimestampSource) lipgloss.Style {
+	if source == serverlog.TimestampLog {
+		return logTimestampStyle
+	}
+	return logReceivedStyle
+}
+
+func styleForLogKind(kind serverlog.Kind) lipgloss.Style {
+	if style, ok := logKindStyles[kind]; ok {
+		return style
+	}
+	return logKindStyles[serverlog.KindOther]
+}
+
+func styleForPlayer(name string) lipgloss.Style {
+	if len(logPlayerStyles) == 0 {
+		return lipgloss.NewStyle()
+	}
+	// FNV-1a で名前を固定の色番号へ割り当てる。
+	hash := uint32(2166136261)
+	for index := 0; index < len(name); index++ {
+		hash ^= uint32(name[index])
+		hash *= 16777619
+	}
+	return logPlayerStyles[int(hash%uint32(len(logPlayerStyles)))]
+}

--- a/internal/ui/log_render.go
+++ b/internal/ui/log_render.go
@@ -15,7 +15,9 @@ func renderLogRecord(record logRecord, width int) string {
 		return ""
 	}
 
-	body := record.line()
+	// タブは幅計算では 0 桁だが lipgloss が描画時に空白 4 個へ展開するので、
+	// 幅を数える前に空白 1 個へ潰す。1 バイトのままなので後段の位置計算も狂わない。
+	body := strings.ReplaceAll(record.line(), "\t", " ")
 	prefix := ""
 	if width >= timestampGutterWidth {
 		prefix = formatLogTimestamp(record) + " "

--- a/internal/ui/log_render_test.go
+++ b/internal/ui/log_render_test.go
@@ -50,6 +50,27 @@ func TestPlayerColorIsStableForSameName(t *testing.T) {
 	}
 }
 
+// lipgloss はタブを空白 4 個へ展開するので、残したままだと幅計算より実際の
+// 描画が広くなり枠がずれる。スタックトレースのような本文で起きる。
+func TestRenderLogRecordFlattensTabs(t *testing.T) {
+	record := logRecord{
+		timestamp:       time.Date(2026, time.August, 5, 12, 34, 56, 0, time.UTC),
+		timestampSource: serverlog.TimestampLog,
+		kind:            serverlog.KindOther,
+		text:            "\tat java.base/java.lang.Thread.run",
+	}
+
+	for width := 1; width <= 40; width++ {
+		line := renderLogRecord(record, width)
+		if strings.Contains(line, "\t") {
+			t.Fatalf("width %d: line still contains a tab: %q", width, stripANSI(line))
+		}
+		if got := stringWidth(line); got != width {
+			t.Fatalf("width %d: line width = %d, text = %q", width, got, stripANSI(line))
+		}
+	}
+}
+
 func TestRenderLogRecordKeepsWidthAfterColoring(t *testing.T) {
 	record := logRecord{
 		timestamp:       time.Date(2026, time.August, 5, 12, 34, 56, 0, time.UTC),

--- a/internal/ui/log_render_test.go
+++ b/internal/ui/log_render_test.go
@@ -1,0 +1,68 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hijoushoku7/hijo-server-ops/internal/serverlog"
+)
+
+func TestRenderLogRecordAddsSixColumnTimestampGutter(t *testing.T) {
+	record := logRecord{
+		timestamp:       time.Date(2026, time.August, 5, 12, 34, 56, 0, time.UTC),
+		timestampSource: serverlog.TimestampLog,
+		kind:            serverlog.KindOther,
+		text:            "server ready",
+	}
+
+	got := stripANSI(renderLogRecord(record, 30))
+	if !strings.HasPrefix(got, "12:34 server ready") {
+		t.Fatalf("line = %q", got)
+	}
+	gutter := got[:timestampGutterWidth]
+	if gutter != "12:34 " || stringWidth(gutter) != timestampGutterWidth {
+		t.Fatalf("gutter = %q, width = %d", gutter, stringWidth(gutter))
+	}
+}
+
+func TestRenderLogRecordDropsTimestampWhenWidthIsNarrow(t *testing.T) {
+	record := logRecord{
+		timestamp:       time.Date(2026, time.August, 5, 12, 34, 56, 0, time.UTC),
+		timestampSource: serverlog.TimestampLog,
+		kind:            serverlog.KindOther,
+		text:            "hello",
+	}
+
+	got := stripANSI(renderLogRecord(record, timestampGutterWidth-1))
+	if got != "hello" {
+		t.Fatalf("line = %q", got)
+	}
+}
+
+func TestPlayerColorIsStableForSameName(t *testing.T) {
+	applyTheme(DefaultSettings())
+	want := styleForPlayer("alice").GetForeground()
+	for range 10 {
+		if got := styleForPlayer("alice").GetForeground(); got != want {
+			t.Fatalf("player color = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestRenderLogRecordKeepsWidthAfterColoring(t *testing.T) {
+	record := logRecord{
+		timestamp:       time.Date(2026, time.August, 5, 12, 34, 56, 0, time.UTC),
+		timestampSource: serverlog.TimestampReceived,
+		kind:            serverlog.KindChat,
+		player:          "alice",
+		text:            "こんにちは world",
+	}
+
+	for width := 1; width <= 30; width++ {
+		line := renderLogRecord(record, width)
+		if got := stringWidth(line); got != width {
+			t.Fatalf("width %d: line width = %d, text = %q", width, got, stripANSI(line))
+		}
+	}
+}

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -162,7 +162,7 @@ func TestModelKeepsHistoryWhenTerminalBecomesTooSmall(t *testing.T) {
 
 func TestModelRestoresFullLogLineAfterResize(t *testing.T) {
 	model := newTestModel()
-	_, _ = model.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	_, _ = model.Update(tea.WindowSizeMsg{Width: 140, Height: 24})
 	line := "start-" + strings.Repeat("x", 50) + "-restored"
 	_, _ = model.Update(LogMsg{Entry: serverlog.Entry{
 		Kind:    serverlog.KindOther,
@@ -173,7 +173,7 @@ func TestModelRestoresFullLogLineAfterResize(t *testing.T) {
 	if strings.Contains(model.View().Content, line) {
 		t.Fatalf("narrow view unexpectedly contains the full line")
 	}
-	_, _ = model.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	_, _ = model.Update(tea.WindowSizeMsg{Width: 140, Height: 24})
 	if !strings.Contains(model.View().Content, line) {
 		t.Fatalf("expanded view did not restore the full line")
 	}

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -17,6 +17,7 @@ type Settings struct {
 	MeterPreset     string
 	TitlePreset     string
 	SelectionPreset string
+	LogPreset       string
 }
 
 func DefaultSettings() Settings {
@@ -26,6 +27,7 @@ func DefaultSettings() Settings {
 		MeterPreset:     "signal",
 		TitlePreset:     "cyan",
 		SelectionPreset: "amber",
+		LogPreset:       "dracula",
 	}
 }
 
@@ -110,6 +112,20 @@ var settingItems = []settingItem{
 		get: func(settings Settings) string { return settings.SelectionPreset },
 		set: func(settings *Settings, value string) {
 			settings.SelectionPreset = value
+		},
+	},
+	{
+		label: msg.LabelLog,
+		options: []settingOption{
+			{label: msg.OptDefault, value: "dracula"},
+			{label: msg.OptMono, value: "mono"},
+			{label: msg.OptWarm, value: "warm"},
+			{label: msg.OptCool, value: "cool"},
+			{label: msg.OptSafe, value: "safe"},
+		},
+		get: func(settings Settings) string { return settings.LogPreset },
+		set: func(settings *Settings, value string) {
+			settings.LogPreset = value
 		},
 	},
 }

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -128,4 +128,8 @@ func TestApplyThemeFallsBackToDefaultsForUnknownPresets(t *testing.T) {
 		color(meterPresets[defaults.MeterPreset].over).GetForeground() {
 		t.Fatalf("meter = %#v", meterOverStyle)
 	}
+	if logTimestampStyle.GetForeground() !=
+		color(logPresets[defaults.LogPreset].timestamp).GetForeground() {
+		t.Fatalf("log timestamp = %#v", logTimestampStyle)
+	}
 }

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -1,6 +1,10 @@
 package ui
 
-import "charm.land/lipgloss/v2"
+import (
+	"charm.land/lipgloss/v2"
+
+	"github.com/hijoushoku7/hijo-server-ops/internal/serverlog"
+)
 
 // 初期値を既定プリセットと揃え、New を通さないテストでも同じ配色にする。
 var (
@@ -20,6 +24,19 @@ var (
 	keyStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#282A36")).
 			Background(lipgloss.Color("#BBBBBB"))
+	logTimestampStyle = color("#777777")
+	logReceivedStyle  = color("#5A5A5A").Faint(true)
+	logKindStyles     = map[serverlog.Kind]lipgloss.Style{
+		serverlog.KindPlayerJoin:  color("#50FA7B"),
+		serverlog.KindPlayerLeave: color("#FF5555"),
+		serverlog.KindChat:        color("#F8F8F2"),
+		serverlog.KindCommand:     color("#BD93F9"),
+		serverlog.KindLag:         color("#FFB86C"),
+		serverlog.KindOther:       color("#BBBBBB"),
+	}
+	logPlayerStyles = playerStyles([]string{
+		"#8BE9FD", "#FF79C6", "#F1FA8C", "#50FA7B", "#BD93F9", "#FFB86C",
+	})
 )
 
 type framePalette struct {
@@ -47,6 +64,18 @@ type selectionPalette struct {
 	background    string
 	keyForeground string
 	keyBackground string
+}
+
+type logPalette struct {
+	timestamp string
+	received  string
+	join      string
+	leave     string
+	chat      string
+	command   string
+	lag       string
+	other     string
+	players   []string
 }
 
 var framePresets = map[string]framePalette{
@@ -101,6 +130,39 @@ var selectionPresets = map[string]selectionPalette{
 	},
 }
 
+var logPresets = map[string]logPalette{
+	"dracula": {
+		timestamp: "#777777", received: "#5A5A5A",
+		join: "#50FA7B", leave: "#FF5555", chat: "#F8F8F2",
+		command: "#BD93F9", lag: "#FFB86C", other: "#BBBBBB",
+		players: []string{"#8BE9FD", "#FF79C6", "#F1FA8C", "#50FA7B", "#BD93F9", "#FFB86C"},
+	},
+	"mono": {
+		timestamp: "#777777", received: "#555555",
+		join: "#E0E0E0", leave: "#A0A0A0", chat: "#F8F8F2",
+		command: "#C8C8C8", lag: "#FFFFFF", other: "#909090",
+		players: []string{"#FFFFFF", "#E0E0E0", "#C8C8C8", "#B0B0B0"},
+	},
+	"warm": {
+		timestamp: "#9B7B6B", received: "#70584D",
+		join: "#F1FA8C", leave: "#FF5555", chat: "#FFF1DC",
+		command: "#FF79C6", lag: "#FFB86C", other: "#C9A58A",
+		players: []string{"#FFD166", "#FF9F68", "#FF79C6", "#F1FA8C", "#FFB86C"},
+	},
+	"cool": {
+		timestamp: "#6272A4", received: "#44506B",
+		join: "#8BE9FD", leave: "#BD93F9", chat: "#E6F7FF",
+		command: "#7AA2F7", lag: "#FF79C6", other: "#8FA9B8",
+		players: []string{"#8BE9FD", "#56B4E9", "#BD93F9", "#A0E9FF", "#7DCFFF"},
+	},
+	"safe": {
+		timestamp: "#777777", received: "#555555",
+		join: "#009E73", leave: "#D55E00", chat: "#F0F0F0",
+		command: "#CC79A7", lag: "#E69F00", other: "#999999",
+		players: []string{"#56B4E9", "#E69F00", "#CC79A7", "#009E73", "#F0E442"},
+	},
+}
+
 // 配色をグループ単位に限定し、反転表示や警告色の意味を壊さない。
 func applyTheme(settings Settings) {
 	defaults := DefaultSettings()
@@ -136,6 +198,20 @@ func applyTheme(settings Settings) {
 		Bold(true)
 	keyStyle = color(selection.keyForeground).
 		Background(lipgloss.Color(selection.keyBackground))
+
+	logs := preset(logPresets, settings.LogPreset, defaults.LogPreset)
+	logTimestampStyle = color(logs.timestamp)
+	// 受信時刻はログ由来の時刻より暗くし、推定値であることを区別する。
+	logReceivedStyle = color(logs.received).Faint(true)
+	logKindStyles = map[serverlog.Kind]lipgloss.Style{
+		serverlog.KindPlayerJoin:  color(logs.join),
+		serverlog.KindPlayerLeave: color(logs.leave),
+		serverlog.KindChat:        color(logs.chat),
+		serverlog.KindCommand:     color(logs.command),
+		serverlog.KindLag:         color(logs.lag),
+		serverlog.KindOther:       color(logs.other),
+	}
+	logPlayerStyles = playerStyles(logs.players)
 }
 
 func preset[T any](presets map[string]T, selected, fallback string) T {
@@ -147,4 +223,12 @@ func preset[T any](presets map[string]T, selected, fallback string) T {
 
 func color(value string) lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(value))
+}
+
+func playerStyles(colors []string) []lipgloss.Style {
+	styles := make([]lipgloss.Style, len(colors))
+	for index, value := range colors {
+		styles[index] = color(value).Bold(true)
+	}
+	return styles
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -126,16 +126,20 @@ func (model *Model) renderBufferPanel(
 	contentHeight := max(0, height-2)
 	window := buffer.Window(contentHeight)
 	lines := make([]string, contentHeight)
+	innerWidth := max(0, width-2)
+	for index := range lines {
+		lines[index] = strings.Repeat(" ", innerWidth)
+	}
 	padding := max(0, contentHeight-len(window))
 	for index := 0; index < len(window) && padding+index < len(lines); index++ {
-		lines[padding+index] = window[index].line()
+		lines[padding+index] = renderLogRecord(window[index], innerWidth)
 	}
 
 	title := target.title()
 	if offset := buffer.Offset(); offset > 0 {
 		title = fmt.Sprintf("%s ↑%d", title, offset)
 	}
-	return renderPanel(title, lines, width, height, true, model.frameFor(target))
+	return renderFittedPanel(title, lines, width, height, true, model.frameFor(target))
 }
 
 func renderPanel(
@@ -145,6 +149,31 @@ func renderPanel(
 	height int,
 	alignBottom bool,
 	box frame,
+) string {
+	return renderPanelLines(title, lines, width, height, alignBottom, box, false)
+}
+
+// renderFittedPanel は素テキストで切り詰めてから色を付けた行をそのまま描く。
+// ANSI 付きの行へ再度 fitLine を通さず、ログの色と枠幅を保つ。
+func renderFittedPanel(
+	title string,
+	lines []string,
+	width int,
+	height int,
+	alignBottom bool,
+	box frame,
+) string {
+	return renderPanelLines(title, lines, width, height, alignBottom, box, true)
+}
+
+func renderPanelLines(
+	title string,
+	lines []string,
+	width int,
+	height int,
+	alignBottom bool,
+	box frame,
+	linesFitted bool,
 ) string {
 	if width <= 0 || height <= 0 {
 		return ""
@@ -178,7 +207,10 @@ func renderPanel(
 		if position >= 0 && position < len(lines) {
 			line = lines[position]
 		}
-		result.WriteString(fitLine(line, innerWidth))
+		if !linesFitted {
+			line = fitLine(line, innerWidth)
+		}
+		result.WriteString(line)
 		result.WriteString(vertical)
 	}
 	result.WriteByte('\n')


### PR DESCRIPTION
[docs/log-pane.md](docs/log-pane.md) のフェーズ B（項目 4）。フェーズ A は #31 で完了済み。

## 内容

- 左端に `HH:MM` の 5 桁 + 区切り 1 桁、計 6 桁のガターを置く
- kind ごと（join / leave / chat / command / lag / other）に配色
- プレイヤー名は FNV-1a のハッシュで固定色を割り当て、同じ人が常に同じ色になる
- 幅が 6 桁に満たないときはタイムスタンプを落とす
- ログ由来の時刻と hso の受信時刻を色で区別し、時刻が取れないものは `n/a` と出す（設計原則 4）
- 配色は既存のプリセット機構に乗せ、設定モーダルと `hso.toml` の `[ui.theme].log` から選べる

## フェーズ C への備え

折り返しが ANSI をまたぐ処理を強いられないよう、**切り詰めは素テキストのうちに済ませてから色を付ける**構造にした。色付き文字列へ再度 `fitLine` を通す経路は作らない（`renderFittedPanel`）。

## 確認

- `go build ./...` / `go build -tags en ./...`
- `go test ./...` / `go test -tags en ./...`
- `gofmt -l .` 出力なし

フェーズ C（折り返し・スクロール）は対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)