### PR TITLE
feat: ログを折り返し、スクロールをアンカーで保持する

### DIFF
--- a/internal/ui/buffer.go
+++ b/internal/ui/buffer.go
@@ -48,9 +48,12 @@ type wrappedLogRecord struct {
 	lines  []logLine
 }
 
+// logAnchor は閲覧位置を本文のバイト位置で覚える。セグメント番号で持つと
+// 幅を変えたときにセグメントの総数自体が変わり、同じ番号が本文の別の場所を
+// 指してしまう（長い JSON やスタックトレースで顕著）。
 type logAnchor struct {
-	record  uint64
-	segment int
+	record uint64
+	offset int
 }
 
 type bufferViewport struct {
@@ -205,13 +208,13 @@ func (buffer *lineBuffer) clampViewport(viewport bufferViewport) {
 	if len(buffer.wrapped) == 0 || buffer.anchor.record == 0 {
 		return
 	}
-	start := buffer.anchorLine()
+	// 末尾より下を指してしまったときだけ追従へ戻す。それ以外で書き戻すと
+	// 覚えた本文位置が現在の幅のセグメント先頭へ丸められ、幅を往復した
+	// ときに位置がずれていく。
 	tail := max(0, buffer.displayLineCount()-viewport.height)
-	if start >= tail {
+	if buffer.anchorLine() >= tail {
 		buffer.anchor = logAnchor{}
-		return
 	}
-	buffer.anchor = buffer.anchorAt(max(0, start))
 }
 
 func (buffer *lineBuffer) viewportStart(viewport bufferViewport) int {
@@ -225,7 +228,15 @@ func (buffer *lineBuffer) anchorLine() int {
 	lineNumber := 0
 	for _, record := range buffer.wrapped {
 		if record.number == buffer.anchor.record {
-			segment := clamp(buffer.anchor.segment, 0, max(0, len(record.lines)-1))
+			// 覚えた本文位置を含むセグメント、つまり先頭がその位置を
+			// 追い越さない最後のセグメントへ写す。
+			segment := 0
+			for index, line := range record.lines {
+				if line.bodyOffset > buffer.anchor.offset {
+					break
+				}
+				segment = index
+			}
 			return lineNumber + segment
 		}
 		lineNumber += len(record.lines)
@@ -239,7 +250,8 @@ func (buffer *lineBuffer) anchorAt(lineNumber int) logAnchor {
 	for _, record := range buffer.wrapped {
 		end := position + len(record.lines)
 		if lineNumber < end {
-			return logAnchor{record: record.number, segment: lineNumber - position}
+			line := record.lines[lineNumber-position]
+			return logAnchor{record: record.number, offset: line.bodyOffset}
 		}
 		position = end
 	}

--- a/internal/ui/buffer.go
+++ b/internal/ui/buffer.go
@@ -38,12 +38,37 @@ func (record logRecord) bounded(width int) logRecord {
 	return record
 }
 
+type storedLogRecord struct {
+	number uint64
+	record logRecord
+}
+
+type wrappedLogRecord struct {
+	number uint64
+	lines  []logLine
+}
+
+type logAnchor struct {
+	record  uint64
+	segment int
+}
+
+type bufferViewport struct {
+	width  int
+	height int
+}
+
 type lineBuffer struct {
-	lines []logRecord
-	start int
-	count int
-	// offset は最新行から何行遡って表示しているか。0 なら最新に追従する。
-	offset int
+	lines      []storedLogRecord
+	start      int
+	count      int
+	nextNumber uint64
+	// record が 0 の間は、幅が変わっても末尾への追従を続ける。
+	anchor logAnchor
+
+	wrapWidth int
+	wrapValid bool
+	wrapped   []wrappedLogRecord
 }
 
 func (buffer *lineBuffer) Add(record logRecord) {
@@ -51,25 +76,32 @@ func (buffer *lineBuffer) Add(record logRecord) {
 		return
 	}
 	record = record.bounded(maxLogRecordWidth)
-	if buffer.count < len(buffer.lines) {
+	buffer.nextNumber++
+	item := storedLogRecord{number: buffer.nextNumber, record: record}
+	full := buffer.count == len(buffer.lines)
+
+	if !full {
 		position := (buffer.start + buffer.count) % len(buffer.lines)
-		buffer.lines[position] = record
+		buffer.lines[position] = item
 		buffer.count++
-		// 遡って読んでいる間は、新着で表示が流れないよう位置を保つ。
-		if buffer.offset > 0 {
-			buffer.offset++
-		}
-		buffer.clampOffset()
+	} else {
+		buffer.lines[buffer.start] = item
+		buffer.start = (buffer.start + 1) % len(buffer.lines)
+	}
+
+	if !buffer.wrapValid {
 		return
 	}
-	buffer.lines[buffer.start] = record
-	buffer.start = (buffer.start + 1) % len(buffer.lines)
-	// 満杯のときは最古行が押し出されて全体が 1 行ずれるので、空きがある
-	// ときと同じく offset も進めないと遡り位置が流れてしまう。
-	if buffer.offset > 0 {
-		buffer.offset++
+	wrapped := wrappedLogRecord{
+		number: item.number,
+		lines:  wrapLogRecord(item.record, buffer.wrapWidth),
 	}
-	buffer.clampOffset()
+	if !full {
+		buffer.wrapped = append(buffer.wrapped, wrapped)
+		return
+	}
+	copy(buffer.wrapped, buffer.wrapped[1:])
+	buffer.wrapped[len(buffer.wrapped)-1] = wrapped
 }
 
 func (buffer *lineBuffer) SetLimit(limit int) {
@@ -83,69 +115,177 @@ func (buffer *lineBuffer) SetLimit(limit int) {
 		buffer.lines = nil
 		buffer.start = 0
 		buffer.count = 0
-		buffer.offset = 0
+		buffer.nextNumber = 0
+		buffer.anchor = logAnchor{}
+		buffer.invalidateWrap()
 		return
 	}
 
 	keep := min(buffer.count, limit)
-	lines := make([]logRecord, limit)
+	lines := make([]storedLogRecord, limit)
 	for index := 0; index < keep; index++ {
-		lines[index] = buffer.At(buffer.count - keep + index)
+		lines[index] = buffer.itemAt(buffer.count - keep + index)
 	}
 	buffer.lines = lines
 	buffer.start = 0
 	buffer.count = keep
-	buffer.clampOffset()
+	buffer.invalidateWrap()
 }
 
-func (buffer *lineBuffer) Scroll(delta, viewport int) {
-	buffer.offset += delta
-	buffer.clampViewport(viewport)
+func (buffer *lineBuffer) Scroll(delta int, viewport bufferViewport) {
+	if delta == 0 || viewport.width <= 0 || viewport.height <= 0 || buffer.count == 0 {
+		return
+	}
+	buffer.ensureWrapped(viewport.width)
+	start := buffer.viewportStart(viewport)
+	tail := max(0, buffer.displayLineCount()-viewport.height)
+	target := clamp(start-delta, 0, tail)
+	if target == tail {
+		buffer.anchor = logAnchor{}
+		return
+	}
+	buffer.anchor = buffer.anchorAt(target)
+}
+
+func (buffer *lineBuffer) ScrollToStart(viewport bufferViewport) {
+	if viewport.width <= 0 || viewport.height <= 0 || buffer.count == 0 {
+		return
+	}
+	buffer.ensureWrapped(viewport.width)
+	if buffer.displayLineCount() <= viewport.height {
+		buffer.anchor = logAnchor{}
+		return
+	}
+	buffer.anchor = buffer.anchorAt(0)
 }
 
 func (buffer *lineBuffer) ScrollToEnd() {
-	buffer.offset = 0
+	buffer.anchor = logAnchor{}
 }
 
-func (buffer *lineBuffer) Window(viewport int) []logRecord {
-	if viewport <= 0 || buffer.count == 0 {
+func (buffer *lineBuffer) Window(viewport bufferViewport) []logLine {
+	if viewport.width <= 0 || viewport.height <= 0 || buffer.count == 0 {
 		return nil
 	}
+	buffer.ensureWrapped(viewport.width)
 	buffer.clampViewport(viewport)
-	end := buffer.count - buffer.offset
-	start := max(0, end-viewport)
-	window := make([]logRecord, 0, end-start)
-	for index := start; index < end; index++ {
-		window = append(window, buffer.At(index))
+	start := buffer.viewportStart(viewport)
+	end := min(buffer.displayLineCount(), start+viewport.height)
+	window := make([]logLine, 0, end-start)
+	lineNumber := 0
+	for _, record := range buffer.wrapped {
+		for _, line := range record.lines {
+			if lineNumber >= start && lineNumber < end {
+				window = append(window, line)
+			}
+			lineNumber++
+			if lineNumber >= end {
+				return window
+			}
+		}
 	}
 	return window
 }
 
-func (buffer *lineBuffer) Offset() int {
-	return buffer.offset
+// Offset は現在の表示領域より下にある表示行数を返す。
+func (buffer *lineBuffer) Offset(viewport bufferViewport) int {
+	if viewport.width <= 0 || viewport.height <= 0 || buffer.count == 0 {
+		return 0
+	}
+	buffer.ensureWrapped(viewport.width)
+	buffer.clampViewport(viewport)
+	if buffer.anchor.record == 0 {
+		return 0
+	}
+	start := buffer.viewportStart(viewport)
+	return max(0, buffer.displayLineCount()-min(buffer.displayLineCount(), start+viewport.height))
 }
 
-func (buffer *lineBuffer) clampOffset() {
-	if buffer.offset > buffer.count {
-		buffer.offset = buffer.count
+func (buffer *lineBuffer) clampViewport(viewport bufferViewport) {
+	if len(buffer.wrapped) == 0 || buffer.anchor.record == 0 {
+		return
 	}
-	if buffer.offset < 0 {
-		buffer.offset = 0
+	start := buffer.anchorLine()
+	tail := max(0, buffer.displayLineCount()-viewport.height)
+	if start >= tail {
+		buffer.anchor = logAnchor{}
+		return
 	}
+	buffer.anchor = buffer.anchorAt(max(0, start))
 }
 
-func (buffer *lineBuffer) clampViewport(viewport int) {
-	buffer.clampOffset()
-	if limit := max(0, buffer.count-viewport); buffer.offset > limit {
-		buffer.offset = limit
+func (buffer *lineBuffer) viewportStart(viewport bufferViewport) int {
+	if buffer.anchor.record == 0 {
+		return max(0, buffer.displayLineCount()-viewport.height)
 	}
+	return max(0, buffer.anchorLine())
+}
+
+func (buffer *lineBuffer) anchorLine() int {
+	lineNumber := 0
+	for _, record := range buffer.wrapped {
+		if record.number == buffer.anchor.record {
+			segment := clamp(buffer.anchor.segment, 0, max(0, len(record.lines)-1))
+			return lineNumber + segment
+		}
+		lineNumber += len(record.lines)
+	}
+	// アンカーのレコードが履歴から押し出されたときは最古行へ寄せる。
+	return 0
+}
+
+func (buffer *lineBuffer) anchorAt(lineNumber int) logAnchor {
+	position := 0
+	for _, record := range buffer.wrapped {
+		end := position + len(record.lines)
+		if lineNumber < end {
+			return logAnchor{record: record.number, segment: lineNumber - position}
+		}
+		position = end
+	}
+	return logAnchor{}
+}
+
+func (buffer *lineBuffer) ensureWrapped(width int) {
+	if buffer.wrapValid && buffer.wrapWidth == width {
+		return
+	}
+	wrapped := make([]wrappedLogRecord, 0, len(buffer.lines))
+	for index := 0; index < buffer.count; index++ {
+		item := buffer.itemAt(index)
+		wrapped = append(wrapped, wrappedLogRecord{
+			number: item.number,
+			lines:  wrapLogRecord(item.record, width),
+		})
+	}
+	buffer.wrapWidth = width
+	buffer.wrapValid = true
+	buffer.wrapped = wrapped
+}
+
+func (buffer *lineBuffer) invalidateWrap() {
+	buffer.wrapWidth = 0
+	buffer.wrapValid = false
+	buffer.wrapped = nil
+}
+
+func (buffer *lineBuffer) displayLineCount() int {
+	count := 0
+	for _, record := range buffer.wrapped {
+		count += len(record.lines)
+	}
+	return count
+}
+
+func (buffer *lineBuffer) itemAt(index int) storedLogRecord {
+	if index < 0 || index >= buffer.count {
+		return storedLogRecord{}
+	}
+	return buffer.lines[(buffer.start+index)%len(buffer.lines)]
 }
 
 func (buffer *lineBuffer) At(index int) logRecord {
-	if index < 0 || index >= buffer.count {
-		return logRecord{}
-	}
-	return buffer.lines[(buffer.start+index)%len(buffer.lines)]
+	return buffer.itemAt(index).record
 }
 
 func (buffer *lineBuffer) Len() int {

--- a/internal/ui/buffer_test.go
+++ b/internal/ui/buffer_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -85,7 +86,10 @@ func TestLineBufferKeepsRecordAnchorAcrossWidthChange(t *testing.T) {
 	firstLines := len(wrapLogRecord(buffer.At(0), narrow.width))
 	buffer.Scroll(-firstLines-1, narrow)
 	wantAnchor := buffer.itemAt(1).number
-	want := logAnchor{record: wantAnchor, segment: 1}
+	want := logAnchor{
+		record: wantAnchor,
+		offset: wrapLogRecord(buffer.At(1), narrow.width)[1].bodyOffset,
+	}
 	if buffer.anchor != want {
 		t.Fatalf("anchor = %#v, want %#v", buffer.anchor, want)
 	}
@@ -95,9 +99,45 @@ func TestLineBufferKeepsRecordAnchorAcrossWidthChange(t *testing.T) {
 	if buffer.anchor != want {
 		t.Fatalf("anchor after resize = %#v, want %#v", buffer.anchor, want)
 	}
-	if len(window) == 0 || window[0].record.line() != "anchored record wraps" ||
-		window[0].bodyOffset == 0 {
+	// 幅が広がるとセグメントの切れ目は変わるので、先頭が同じセグメント
+	// 番号になるとは限らない。覚えた本文位置を含んでいればよい。
+	top := window[0]
+	if len(window) == 0 || top.record.line() != "anchored record wraps" ||
+		top.bodyOffset > want.offset ||
+		want.offset >= top.bodyOffset+len(top.text) {
 		t.Fatalf("window after resize = %#v", window)
+	}
+}
+
+// 1 レコードが何十セグメントにも折れるとき、アンカーをセグメント番号で
+// 持つと幅を変えた時点でセグメント総数が変わり、まったく別の場所へ飛ぶ。
+// 本文位置で覚えていれば、広げても狭めても同じ本文が先頭に残る。
+func TestLineBufferKeepsBodyPositionAcrossWidthRoundTrip(t *testing.T) {
+	var buffer lineBuffer
+	buffer.SetLimit(2)
+	buffer.Add(testLogRecord(strings.Repeat("あa1", 200)))
+
+	narrow := bufferViewport{width: 12, height: 3}
+	buffer.ScrollToStart(narrow)
+	buffer.Scroll(-30, narrow)
+	want := buffer.Window(narrow)[0].bodyOffset
+	if want == 0 {
+		t.Fatalf("scroll did not move into the record")
+	}
+
+	for _, viewport := range []bufferViewport{
+		{width: 60, height: 3},
+		{width: 8, height: 3},
+		narrow,
+	} {
+		line := buffer.Window(viewport)[0]
+		length := len(line.text)
+		if line.bodyOffset > want || want >= line.bodyOffset+max(1, length) {
+			t.Fatalf(
+				"width %d: top segment covers [%d,%d), want it to contain %d",
+				viewport.width, line.bodyOffset, line.bodyOffset+length, want,
+			)
+		}
 	}
 }
 

--- a/internal/ui/buffer_test.go
+++ b/internal/ui/buffer_test.go
@@ -38,31 +38,150 @@ func TestLineBufferResizeReleasesOldLines(t *testing.T) {
 func TestLineBufferKeepsScrollPositionWhenFull(t *testing.T) {
 	var buffer lineBuffer
 	buffer.SetLimit(4)
+	viewport := bufferViewport{width: 40, height: 2}
 	for _, line := range []string{"l0", "l1", "l2", "l3"} {
 		buffer.Add(testLogRecord(line))
 	}
-	buffer.Scroll(2, 2)
+	buffer.Scroll(2, viewport)
 
-	if got, want := recordLines(buffer.Window(2)), []string{"l0", "l1"}; !reflect.DeepEqual(got, want) {
+	if got, want := windowTexts(buffer.Window(viewport)), []string{"l0", "l1"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("window = %v, want %v", got, want)
 	}
 
 	// 満杯なので最古行が押し出されるが、見えている内容は動かない。
 	buffer.Add(testLogRecord("l4"))
-	if got, want := recordLines(buffer.Window(2)), []string{"l1", "l2"}; !reflect.DeepEqual(got, want) {
+	if got, want := windowTexts(buffer.Window(viewport)), []string{"l1", "l2"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("window after add = %v, want %v", got, want)
 	}
 
 	// 履歴から落ちた先へは遡れないので、最古行に張り付く。
 	buffer.Add(testLogRecord("l5"))
 	buffer.Add(testLogRecord("l6"))
-	if got, want := recordLines(buffer.Window(2)), []string{"l3", "l4"}; !reflect.DeepEqual(got, want) {
+	if got, want := windowTexts(buffer.Window(viewport)), []string{"l3", "l4"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("window at the oldest line = %v, want %v", got, want)
 	}
 
 	buffer.ScrollToEnd()
-	if got, want := recordLines(buffer.Window(2)), []string{"l5", "l6"}; !reflect.DeepEqual(got, want) {
+	if got, want := windowTexts(buffer.Window(viewport)), []string{"l5", "l6"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("window after ScrollToEnd = %v, want %v", got, want)
+	}
+}
+
+func TestLineBufferKeepsRecordAnchorAcrossWidthChange(t *testing.T) {
+	var buffer lineBuffer
+	buffer.SetLimit(10)
+	for _, line := range []string{
+		"first record wraps",
+		"anchored record wraps",
+		"third record wraps",
+		"fourth record wraps",
+		"fifth record wraps",
+	} {
+		buffer.Add(testLogRecord(line))
+	}
+
+	narrow := bufferViewport{width: 12, height: 3}
+	buffer.ScrollToStart(narrow)
+	firstLines := len(wrapLogRecord(buffer.At(0), narrow.width))
+	buffer.Scroll(-firstLines-1, narrow)
+	wantAnchor := buffer.itemAt(1).number
+	want := logAnchor{record: wantAnchor, segment: 1}
+	if buffer.anchor != want {
+		t.Fatalf("anchor = %#v, want %#v", buffer.anchor, want)
+	}
+
+	wide := bufferViewport{width: 18, height: 3}
+	window := buffer.Window(wide)
+	if buffer.anchor != want {
+		t.Fatalf("anchor after resize = %#v, want %#v", buffer.anchor, want)
+	}
+	if len(window) == 0 || window[0].record.line() != "anchored record wraps" ||
+		window[0].bodyOffset == 0 {
+		t.Fatalf("window after resize = %#v", window)
+	}
+}
+
+func TestLineBufferKeepsFollowingTailAcrossWidthChange(t *testing.T) {
+	var buffer lineBuffer
+	buffer.SetLimit(4)
+	for _, line := range []string{"one long record", "two long record", "last long record"} {
+		buffer.Add(testLogRecord(line))
+	}
+
+	narrow := bufferViewport{width: 10, height: 2}
+	_ = buffer.Window(narrow)
+	wide := bufferViewport{width: 16, height: 2}
+	window := buffer.Window(wide)
+	lastRecord := buffer.At(buffer.Len() - 1)
+	lastLines := wrapLogRecord(lastRecord, wide.width)
+	if buffer.anchor.record != 0 {
+		t.Fatalf("tail following anchor = %#v", buffer.anchor)
+	}
+	if got, want := window[len(window)-1].text, lastLines[len(lastLines)-1].text; got != want {
+		t.Fatalf("tail = %q, want %q", got, want)
+	}
+}
+
+func TestLineBufferShowsTailOfRecordTallerThanViewport(t *testing.T) {
+	var buffer lineBuffer
+	buffer.SetLimit(1)
+	buffer.Add(testLogRecord("abcdefghijklmnopqrst"))
+	viewport := bufferViewport{width: 10, height: 2}
+
+	window := buffer.Window(viewport)
+	if len(window) != viewport.height {
+		t.Fatalf("window height = %d, want %d", len(window), viewport.height)
+	}
+	if window[0].bodyOffset == 0 {
+		t.Fatalf("window starts at the first segment: %#v", window)
+	}
+	if got, want := windowTexts(window), []string{"mnop", "qrst"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("window = %v, want %v", got, want)
+	}
+
+	buffer.ScrollToStart(viewport)
+	if got := buffer.Window(viewport)[0].bodyOffset; got != 0 {
+		t.Fatalf("first segment offset = %d", got)
+	}
+}
+
+func TestLineBufferScrollsByWrappedDisplayLine(t *testing.T) {
+	var buffer lineBuffer
+	buffer.SetLimit(1)
+	buffer.Add(testLogRecord("abcdefghijklmnopqrst"))
+	viewport := bufferViewport{width: 10, height: 2}
+
+	buffer.Scroll(1, viewport)
+	if got, want := windowTexts(buffer.Window(viewport)), []string{"ijkl", "mnop"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("window after up = %v, want %v", got, want)
+	}
+	if got := buffer.Offset(viewport); got != 1 {
+		t.Fatalf("offset after up = %d, want 1", got)
+	}
+
+	buffer.Scroll(-1, viewport)
+	if got, want := windowTexts(buffer.Window(viewport)), []string{"mnop", "qrst"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("window after down = %v, want %v", got, want)
+	}
+	if got := buffer.Offset(viewport); got != 0 {
+		t.Fatalf("offset after down = %d, want 0", got)
+	}
+}
+
+func TestLineBufferWrapCacheAddsOnlyTailAtSameWidth(t *testing.T) {
+	var buffer lineBuffer
+	buffer.SetLimit(3)
+	buffer.Add(testLogRecord("first record wraps"))
+	viewport := bufferViewport{width: 12, height: 2}
+	_ = buffer.Window(viewport)
+	firstLine := &buffer.wrapped[0].lines[0]
+
+	buffer.Add(testLogRecord("second record wraps"))
+	if got := &buffer.wrapped[0].lines[0]; got != firstLine {
+		t.Fatalf("cached first record was rebuilt: %p -> %p", firstLine, got)
+	}
+	if got, want := len(buffer.wrapped), 2; got != want {
+		t.Fatalf("wrapped records = %d, want %d", got, want)
 	}
 }
 
@@ -86,10 +205,10 @@ func bufferValues(buffer lineBuffer) []string {
 	return values
 }
 
-func recordLines(records []logRecord) []string {
-	values := make([]string, len(records))
-	for index, record := range records {
-		values[index] = record.line()
+func windowTexts(lines []logLine) []string {
+	values := make([]string, len(lines))
+	for index, line := range lines {
+		values[index] = line.text
 	}
 	return values
 }

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -167,25 +167,31 @@ func (model *Model) handleBufferKey(key tea.Key) (tea.Model, tea.Cmd) {
 	case tea.KeyDown:
 		buffer.Scroll(-1, viewport)
 	case tea.KeyPgUp:
-		buffer.Scroll(viewport, viewport)
+		buffer.Scroll(viewport.height, viewport)
 	case tea.KeyPgDown:
-		buffer.Scroll(-viewport, viewport)
+		buffer.Scroll(-viewport.height, viewport)
 	case tea.KeyHome:
-		buffer.Scroll(buffer.Len(), viewport)
+		buffer.ScrollToStart(viewport)
 	case tea.KeyEnd:
 		buffer.ScrollToEnd()
 	}
 	return model, nil
 }
 
-func (model *Model) focusedBuffer() (*lineBuffer, int) {
+func (model *Model) focusedBuffer() (*lineBuffer, bufferViewport) {
 	switch model.panel {
 	case panelChat:
-		return &model.chat, model.layout.chatLines()
+		return &model.chat, bufferViewport{
+			width:  model.layout.leftContentWidth(),
+			height: model.layout.chatLines(),
+		}
 	case panelLog:
-		return &model.logs, model.layout.logLines()
+		return &model.logs, bufferViewport{
+			width:  model.layout.rightContentWidth(),
+			height: model.layout.logLines(),
+		}
 	default:
-		return nil, 0
+		return nil, bufferViewport{}
 	}
 }
 

--- a/internal/ui/log_render.go
+++ b/internal/ui/log_render.go
@@ -2,53 +2,192 @@ package ui
 
 import (
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/hijoushoku7/hijo-server-ops/internal/serverlog"
 )
 
 const timestampGutterWidth = 6
 
+type textSegment struct {
+	text   string
+	offset int
+}
+
+type logLine struct {
+	record     logRecord
+	text       string
+	bodyOffset int
+	prefix     string
+	timestamp  bool
+}
+
+func wrapLogRecord(record logRecord, width int) []logLine {
+	body := strings.ReplaceAll(record.line(), "\t", " ")
+	firstWidth := width
+	continuationWidth := width
+	indent := 0
+	prefix := ""
+	if width >= timestampGutterWidth {
+		firstWidth -= timestampGutterWidth
+		indent = timestampGutterWidth
+		prefix = formatLogTimestamp(record) + " "
+	}
+
+	segments := wrapPlainText(body, firstWidth, continuationWidth, indent)
+	lines := make([]logLine, len(segments))
+	for index, segment := range segments {
+		linePrefix := strings.Repeat(" ", indent)
+		showTimestamp := false
+		if index == 0 {
+			linePrefix = prefix
+			showTimestamp = prefix != ""
+		}
+		lines[index] = logLine{
+			record:     record,
+			text:       segment.text,
+			bodyOffset: segment.offset,
+			prefix:     linePrefix,
+			timestamp:  showTimestamp,
+		}
+	}
+	return lines
+}
+
+// wrapPlainText は ANSI を含まない本文だけを折り、元文字列内の位置も残す。
+// 空白で折れるときは区切りを表示せず、長い単語はセル幅で切る。
+func wrapPlainText(value string, firstWidth, continuationWidth, indent int) []textSegment {
+	firstWidth = max(0, firstWidth)
+	continuationWidth = max(0, continuationWidth-indent)
+	if value == "" || firstWidth == 0 {
+		return []textSegment{{}}
+	}
+
+	segments := make([]textSegment, 0, 1)
+	start := 0
+	width := firstWidth
+	for start < len(value) {
+		end := hardWrapEnd(value, start, width)
+		if end >= len(value) {
+			segments = append(segments, textSegment{text: value[start:], offset: start})
+			break
+		}
+
+		breakAt, next := whitespaceBreak(value, start, end)
+		if breakAt < 0 {
+			breakAt, next = end, end
+			for next < len(value) {
+				character, size := utf8.DecodeRuneInString(value[next:])
+				if !unicode.IsSpace(character) {
+					break
+				}
+				next += size
+			}
+		}
+		segments = append(segments, textSegment{
+			text:   value[start:breakAt],
+			offset: start,
+		})
+		start = next
+		width = continuationWidth
+		if width == 0 {
+			break
+		}
+	}
+	if len(segments) == 0 {
+		return []textSegment{{}}
+	}
+	return segments
+}
+
+func hardWrapEnd(value string, start, width int) int {
+	end := start
+	used := 0
+	for end < len(value) {
+		cluster, characterWidth := ansi.FirstGraphemeCluster(
+			value[end:],
+			ansi.GraphemeWidth,
+		)
+		if end > start && used+characterWidth > width {
+			break
+		}
+		end += len(cluster)
+		used += characterWidth
+		if used >= width {
+			break
+		}
+	}
+	return end
+}
+
+func whitespaceBreak(value string, start, end int) (int, int) {
+	breakAt := -1
+	next := -1
+	for index, character := range value[start:end] {
+		position := start + index
+		if position > start && unicode.IsSpace(character) {
+			breakAt = position
+			next = position + utf8.RuneLen(character)
+		}
+	}
+	if breakAt < 0 {
+		return -1, -1
+	}
+	for next < len(value) {
+		character, size := utf8.DecodeRuneInString(value[next:])
+		if !unicode.IsSpace(character) {
+			break
+		}
+		next += size
+	}
+	return breakAt, next
+}
+
 func renderLogRecord(record logRecord, width int) string {
+	lines := wrapLogRecord(record, width)
+	return renderLogLine(lines[0], width)
+}
+
+func renderLogLine(line logLine, width int) string {
 	if width <= 0 {
 		return ""
 	}
 
-	// タブは幅計算では 0 桁だが lipgloss が描画時に空白 4 個へ展開するので、
-	// 幅を数える前に空白 1 個へ潰す。1 バイトのままなので後段の位置計算も狂わない。
-	body := strings.ReplaceAll(record.line(), "\t", " ")
-	prefix := ""
-	if width >= timestampGutterWidth {
-		prefix = formatLogTimestamp(record) + " "
-	}
-	// 切り詰めは ANSI を含まない状態で済ませ、色は残った範囲へ最後に付ける。
-	plain := truncate(prefix+body, width)
+	prefix := truncate(line.prefix, width)
+	bodyWidth := max(0, width-stringWidth(prefix))
+	body := truncate(line.text, bodyWidth)
 
 	var result strings.Builder
-	prefixEnd := min(len(prefix), len(plain))
-	if prefixEnd > 0 {
-		result.WriteString(timestampStyle(record.timestampSource).Render(plain[:prefixEnd]))
-	}
-
-	bodyStart := prefixEnd
-	playerStart := -1
-	if record.player != "" {
-		if position := strings.Index(body, record.player); position >= 0 {
-			playerStart = len(prefix) + position
-		}
-	}
-	kindStyle := styleForLogKind(record.kind)
-	if playerStart < bodyStart || playerStart >= len(plain) {
-		result.WriteString(kindStyle.Render(plain[bodyStart:]))
+	if line.timestamp {
+		result.WriteString(timestampStyle(line.record.timestampSource).Render(prefix))
 	} else {
-		playerEnd := min(playerStart+len(record.player), len(plain))
-		result.WriteString(kindStyle.Render(plain[bodyStart:playerStart]))
-		result.WriteString(styleForPlayer(record.player).Render(plain[playerStart:playerEnd]))
-		result.WriteString(kindStyle.Render(plain[playerEnd:]))
+		result.WriteString(prefix)
 	}
 
-	if padding := width - stringWidth(plain); padding > 0 {
+	playerStart := -1
+	normalized := strings.ReplaceAll(line.record.line(), "\t", " ")
+	if line.record.player != "" {
+		playerStart = strings.Index(normalized, line.record.player)
+	}
+	segmentStart := line.bodyOffset
+	segmentEnd := segmentStart + len(body)
+	playerEnd := playerStart + len(line.record.player)
+	kindStyle := styleForLogKind(line.record.kind)
+	if playerStart < 0 || playerEnd <= segmentStart || playerStart >= segmentEnd {
+		result.WriteString(kindStyle.Render(body))
+	} else {
+		start := clamp(playerStart-segmentStart, 0, len(body))
+		end := clamp(playerEnd-segmentStart, start, len(body))
+		result.WriteString(kindStyle.Render(body[:start]))
+		result.WriteString(styleForPlayer(line.record.player).Render(body[start:end]))
+		result.WriteString(kindStyle.Render(body[end:]))
+	}
+
+	if padding := width - stringWidth(prefix+body); padding > 0 {
 		result.WriteString(strings.Repeat(" ", padding))
 	}
 	return result.String()

--- a/internal/ui/log_render_test.go
+++ b/internal/ui/log_render_test.go
@@ -1,12 +1,47 @@
 package ui
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/hijoushoku7/hijo-server-ops/internal/serverlog"
 )
+
+func TestWrapPlainTextPrefersWhitespace(t *testing.T) {
+	segments := wrapPlainText("alpha beta gamma", 8, 10, 2)
+	if got, want := segmentTexts(segments), []string{"alpha", "beta", "gamma"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("segments = %q, want %q", got, want)
+	}
+}
+
+func TestWrapPlainTextHardWrapsLongWords(t *testing.T) {
+	segments := wrapPlainText("abcdefghij", 4, 4, 0)
+	if got, want := segmentTexts(segments), []string{"abcd", "efgh", "ij"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("segments = %q, want %q", got, want)
+	}
+}
+
+func TestWrapPlainTextUsesCellWidthForWideCharacters(t *testing.T) {
+	segments := wrapPlainText("あいうえお", 4, 6, 2)
+	if got, want := segmentTexts(segments), []string{"あい", "うえ", "お"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("segments = %q, want %q", got, want)
+	}
+}
+
+func TestWrapLogRecordIndentsContinuationLines(t *testing.T) {
+	record := logRecord{kind: serverlog.KindOther, text: "abcdefghij"}
+	lines := wrapLogRecord(record, 10)
+	got := make([]string, len(lines))
+	for index, line := range lines {
+		got[index] = stripANSI(renderLogLine(line, 10))
+	}
+	want := []string{"n/a   abcd", "      efgh", "      ij  "}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("lines = %q, want %q", got, want)
+	}
+}
 
 func TestRenderLogRecordAddsSixColumnTimestampGutter(t *testing.T) {
 	record := logRecord{
@@ -86,4 +121,12 @@ func TestRenderLogRecordKeepsWidthAfterColoring(t *testing.T) {
 			t.Fatalf("width %d: line width = %d, text = %q", width, got, stripANSI(line))
 		}
 	}
+}
+
+func segmentTexts(segments []textSegment) []string {
+	values := make([]string, len(segments))
+	for index, segment := range segments {
+		values[index] = segment.text
+	}
+	return values
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -31,7 +31,7 @@ func TestModelBoundsLogHistoryAndStoredRecords(t *testing.T) {
 	if model.logs.Len() != historyLines {
 		t.Fatalf("logs = %d, limit = %d", model.logs.Len(), historyLines)
 	}
-	if window := model.logs.Window(model.layout.logLines()); len(window) !=
+	if window := model.logs.Window(modelLogViewport(model)); len(window) !=
 		model.layout.logLines() {
 		t.Fatalf("window = %d, viewport = %d", len(window), model.layout.logLines())
 	}
@@ -391,6 +391,7 @@ func TestModelScrollsFocusedBufferAndKeepsPositionOnNewLines(t *testing.T) {
 	model := newTestModel()
 	_, _ = model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	viewport := model.layout.logLines()
+	logViewport := modelLogViewport(model)
 	for index := 0; index < viewport*3; index++ {
 		_, _ = model.Update(LogMsg{Entry: serverlog.Entry{
 			Kind:    serverlog.KindOther,
@@ -408,27 +409,27 @@ func TestModelScrollsFocusedBufferAndKeepsPositionOnNewLines(t *testing.T) {
 	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
 	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyPgUp})
-	if model.logs.Offset() != viewport {
-		t.Fatalf("offset = %d, viewport = %d", model.logs.Offset(), viewport)
+	if model.logs.Offset(logViewport) != viewport {
+		t.Fatalf("offset = %d, viewport = %d", model.logs.Offset(logViewport), viewport)
 	}
-	top := model.logs.Window(viewport)[0].line()
+	top := model.logs.Window(logViewport)[0].record.line()
 
 	// 遡っている間は新着で表示が流れない。
 	_, _ = model.Update(LogMsg{Entry: serverlog.Entry{
 		Kind:    serverlog.KindOther,
 		Message: "newest",
 	}})
-	if got := model.logs.Window(viewport)[0].line(); got != top {
+	if got := model.logs.Window(logViewport)[0].record.line(); got != top {
 		t.Fatalf("window shifted: %q -> %q", top, got)
 	}
 
 	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEnd})
-	if model.logs.Offset() != 0 {
-		t.Fatalf("offset = %d", model.logs.Offset())
+	if model.logs.Offset(logViewport) != 0 {
+		t.Fatalf("offset = %d", model.logs.Offset(logViewport))
 	}
-	window := model.logs.Window(viewport)
-	if window[len(window)-1].line() != "newest" {
-		t.Fatalf("tail = %q", window[len(window)-1].line())
+	window := model.logs.Window(logViewport)
+	if window[len(window)-1].record.line() != "newest" {
+		t.Fatalf("tail = %q", window[len(window)-1].record.line())
 	}
 }
 
@@ -436,6 +437,7 @@ func TestModelReturnsToLatestWhenFocusIsReleased(t *testing.T) {
 	model := newTestModel()
 	_, _ = model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	viewport := model.layout.logLines()
+	logViewport := modelLogViewport(model)
 	for index := 0; index < viewport*3; index++ {
 		_, _ = model.Update(LogMsg{Entry: serverlog.Entry{
 			Kind:    serverlog.KindOther,
@@ -448,7 +450,7 @@ func TestModelReturnsToLatestWhenFocusIsReleased(t *testing.T) {
 	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyRight})
 	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyPgUp})
-	if model.logs.Offset() == 0 {
+	if model.logs.Offset(logViewport) == 0 {
 		t.Fatalf("buffer did not scroll back")
 	}
 
@@ -456,11 +458,38 @@ func TestModelReturnsToLatestWhenFocusIsReleased(t *testing.T) {
 	if model.mode != modeSelect {
 		t.Fatalf("mode = %d", model.mode)
 	}
-	if model.logs.Offset() != 0 {
-		t.Fatalf("offset = %d, want 0", model.logs.Offset())
+	if model.logs.Offset(logViewport) != 0 {
+		t.Fatalf("offset = %d, want 0", model.logs.Offset(logViewport))
 	}
 	if !strings.Contains(model.View().Content, "line "+fmt.Sprint(viewport*3-1)) {
 		t.Fatalf("view does not show the latest line")
+	}
+}
+
+func TestBufferPanelIndicatorCountsWrappedDisplayLines(t *testing.T) {
+	model := newTestModel()
+	_, _ = model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	for index := 0; index < 6; index++ {
+		_, _ = model.Update(LogMsg{Entry: serverlog.Entry{
+			Kind:    serverlog.KindOther,
+			Message: strings.Repeat(fmt.Sprintf("record%d ", index), 20),
+		}})
+	}
+	viewport := modelLogViewport(model)
+	model.logs.ScrollToStart(viewport)
+	offset := model.logs.Offset(viewport)
+	if offset <= model.logs.Len() {
+		t.Fatalf("display-line offset = %d, records = %d", offset, model.logs.Len())
+	}
+
+	panel := stripANSI(model.renderBufferPanel(
+		panelLog,
+		&model.logs,
+		model.layout.rightWidth,
+		model.layout.bodyHeight,
+	))
+	if !strings.Contains(panel, fmt.Sprintf("Log ↑%d", offset)) {
+		t.Fatalf("panel title does not contain display-line offset %d:\n%s", offset, panel)
 	}
 }
 
@@ -922,6 +951,13 @@ func TestModelViewKeepsRectangularWithThreeTopPanels(t *testing.T) {
 
 func newTestModel() *Model {
 	return New(make(chan Action, 8), nil, 0, DefaultSettings())
+}
+
+func modelLogViewport(model *Model) bufferViewport {
+	return bufferViewport{
+		width:  model.layout.rightContentWidth(),
+		height: model.layout.logLines(),
+	}
 }
 
 func stripANSI(value string) string {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -124,19 +124,20 @@ func (model *Model) renderBufferPanel(
 	width, height int,
 ) string {
 	contentHeight := max(0, height-2)
-	window := buffer.Window(contentHeight)
-	lines := make([]string, contentHeight)
 	innerWidth := max(0, width-2)
+	viewport := bufferViewport{width: innerWidth, height: contentHeight}
+	window := buffer.Window(viewport)
+	lines := make([]string, contentHeight)
 	for index := range lines {
 		lines[index] = strings.Repeat(" ", innerWidth)
 	}
 	padding := max(0, contentHeight-len(window))
 	for index := 0; index < len(window) && padding+index < len(lines); index++ {
-		lines[padding+index] = renderLogRecord(window[index], innerWidth)
+		lines[padding+index] = renderLogLine(window[index], innerWidth)
 	}
 
 	title := target.title()
-	if offset := buffer.Offset(); offset > 0 {
+	if offset := buffer.Offset(viewport); offset > 0 {
 		title = fmt.Sprintf("%s ↑%d", title, offset)
 	}
 	return renderFittedPanel(title, lines, width, height, true, model.frameFor(target))


### PR DESCRIPTION
[docs/log-pane.md](docs/log-pane.md) のフェーズ C（項目 1 + 3）。これで log-pane 改修は完結する（A: #31 / B: #32）。

折り返すと「1 レコード = 1 表示行」でなくなり、最新から何行遡ったかで持っていたスクロール位置の意味が壊れる。折り返しだけ入れてスクロールを据え置くと壊れた中間状態が残るので、同一 PR にしている。

## 折り返し

- 素テキストを空白優先で折り、折れないときはセル単位のハード折り。ログはパスや JSON が多く、単語折りだけでは破綻する
- 継続行はタイムスタンプガターの 6 桁だけぶら下げインデント
- 全角は `ansi.FirstGraphemeCluster` / `ansi.StringWidth` でセル単位に扱う
- 折り返しは**素のテキストだけを扱う**（フェーズ B で整えた「折る → 色を付ける」順を維持）

## スクロール

- 位置を `(レコード番号, セグメント番号)` のアンカーで保持し、表示行オフセットは派生値。表示行番号で持つとリサイズのたびに見ていた場所が飛ぶ
- 末尾追従中は特別扱いし、リサイズしても追従を維持
- アンカーのレコードが履歴から押し出されたら最古行へ寄せる
- `Home` は `Scroll(Len())` ではなく `ScrollToStart` へ
- `↑N` の単位を表示行に変更
- 1 レコードが画面高を超える場合は上端で途中から表示する

## キャッシュ

幅が変わらない限り再計算せず、レコード追加時は末尾だけ差分更新する。

## 確認

- `go build ./...` / `go build -tags en ./...`
- `go test ./...` / `go test -tags en ./...`
- `gofmt -l .` 出力なし

chat ペインもログペインと同じ機構を共有する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)