### PR TITLE
feat: サーバー終了時に TUI を残し、終了モーダルとログ閲覧を出す

### DIFF
--- a/cmd/hso/app_test.go
+++ b/cmd/hso/app_test.go
@@ -368,3 +368,42 @@ func waitForFileLines(t *testing.T, path string, count int) {
 	}
 	t.Fatalf("%s did not contain %d lines", path, count)
 }
+
+func TestPumpLogsDrainsRemainingOutputBeforeDone(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	actions := make(chan ui.Action, 1)
+	model := ui.New(actions, nil, initialGeneration, ui.DefaultSettings())
+	program := tea.NewProgram(
+		model,
+		tea.WithContext(ctx),
+		tea.WithInput(nil),
+		tea.WithoutRenderer(),
+	)
+	programDone := make(chan struct{})
+	go func() {
+		_, _ = program.Run()
+		close(programDone)
+	}()
+
+	// クラッシュ直前のスタックトレースを模して、キューを埋めてから閉じる。
+	logs := make(chan serverlog.Entry, logQueueSize)
+	for index := 0; index < logQueueSize; index++ {
+		logs <- serverlog.Entry{Kind: serverlog.KindOther, Message: "crash tail"}
+	}
+	close(logs)
+
+	done := make(chan struct{})
+	go pumpLogs(ctx, program, logs, initialGeneration, done)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pumpLogs did not finish")
+	}
+	if remaining := len(logs); remaining != 0 {
+		t.Fatalf("dropped %d entries", remaining)
+	}
+
+	program.Quit()
+	<-programDone
+}

--- a/cmd/hso/app_test.go
+++ b/cmd/hso/app_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -165,6 +166,19 @@ func TestServerExitErrorRejectsUnexpectedCleanExit(t *testing.T) {
 	}
 }
 
+func TestProcessExitCode(t *testing.T) {
+	if code := processExitCode(nil); code != 0 {
+		t.Fatalf("clean exit code = %d", code)
+	}
+	err := exec.Command("sh", "-c", "exit 7").Run()
+	if code := processExitCode(err); code != 7 {
+		t.Fatalf("failed exit code = %d, err = %v", code, err)
+	}
+	if code := processExitCode(errors.New("wait failed")); code != -1 {
+		t.Fatalf("unknown exit code = %d", code)
+	}
+}
+
 func TestCalculateCPU(t *testing.T) {
 	previous := procstats.Duration{Value: time.Second, Available: true}
 	current := procstats.Duration{Value: 2500 * time.Millisecond, Available: true}
@@ -230,6 +244,16 @@ func TestServerControllerSendsCommandsAndRestarts(t *testing.T) {
 		t.Fatalf("generation = %d", runtime.generation)
 	}
 
+	// 自然停止後は runtime が detach 済みでも、最後の世代の次から起動する。
+	controller.sendCommand(ui.Action{Kind: ui.ActionSendCommand, Command: "stop"})
+	waitForControllerStopped(t, controller)
+	controller.restart()
+	waitForFileLines(t, filepath.Join(dir, "launches"), 3)
+	waitForControllerJava(t, controller)
+	if runtime := controller.currentRuntime(); runtime.generation != 3 {
+		t.Fatalf("generation after stopped restart = %d", runtime.generation)
+	}
+
 	cancel()
 	if err := controller.shutdown(); err != nil {
 		t.Fatal(err)
@@ -244,8 +268,8 @@ func TestServerControllerSendsCommandsAndRestarts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := strings.Fields(string(data)); len(got) != 4 ||
-		strings.Join(got, " ") != "say hello stop stop" {
+	if got := strings.Fields(string(data)); len(got) != 5 ||
+		strings.Join(got, " ") != "say hello stop stop stop" {
 		t.Fatalf("commands = %q", data)
 	}
 }
@@ -318,6 +342,18 @@ func waitForControllerJava(t *testing.T, controller *serverController) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("java process was not found")
+}
+
+func waitForControllerStopped(t *testing.T, controller *serverController) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if controller.currentRuntime() == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("server runtime was not detached")
 }
 
 func waitForFileLines(t *testing.T, path string, count int) {

--- a/cmd/hso/controller.go
+++ b/cmd/hso/controller.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -48,6 +50,7 @@ func (pipe outputPipe) close() {
 type serverRuntime struct {
 	server       *process.Process
 	generation   uint64
+	startedAt    time.Time
 	javaFound    atomic.Bool
 	expectedExit atomic.Bool
 	cancel       context.CancelFunc
@@ -69,6 +72,8 @@ type serverController struct {
 	operation sync.Mutex
 	currentMu sync.Mutex
 	current   *serverRuntime
+	// runtime を手放した後も、次の起動世代を決められるよう保持する。
+	lastGeneration uint64
 }
 
 func newServerController(
@@ -101,16 +106,21 @@ func (controller *serverController) start(generation uint64, announce bool) erro
 	runtime := &serverRuntime{
 		server:     server,
 		generation: generation,
+		startedAt:  time.Now(),
 		cancel:     runtimeCancel,
 		stdout:     stdout,
 		stderr:     stderr,
 	}
 	controller.currentMu.Lock()
 	controller.current = runtime
+	controller.lastGeneration = generation
 	controller.currentMu.Unlock()
 
 	if announce {
-		controller.program.Send(ui.ServerStartedMsg{Generation: generation})
+		controller.program.Send(ui.ServerStartedMsg{
+			Generation: generation,
+			StartedAt:  runtime.startedAt,
+		})
 	}
 
 	logs := make(chan serverlog.Entry, logQueueSize)
@@ -171,7 +181,10 @@ func (controller *serverController) restart() {
 
 	runtime := controller.currentRuntime()
 	if runtime == nil {
-		controller.sendRestartResult(msg.ErrServerStopped)
+		controller.program.Send(ui.ServerRestartingMsg{})
+		if err := controller.start(controller.latestGeneration()+1, true); err != nil {
+			controller.program.Send(ui.FatalMsg{Err: msg.RestartFailed(err)})
+		}
 		return
 	}
 	if !runtime.javaFound.Load() {
@@ -230,12 +243,26 @@ func (controller *serverController) waitForServer(runtime *serverRuntime) {
 	}
 	controller.program.Send(ui.ProcessExitedMsg{
 		Generation: runtime.generation,
+		ExitCode:   processExitCode(waitErr),
+		StartedAt:  runtime.startedAt,
+		ExitedAt:   time.Now(),
 		Err: serverExitError(
 			waitErr,
 			runtime.javaFound.Load(),
 			runtime.expectedExit.Load(),
 		),
 	})
+}
+
+func processExitCode(waitErr error) int {
+	if waitErr == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(waitErr, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
 }
 
 func serverExitError(waitErr error, javaFound, expected bool) error {
@@ -252,6 +279,12 @@ func (controller *serverController) currentRuntime() *serverRuntime {
 	controller.currentMu.Lock()
 	defer controller.currentMu.Unlock()
 	return controller.current
+}
+
+func (controller *serverController) latestGeneration() uint64 {
+	controller.currentMu.Lock()
+	defer controller.currentMu.Unlock()
+	return controller.lastGeneration
 }
 
 func (controller *serverController) detachCurrent() *serverRuntime {

--- a/cmd/hso/controller.go
+++ b/cmd/hso/controller.go
@@ -56,6 +56,9 @@ type serverRuntime struct {
 	cancel       context.CancelFunc
 	stdout       outputPipe
 	stderr       outputPipe
+	// logsDone は pumpLogs が止まったことを知らせる。終了を UI へ告げる
+	// 前に、残っているログを送り切るために待つ。
+	logsDone chan struct{}
 }
 
 func (runtime *serverRuntime) close() {
@@ -110,6 +113,7 @@ func (controller *serverController) start(generation uint64, announce bool) erro
 		cancel:     runtimeCancel,
 		stdout:     stdout,
 		stderr:     stderr,
+		logsDone:   make(chan struct{}),
 	}
 	controller.currentMu.Lock()
 	controller.current = runtime
@@ -123,10 +127,26 @@ func (controller *serverController) start(generation uint64, announce bool) erro
 		})
 	}
 
+	// 出力の読み取りが両方とも EOF に達したら logs を閉じ、pumpLogs が
+	// 残りを送り切ってから logsDone を閉じる。クラッシュ時はスタック
+	// トレースが最後に固まって出るので、ここを待たずに終了を告げると
+	// いちばん読みたい行が捨てられる。
 	logs := make(chan serverlog.Entry, logQueueSize)
-	go pumpLogs(runtimeCtx, controller.program, logs, generation)
-	go readAndCloseServerOutput(stdout.reader, logs)
-	go readAndCloseServerOutput(stderr.reader, logs)
+	var readers sync.WaitGroup
+	readers.Add(2)
+	go pumpLogs(runtimeCtx, controller.program, logs, generation, runtime.logsDone)
+	go func() {
+		defer readers.Done()
+		readAndCloseServerOutput(stdout.reader, logs)
+	}()
+	go func() {
+		defer readers.Done()
+		readAndCloseServerOutput(stderr.reader, logs)
+	}()
+	go func() {
+		readers.Wait()
+		close(logs)
+	}()
 	go controller.waitForServer(runtime)
 	go findJava(runtimeCtx, server, &runtime.javaFound, controller.program, generation)
 	go streamGC(runtimeCtx, server.GCLogPath(), controller.program, generation)
@@ -237,6 +257,9 @@ func (controller *serverController) waitForServer(runtime *serverRuntime) {
 	waitErr := runtime.server.Wait()
 	_ = runtime.stdout.writer.Close()
 	_ = runtime.stderr.writer.Close()
+	// 最後の出力を送り切ってから止める。順番を逆にすると、クラッシュの
+	// 原因が書かれた末尾がそのまま消える。
+	<-runtime.logsDone
 	runtime.cancel()
 	if !controller.detach(runtime) {
 		return

--- a/cmd/hso/controller.go
+++ b/cmd/hso/controller.go
@@ -262,6 +262,9 @@ func (controller *serverController) shutdown() error {
 
 func (controller *serverController) waitForServer(runtime *serverRuntime) {
 	waitErr := runtime.server.Wait()
+	// 停止時刻はここで確定させる。ログを流し切ってから取ると、その排出に
+	// かかった時間まで稼働時間に足される。
+	exitedAt := time.Now()
 	// 監視はここで止める。ログを流し切るまでの間も /proc を引き続けると、
 	// 死んだ PID の結果でモーダルに出す最終 RSS / heap が n/a に化ける。
 	runtime.monitorCancel()
@@ -278,7 +281,7 @@ func (controller *serverController) waitForServer(runtime *serverRuntime) {
 		Generation: runtime.generation,
 		ExitCode:   processExitCode(waitErr),
 		StartedAt:  runtime.startedAt,
-		ExitedAt:   time.Now(),
+		ExitedAt:   exitedAt,
 		Err: serverExitError(
 			waitErr,
 			runtime.javaFound.Load(),

--- a/cmd/hso/controller.go
+++ b/cmd/hso/controller.go
@@ -54,8 +54,11 @@ type serverRuntime struct {
 	javaFound    atomic.Bool
 	expectedExit atomic.Bool
 	cancel       context.CancelFunc
-	stdout       outputPipe
-	stderr       outputPipe
+	// monitorCancel はメトリクス・GC・アドレス解決だけを止める。ログの
+	// 排出は cancel まで生かし、終了直前の行を落とさない。
+	monitorCancel context.CancelFunc
+	stdout        outputPipe
+	stderr        outputPipe
 	// logsDone は pumpLogs が止まったことを知らせる。終了を UI へ告げる
 	// 前に、残っているログを送り切るために待つ。
 	logsDone chan struct{}
@@ -106,14 +109,18 @@ func (controller *serverController) start(generation uint64, announce bool) erro
 	}
 
 	runtimeCtx, runtimeCancel := context.WithCancel(controller.ctx)
+	// 監視はログより先に止める。プロセスが消えた後も /proc を引き続けると、
+	// 最終 RSS / heap を「取れない」で上書きしてしまう。
+	monitorCtx, monitorCancel := context.WithCancel(runtimeCtx)
 	runtime := &serverRuntime{
-		server:     server,
-		generation: generation,
-		startedAt:  time.Now(),
-		cancel:     runtimeCancel,
-		stdout:     stdout,
-		stderr:     stderr,
-		logsDone:   make(chan struct{}),
+		server:        server,
+		generation:    generation,
+		startedAt:     time.Now(),
+		cancel:        runtimeCancel,
+		monitorCancel: monitorCancel,
+		stdout:        stdout,
+		stderr:        stderr,
+		logsDone:      make(chan struct{}),
 	}
 	controller.currentMu.Lock()
 	controller.current = runtime
@@ -148,10 +155,10 @@ func (controller *serverController) start(generation uint64, announce bool) erro
 		close(logs)
 	}()
 	go controller.waitForServer(runtime)
-	go findJava(runtimeCtx, server, &runtime.javaFound, controller.program, generation)
-	go streamGC(runtimeCtx, server.GCLogPath(), controller.program, generation)
+	go findJava(monitorCtx, server, &runtime.javaFound, controller.program, generation)
+	go streamGC(monitorCtx, server.GCLogPath(), controller.program, generation)
 	go resolveServerAddress(
-		runtimeCtx,
+		monitorCtx,
 		controller.cfg.Server.WorkDir,
 		controller.program,
 		generation,
@@ -255,6 +262,9 @@ func (controller *serverController) shutdown() error {
 
 func (controller *serverController) waitForServer(runtime *serverRuntime) {
 	waitErr := runtime.server.Wait()
+	// 監視はここで止める。ログを流し切るまでの間も /proc を引き続けると、
+	// 死んだ PID の結果でモーダルに出す最終 RSS / heap が n/a に化ける。
+	runtime.monitorCancel()
 	_ = runtime.stdout.writer.Close()
 	_ = runtime.stderr.writer.Close()
 	// 最後の出力を送り切ってから止める。順番を逆にすると、クラッシュの

--- a/cmd/hso/monitor.go
+++ b/cmd/hso/monitor.go
@@ -80,6 +80,12 @@ func collectMetrics(
 		)
 		previousCPU = cpuTime
 		previousSample = sampledAt
+		// 採取の途中でプロセスが消えていることがある。止められた後の
+		// 結果を送ると、終了モーダルに出す最終 RSS / heap を n/a で
+		// 上書きしてしまう。
+		if ctx.Err() != nil {
+			return
+		}
 		program.Send(ui.MetricsMsg{
 			Generation:   generation,
 			JVM:          metrics,

--- a/cmd/hso/monitor.go
+++ b/cmd/hso/monitor.go
@@ -200,12 +200,18 @@ func pumpLogs(
 	program *tea.Program,
 	logs <-chan serverlog.Entry,
 	generation uint64,
+	done chan<- struct{},
 ) {
+	defer close(done)
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case entry := <-logs:
+		case entry, ok := <-logs:
+			// logs が閉じるのは出力を読み切ったとき。残りを送ってから抜ける。
+			if !ok {
+				return
+			}
 			program.Send(ui.LogMsg{Generation: generation, Entry: entry})
 		}
 	}

--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -60,6 +60,45 @@ func ActionFailed(err error) string {
 	return "operation failed: " + err.Error()
 }
 
+// Server exit modal and stopped log screen.
+const (
+	ExitTitleCrashed  = "Server crashed"
+	ExitTitleStopped  = "Server stopped"
+	ExitErrorLines    = "Error lines"
+	ExitStateCrashed  = "The server crashed. Read the log or restart it."
+	ExitStateStopped  = "The server stopped normally."
+	ExitButtonLogs    = "Read logs"
+	ExitButtonRestart = "Restart"
+	ExitButtonQuit    = "Quit"
+)
+
+func StoppedLogTitle(code string) string {
+	return "Log · stopped (exit " + code + ")"
+}
+
+func ExitSummary(code, exitedAt, uptime string) string {
+	return fmt.Sprintf("exit %s · stopped %s · uptime %s", code, exitedAt, uptime)
+}
+
+func ExitMemory(rss, heapUsed, heapCommitted, delta string) string {
+	return fmt.Sprintf(
+		"final memory  RSS %s · heap %s/%s · Δ %s",
+		rss, heapUsed, heapCommitted, delta,
+	)
+}
+
+func ExitGC(collections uint64, last string) string {
+	return fmt.Sprintf("GC  %d collections · last pause %s", collections, last)
+}
+
+func ExitStateRestarting(dots string) string {
+	return "restarting" + dots
+}
+
+func ExitAutoQuit(seconds int) string {
+	return fmt.Sprintf("hso exits in %d seconds (press a key to stay)", seconds)
+}
+
 // Key bar (the hint line at the bottom of the screen).
 const (
 	BarItem         = "item"
@@ -80,6 +119,11 @@ const (
 	BarScroll       = "scroll"
 	BarPage         = "page"
 	BarLatest       = "latest"
+	BarExitButton   = "button"
+	BarConfirm      = "confirm"
+	BarReadLogs     = "logs"
+	BarEnds         = "first/last"
+	BarRestart      = "restart"
 )
 
 // Setup wizard screens.

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -58,6 +58,45 @@ func ActionFailed(err error) string {
 	return "操作失敗: " + err.Error()
 }
 
+// サーバー終了後のモーダルとログ画面。
+const (
+	ExitTitleCrashed  = "サーバー異常終了"
+	ExitTitleStopped  = "サーバー停止"
+	ExitErrorLines    = "エラー行"
+	ExitStateCrashed  = "異常終了しました。ログを確認するか再起動してください。"
+	ExitStateStopped  = "サーバーは正常に停止しました。"
+	ExitButtonLogs    = "ログを読む"
+	ExitButtonRestart = "再起動"
+	ExitButtonQuit    = "終了"
+)
+
+func StoppedLogTitle(code string) string {
+	return "Log · 停止済み (exit " + code + ")"
+}
+
+func ExitSummary(code, exitedAt, uptime string) string {
+	return fmt.Sprintf("終了コード %s · 停止 %s · 稼働 %s", code, exitedAt, uptime)
+}
+
+func ExitMemory(rss, heapUsed, heapCommitted, delta string) string {
+	return fmt.Sprintf(
+		"最終メモリ  RSS %s · heap %s/%s · Δ %s",
+		rss, heapUsed, heapCommitted, delta,
+	)
+}
+
+func ExitGC(collections uint64, last string) string {
+	return fmt.Sprintf("GC  %d 回 · 最終停止 %s", collections, last)
+}
+
+func ExitStateRestarting(dots string) string {
+	return "再起動中" + dots
+}
+
+func ExitAutoQuit(seconds int) string {
+	return fmt.Sprintf("%d 秒後に hso を終了します（キー入力で解除）", seconds)
+}
+
 // キーバー（画面下部のキー説明）。日本語は全角なので、最小端末幅 72 桁に
 // 収まるよう短くしている。
 const (
@@ -79,6 +118,11 @@ const (
 	BarScroll       = "スクロール"
 	BarPage         = "ページ"
 	BarLatest       = "最新"
+	BarExitButton   = "ボタン"
+	BarConfirm      = "決定"
+	BarReadLogs     = "ログ"
+	BarEnds         = "先頭/末尾"
+	BarRestart      = "再起動"
 )
 
 // セットアップウィザードの画面。

--- a/internal/ui/exit.go
+++ b/internal/ui/exit.go
@@ -1,0 +1,274 @@
+package ui
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/hijoushoku7/hijo-server-ops/internal/gclog"
+	"github.com/hijoushoku7/hijo-server-ops/internal/hsperfdata"
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
+	"github.com/hijoushoku7/hijo-server-ops/internal/procstats"
+)
+
+const (
+	exitModalWidth     = 64
+	exitModalHeight    = 17
+	normalExitWait     = 3 * time.Second
+	unknownExitCode    = -1
+	exitErrorLineLimit = 3
+)
+
+type exitSnapshot struct {
+	heap hsperfdata.Memory
+	rss  procstats.Number
+	gc   gclog.Stats
+}
+
+type exitState struct {
+	crashed    bool
+	err        error
+	exitCode   int
+	exitedAt   time.Time
+	uptime     time.Duration
+	errorLines []string
+	snapshot   exitSnapshot
+	button     int
+	closed     bool
+	// notice は再起動を試みて失敗したときの理由。モーダルには status 行が
+	// ないので、握り潰さずここへ出す。
+	notice string
+
+	autoQuit   bool
+	autoQuitAt time.Time
+}
+
+type restartTracker struct {
+	startedAt time.Time
+	attempts  []restartAttempt
+}
+
+// restartAttempt はフェーズ 2 の短命再起動判定で記録する 1 回分の枠だけを
+// 先に定義する。今回は記録ロジックを持たせない。
+type restartAttempt struct {
+	startedAt time.Time
+	exitedAt  time.Time
+}
+
+type exitCountdownMsg struct {
+	state *exitState
+}
+
+func (model *Model) setProcessExit(message ProcessExitedMsg) tea.Cmd {
+	model.busy = false
+	model.endRestart()
+	exitedAt := message.ExitedAt
+	if exitedAt.IsZero() {
+		exitedAt = time.Now()
+	}
+	startedAt := message.StartedAt
+	if startedAt.IsZero() {
+		startedAt = model.restart.startedAt
+	}
+	state := model.newExitState(message.Err != nil || message.ExitCode != 0,
+		message.Err, message.ExitCode,
+		startedAt, exitedAt)
+	model.exit = state
+	if state.crashed {
+		return nil
+	}
+	state.autoQuit = true
+	state.autoQuitAt = time.Now().Add(normalExitWait)
+	return model.exitCountdownCmd(state)
+}
+
+func (model *Model) setFatalExit(err error) {
+	model.busy = false
+	model.endRestart()
+	exitedAt := time.Now()
+	model.exit = model.newExitState(
+		true,
+		err,
+		unknownExitCode,
+		model.restart.startedAt,
+		exitedAt,
+	)
+}
+
+func (model *Model) newExitState(
+	crashed bool,
+	err error,
+	exitCode int,
+	startedAt time.Time,
+	exitedAt time.Time,
+) *exitState {
+	uptime := time.Duration(0)
+	if !startedAt.IsZero() && !exitedAt.Before(startedAt) {
+		uptime = exitedAt.Sub(startedAt)
+	}
+	return &exitState{
+		crashed:    crashed,
+		err:        err,
+		exitCode:   exitCode,
+		exitedAt:   exitedAt,
+		uptime:     uptime,
+		errorLines: model.exitErrorLines(err),
+		snapshot: exitSnapshot{
+			heap: model.metrics.Heap,
+			rss:  model.memory.RSS,
+			gc:   model.gcStats,
+		},
+	}
+}
+
+func (model *Model) exitErrorLines(err error) []string {
+	lines := make([]string, 0, exitErrorLineLimit+1)
+	if err != nil {
+		lines = append(lines, err.Error())
+	}
+
+	matches := make([]string, 0, exitErrorLineLimit)
+	for index := model.logs.Len() - 1; index >= 0 && len(matches) < exitErrorLineLimit; index-- {
+		line := model.logs.At(index).line()
+		if strings.Contains(line, "ERROR") || strings.Contains(line, "FATAL") ||
+			strings.Contains(line, "Exception") || strings.Contains(line, "Caused by") {
+			matches = append(matches, line)
+		}
+	}
+	if len(matches) == 0 {
+		for index := model.logs.Len() - 1; index >= 0 && len(matches) < exitErrorLineLimit; index-- {
+			matches = append(matches, model.logs.At(index).line())
+		}
+	}
+	for index := len(matches) - 1; index >= 0; index-- {
+		lines = append(lines, matches[index])
+	}
+	return lines
+}
+
+func (model *Model) exitCountdownCmd(state *exitState) tea.Cmd {
+	return tea.Tick(time.Second, func(time.Time) tea.Msg {
+		return exitCountdownMsg{state: state}
+	})
+}
+
+func (model *Model) handleExitCountdown(message exitCountdownMsg) (tea.Model, tea.Cmd) {
+	if model.exit != message.state || !message.state.autoQuit {
+		return model, nil
+	}
+	if !time.Now().Before(message.state.autoQuitAt) {
+		return model, tea.Quit
+	}
+	return model, model.exitCountdownCmd(message.state)
+}
+
+func (model *Model) exitCountdownSeconds() int {
+	if model.exit == nil || !model.exit.autoQuit {
+		return 0
+	}
+	remaining := time.Until(model.exit.autoQuitAt)
+	if remaining <= 0 {
+		return 0
+	}
+	return int((remaining + time.Second - 1) / time.Second)
+}
+
+func (model *Model) closeExitModal() {
+	model.exit.autoQuit = false
+	model.exit.closed = true
+	model.mode = modeFocus
+	model.panel = panelLog
+}
+
+func (model *Model) exitModal() (string, int, int) {
+	state := model.exit
+	width := min(exitModalWidth, max(2, model.layout.width-4))
+	height := min(exitModalHeight, max(2, model.layout.height-3))
+	title := msg.ExitTitleStopped
+	boxFrame := focusedFrame
+	boxFrame.style = exitStoppedStyle
+	if state.crashed {
+		title = msg.ExitTitleCrashed
+		boxFrame.style = exitCrashStyle
+	}
+
+	exitCode := formatExitCode(state.exitCode)
+	lines := []string{
+		msg.ExitSummary(
+			exitCode,
+			state.exitedAt.Format("2006-01-02 15:04:05"),
+			formatExitUptime(state.uptime),
+		),
+		msg.ExitMemory(
+			formatProcBytes(state.snapshot.rss),
+			formatJVMBytes(state.snapshot.heap.Used),
+			formatJVMBytes(state.snapshot.heap.Committed),
+			formatDelta(state.snapshot.rss, state.snapshot.heap.Committed),
+		),
+		msg.ExitGC(
+			state.snapshot.gc.Collections,
+			formatPause(
+				state.snapshot.gc.LastPause.Value,
+				state.snapshot.gc.LastPause.Available,
+			),
+		),
+		"",
+	}
+	if len(state.errorLines) > 0 {
+		lines = append(lines, msg.ExitErrorLines)
+		for _, line := range state.errorLines {
+			lines = append(lines, "  "+line)
+		}
+		lines = append(lines, "")
+	}
+	switch {
+	case model.restarting:
+		lines = append(lines, msg.ExitStateRestarting(model.restartDots()))
+	case state.notice != "":
+		lines = append(lines, state.notice)
+	case state.crashed:
+		lines = append(lines, msg.ExitStateCrashed)
+	default:
+		lines = append(lines, msg.ExitStateStopped)
+		if seconds := model.exitCountdownSeconds(); seconds > 0 {
+			lines = append(lines, msg.ExitAutoQuit(seconds))
+		}
+	}
+	lines = append(lines, "", model.exitButtons(width-2))
+
+	box := renderPanel(title, lines, width, height, false, boxFrame)
+	x := max(0, (model.layout.width-width)/2)
+	y := max(0, (model.layout.height-1-height)/2)
+	return box, x, y
+}
+
+func (model *Model) exitButtons(width int) string {
+	buttons := []string{
+		"[ " + msg.ExitButtonLogs + " ]",
+		"[ " + msg.ExitButtonRestart + " ]",
+		"[ " + msg.ExitButtonQuit + " ]",
+	}
+	for index := range buttons {
+		if index == model.exit.button {
+			buttons[index] = selectedStyle.Render(buttons[index])
+		} else {
+			buttons[index] = dimStyle.Render(buttons[index])
+		}
+	}
+	line := strings.Join(buttons, "  ")
+	padding := max(0, (width-stringWidth(line))/2)
+	return strings.Repeat(" ", padding) + line
+}
+
+func formatExitCode(code int) string {
+	if code < 0 {
+		return "n/a"
+	}
+	return strconv.Itoa(code)
+}
+
+func formatExitUptime(duration time.Duration) string {
+	return formatUptime(hsperfdata.Duration{Value: duration, Available: true})
+}

--- a/internal/ui/exit.go
+++ b/internal/ui/exit.go
@@ -76,9 +76,16 @@ func (model *Model) setProcessExit(message ProcessExitedMsg) tea.Cmd {
 	if startedAt.IsZero() {
 		startedAt = model.restart.startedAt
 	}
-	state := model.newExitState(message.Err != nil || message.ExitCode != 0,
-		message.Err, message.ExitCode,
-		startedAt, exitedAt)
+	err := message.Err
+	crashed := err != nil || message.ExitCode != 0
+	// 先に出ていた原因を残す。java を見つけられず hso が SIGTERM を送った
+	// ような場合、後から届く「exit status 143」に置き換えると本当の理由が
+	// モーダルから消える。
+	if previous := model.exit; previous != nil && previous.err != nil {
+		err = previous.err
+		crashed = true
+	}
+	state := model.newExitState(crashed, err, message.ExitCode, startedAt, exitedAt)
 	model.exit = state
 	if state.crashed {
 		return nil

--- a/internal/ui/exit.go
+++ b/internal/ui/exit.go
@@ -28,21 +28,18 @@ type exitSnapshot struct {
 }
 
 type exitState struct {
-	crashed     bool
-	err         error
-	exitCode    int
-	exitedAt    time.Time
-	uptime      time.Duration
-	uptimeKnown bool
-	errorLines  []string
-	snapshot    exitSnapshot
-	button      int
-	closed      bool
+	crashed    bool
+	exitCode   int
+	exitedAt   time.Time
+	uptime     hsperfdata.Duration
+	errorLines []string
+	snapshot   exitSnapshot
+	button     int
+	closed     bool
 	// notice は再起動を試みて失敗したときの理由。モーダルには status 行が
 	// ないので、握り潰さずここへ出す。
 	notice string
 
-	autoQuit   bool
 	autoQuitAt time.Time
 }
 
@@ -81,8 +78,8 @@ func (model *Model) setProcessExit(message ProcessExitedMsg) tea.Cmd {
 	// 先に出ていた原因を残す。java を見つけられず hso が SIGTERM を送った
 	// ような場合、後から届く「exit status 143」に置き換えると本当の理由が
 	// モーダルから消える。
-	if previous := model.exit; previous != nil && previous.err != nil {
-		err = previous.err
+	if model.runErr != nil {
+		err = model.runErr
 		crashed = true
 	}
 	state := model.newExitState(crashed, err, message.ExitCode, startedAt, exitedAt)
@@ -90,7 +87,6 @@ func (model *Model) setProcessExit(message ProcessExitedMsg) tea.Cmd {
 	if state.crashed {
 		return nil
 	}
-	state.autoQuit = true
 	state.autoQuitAt = time.Now().Add(normalExitWait)
 	return model.exitCountdownCmd(state)
 }
@@ -113,19 +109,19 @@ func (model *Model) newExitState(
 	startedAt time.Time,
 	exitedAt time.Time,
 ) *exitState {
-	uptime := time.Duration(0)
-	known := !startedAt.IsZero() && !exitedAt.Before(startedAt)
-	if known {
-		uptime = exitedAt.Sub(startedAt)
+	uptime := hsperfdata.Duration{}
+	if !startedAt.IsZero() && !exitedAt.Before(startedAt) {
+		uptime = hsperfdata.Duration{
+			Value:     exitedAt.Sub(startedAt),
+			Available: true,
+		}
 	}
 	return &exitState{
-		crashed:     crashed,
-		err:         err,
-		exitCode:    exitCode,
-		exitedAt:    exitedAt,
-		uptime:      uptime,
-		uptimeKnown: known,
-		errorLines:  model.exitErrorLines(err, crashed),
+		crashed:    crashed,
+		exitCode:   exitCode,
+		exitedAt:   exitedAt,
+		uptime:     uptime,
+		errorLines: model.exitErrorLines(err, crashed),
 		snapshot: exitSnapshot{
 			heap: model.lastHeap,
 			rss:  model.lastRSS,
@@ -166,7 +162,7 @@ func (model *Model) exitErrorLines(err error, crashed bool) []string {
 // generationLogStart は現世代の最初のログが今どの位置にいるかを返す。
 // バッファは再起動で消さないので、位置は古い行が押し出されるたびにずれる。
 func (model *Model) generationLogStart() int {
-	discarded := model.logsAdded - uint64(model.logs.Len())
+	discarded := model.logs.nextNumber - uint64(model.logs.Len())
 	if model.restart.logMark <= discarded {
 		return 0
 	}
@@ -180,7 +176,7 @@ func (model *Model) exitCountdownCmd(state *exitState) tea.Cmd {
 }
 
 func (model *Model) handleExitCountdown(message exitCountdownMsg) (tea.Model, tea.Cmd) {
-	if model.exit != message.state || !message.state.autoQuit {
+	if model.exit != message.state || message.state.autoQuitAt.IsZero() {
 		return model, nil
 	}
 	if !time.Now().Before(message.state.autoQuitAt) {
@@ -190,7 +186,7 @@ func (model *Model) handleExitCountdown(message exitCountdownMsg) (tea.Model, te
 }
 
 func (model *Model) exitCountdownSeconds() int {
-	if model.exit == nil || !model.exit.autoQuit {
+	if model.exit == nil || model.exit.autoQuitAt.IsZero() {
 		return 0
 	}
 	remaining := time.Until(model.exit.autoQuitAt)
@@ -201,7 +197,7 @@ func (model *Model) exitCountdownSeconds() int {
 }
 
 func (model *Model) closeExitModal() {
-	model.exit.autoQuit = false
+	model.exit.autoQuitAt = time.Time{}
 	model.exit.closed = true
 	model.mode = modeFocus
 	model.panel = panelLog
@@ -224,7 +220,7 @@ func (model *Model) exitModal() (string, int, int) {
 		msg.ExitSummary(
 			exitCode,
 			state.exitedAt.Format("2006-01-02 15:04:05"),
-			formatExitUptime(state.uptime, state.uptimeKnown),
+			formatUptime(state.uptime),
 		),
 		msg.ExitMemory(
 			formatProcBytes(state.snapshot.rss),
@@ -249,7 +245,7 @@ func (model *Model) exitModal() (string, int, int) {
 		lines = append(lines, "")
 	}
 	switch {
-	case model.restarting:
+	case model.restartPhase != 0:
 		lines = append(lines, msg.ExitStateRestarting(model.restartDots()))
 	case state.notice != "":
 		lines = append(lines, state.notice)
@@ -292,8 +288,4 @@ func formatExitCode(code int) string {
 		return "n/a"
 	}
 	return strconv.Itoa(code)
-}
-
-func formatExitUptime(duration time.Duration, known bool) string {
-	return formatUptime(hsperfdata.Duration{Value: duration, Available: known})
 }

--- a/internal/ui/exit.go
+++ b/internal/ui/exit.go
@@ -28,15 +28,16 @@ type exitSnapshot struct {
 }
 
 type exitState struct {
-	crashed    bool
-	err        error
-	exitCode   int
-	exitedAt   time.Time
-	uptime     time.Duration
-	errorLines []string
-	snapshot   exitSnapshot
-	button     int
-	closed     bool
+	crashed     bool
+	err         error
+	exitCode    int
+	exitedAt    time.Time
+	uptime      time.Duration
+	uptimeKnown bool
+	errorLines  []string
+	snapshot    exitSnapshot
+	button      int
+	closed      bool
 	// notice は再起動を試みて失敗したときの理由。モーダルには status 行が
 	// ないので、握り潰さずここへ出す。
 	notice string
@@ -47,7 +48,10 @@ type exitState struct {
 
 type restartTracker struct {
 	startedAt time.Time
-	attempts  []restartAttempt
+	// logMark は現世代が始まった時点の累計ログ件数。エラー行の抜粋を
+	// この世代に限り、前回のクラッシュの残骸を原因として出さない。
+	logMark  uint64
+	attempts []restartAttempt
 }
 
 // restartAttempt はフェーズ 2 の短命再起動判定で記録する 1 回分の枠だけを
@@ -84,17 +88,15 @@ func (model *Model) setProcessExit(message ProcessExitedMsg) tea.Cmd {
 	return model.exitCountdownCmd(state)
 }
 
+// setFatalExit は hso 側の失敗（起動できなかった等）でモーダルを出す。
+// 前世代の稼働時間やメモリは引き継がない。停止後にログを読んでいた時間まで
+// uptime に足され、死んだサーバーの RSS が今の値として出てしまう。
 func (model *Model) setFatalExit(err error) {
 	model.busy = false
 	model.endRestart()
-	exitedAt := time.Now()
-	model.exit = model.newExitState(
-		true,
-		err,
-		unknownExitCode,
-		model.restart.startedAt,
-		exitedAt,
-	)
+	state := model.newExitState(true, err, unknownExitCode, time.Time{}, time.Now())
+	state.snapshot = exitSnapshot{}
+	model.exit = state
 }
 
 func (model *Model) newExitState(
@@ -105,16 +107,18 @@ func (model *Model) newExitState(
 	exitedAt time.Time,
 ) *exitState {
 	uptime := time.Duration(0)
-	if !startedAt.IsZero() && !exitedAt.Before(startedAt) {
+	known := !startedAt.IsZero() && !exitedAt.Before(startedAt)
+	if known {
 		uptime = exitedAt.Sub(startedAt)
 	}
 	return &exitState{
-		crashed:    crashed,
-		err:        err,
-		exitCode:   exitCode,
-		exitedAt:   exitedAt,
-		uptime:     uptime,
-		errorLines: model.exitErrorLines(err),
+		crashed:     crashed,
+		err:         err,
+		exitCode:    exitCode,
+		exitedAt:    exitedAt,
+		uptime:      uptime,
+		uptimeKnown: known,
+		errorLines:  model.exitErrorLines(err),
 		snapshot: exitSnapshot{
 			heap: model.metrics.Heap,
 			rss:  model.memory.RSS,
@@ -129,8 +133,9 @@ func (model *Model) exitErrorLines(err error) []string {
 		lines = append(lines, err.Error())
 	}
 
+	oldest := model.generationLogStart()
 	matches := make([]string, 0, exitErrorLineLimit)
-	for index := model.logs.Len() - 1; index >= 0 && len(matches) < exitErrorLineLimit; index-- {
+	for index := model.logs.Len() - 1; index >= oldest && len(matches) < exitErrorLineLimit; index-- {
 		line := model.logs.At(index).line()
 		if strings.Contains(line, "ERROR") || strings.Contains(line, "FATAL") ||
 			strings.Contains(line, "Exception") || strings.Contains(line, "Caused by") {
@@ -138,7 +143,7 @@ func (model *Model) exitErrorLines(err error) []string {
 		}
 	}
 	if len(matches) == 0 {
-		for index := model.logs.Len() - 1; index >= 0 && len(matches) < exitErrorLineLimit; index-- {
+		for index := model.logs.Len() - 1; index >= oldest && len(matches) < exitErrorLineLimit; index-- {
 			matches = append(matches, model.logs.At(index).line())
 		}
 	}
@@ -146,6 +151,16 @@ func (model *Model) exitErrorLines(err error) []string {
 		lines = append(lines, matches[index])
 	}
 	return lines
+}
+
+// generationLogStart は現世代の最初のログが今どの位置にいるかを返す。
+// バッファは再起動で消さないので、位置は古い行が押し出されるたびにずれる。
+func (model *Model) generationLogStart() int {
+	discarded := model.logsAdded - uint64(model.logs.Len())
+	if model.restart.logMark <= discarded {
+		return 0
+	}
+	return int(model.restart.logMark - discarded)
 }
 
 func (model *Model) exitCountdownCmd(state *exitState) tea.Cmd {
@@ -199,7 +214,7 @@ func (model *Model) exitModal() (string, int, int) {
 		msg.ExitSummary(
 			exitCode,
 			state.exitedAt.Format("2006-01-02 15:04:05"),
-			formatExitUptime(state.uptime),
+			formatExitUptime(state.uptime, state.uptimeKnown),
 		),
 		msg.ExitMemory(
 			formatProcBytes(state.snapshot.rss),
@@ -269,6 +284,6 @@ func formatExitCode(code int) string {
 	return strconv.Itoa(code)
 }
 
-func formatExitUptime(duration time.Duration) string {
-	return formatUptime(hsperfdata.Duration{Value: duration, Available: true})
+func formatExitUptime(duration time.Duration, known bool) string {
+	return formatUptime(hsperfdata.Duration{Value: duration, Available: known})
 }

--- a/internal/ui/exit.go
+++ b/internal/ui/exit.go
@@ -118,16 +118,19 @@ func (model *Model) newExitState(
 		exitedAt:    exitedAt,
 		uptime:      uptime,
 		uptimeKnown: known,
-		errorLines:  model.exitErrorLines(err),
+		errorLines:  model.exitErrorLines(err, crashed),
 		snapshot: exitSnapshot{
-			heap: model.metrics.Heap,
-			rss:  model.memory.RSS,
+			heap: model.lastHeap,
+			rss:  model.lastRSS,
 			gc:   model.gcStats,
 		},
 	}
 }
 
-func (model *Model) exitErrorLines(err error) []string {
+// exitErrorLines は原因として読ませる行を集める。異常終了で 1 本も
+// 拾えなかったときだけ末尾で埋める。正常停止でこれをやると、保存完了の
+// INFO 行が「エラー行」の見出しで並ぶ。
+func (model *Model) exitErrorLines(err error, crashed bool) []string {
 	lines := make([]string, 0, exitErrorLineLimit+1)
 	if err != nil {
 		lines = append(lines, err.Error())
@@ -142,7 +145,7 @@ func (model *Model) exitErrorLines(err error) []string {
 			matches = append(matches, line)
 		}
 	}
-	if len(matches) == 0 {
+	if len(matches) == 0 && crashed {
 		for index := model.logs.Len() - 1; index >= oldest && len(matches) < exitErrorLineLimit; index-- {
 			matches = append(matches, model.logs.At(index).line())
 		}

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -59,7 +60,7 @@ func (model *Model) handleExitKey(message tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 	}
 
 	// 正常終了の自動終了は、モーダルに対するどのキー操作でも解除する。
-	model.exit.autoQuit = false
+	model.exit.autoQuitAt = time.Time{}
 	switch key.Code {
 	case tea.KeyLeft:
 		model.exit.button = (model.exit.button + 2) % 3

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -14,6 +14,9 @@ func (model *Model) handleKey(message tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if message.String() == "ctrl+c" {
 		return model, tea.Quit
 	}
+	if model.exit != nil {
+		return model.handleExitKey(message)
+	}
 	if model.settingsOpen {
 		return model.handleSettingsKey(key)
 	}
@@ -33,6 +36,48 @@ func (model *Model) handleKey(message tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return model.handlePlayersKey(key)
 	}
 	return model.handleBufferKey(key)
+}
+
+func (model *Model) handleExitKey(message tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	key := message.Key()
+	if model.exit.closed {
+		switch message.String() {
+		case "r", "R":
+			return model, model.requestRestart()
+		case "q", "Q":
+			return model, tea.Quit
+		}
+		switch key.Code {
+		case tea.KeyEnter, tea.KeyKpEnter:
+			return model, tea.Quit
+		case tea.KeyUp, tea.KeyDown, tea.KeyPgUp, tea.KeyPgDown,
+			tea.KeyHome, tea.KeyEnd:
+			return model.handleBufferKey(key)
+		default:
+			return model, nil
+		}
+	}
+
+	// 正常終了の自動終了は、モーダルに対するどのキー操作でも解除する。
+	model.exit.autoQuit = false
+	switch key.Code {
+	case tea.KeyLeft:
+		model.exit.button = (model.exit.button + 2) % 3
+	case tea.KeyRight, tea.KeyTab:
+		model.exit.button = (model.exit.button + 1) % 3
+	case tea.KeyEscape:
+		model.closeExitModal()
+	case tea.KeyEnter, tea.KeyKpEnter:
+		switch model.exit.button {
+		case 0:
+			model.closeExitModal()
+		case 1:
+			return model, model.requestRestart()
+		case 2:
+			return model, tea.Quit
+		}
+	}
+	return model, nil
 }
 
 func (model *Model) editingConsole() bool {
@@ -139,7 +184,7 @@ func (model *Model) handleConsoleKey(key tea.Key) (tea.Model, tea.Cmd) {
 		case consoleStop:
 			return model, tea.Quit
 		case consoleRestart:
-			model.offer(Action{Kind: ActionRestart})
+			return model, model.requestRestart()
 		default:
 			model.sendInput()
 		}
@@ -179,6 +224,12 @@ func (model *Model) handleBufferKey(key tea.Key) (tea.Model, tea.Cmd) {
 }
 
 func (model *Model) focusedBuffer() (*lineBuffer, bufferViewport) {
+	if model.exit != nil {
+		return &model.logs, bufferViewport{
+			width:  max(0, model.layout.width-2),
+			height: max(0, model.layout.height-3),
+		}
+	}
 	switch model.panel {
 	case panelChat:
 		return &model.chat, bufferViewport{
@@ -214,6 +265,15 @@ func (model *Model) sendInput() {
 	if model.offer(Action{Kind: ActionSendCommand, Command: command}) {
 		model.input = model.input[:0]
 	}
+}
+
+// requestRestart は再起動を頼み、受け付けられたときだけ点のアニメーションを
+// 始める。詰まって落とされた要求で動かすと、動いていないものが動いて見える。
+func (model *Model) requestRestart() tea.Cmd {
+	if !model.offer(Action{Kind: ActionRestart}) {
+		return nil
+	}
+	return model.beginRestart()
 }
 
 func (model *Model) offer(action Action) bool {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -130,6 +130,9 @@ type Model struct {
 	// logsAdded は Log ペインへ足した累計。バッファから押し出された分を
 	// 差し引いて、世代の境目が今どの位置かを割り出す。
 	logsAdded uint64
+	// 終了モーダル用に、最後に取れたメモリの値を控える。
+	lastHeap hsperfdata.Memory
+	lastRSS  procstats.Number
 }
 
 // restartTickMsg は再起動待ちの点を進める。停止から起動まで数十秒かかるので、

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -91,8 +91,10 @@ type ActionResultMsg struct {
 }
 
 type Model struct {
-	layout            layout
-	status            string
+	layout layout
+	status string
+	// runErr は現世代で最初に起きた終了原因。後続の終了通知でも上書きせず、
+	// ServerStartedMsg で復旧したときだけ消す。
 	runErr            error
 	actions           chan<- Action
 	save              func(Settings) error
@@ -125,11 +127,8 @@ type Model struct {
 	settingCursor     int
 	exit              *exitState
 	restart           restartTracker
-	restarting        bool
-	restartPhase      int
-	// logsAdded は Log ペインへ足した累計。バッファから押し出された分を
-	// 差し引いて、世代の境目が今どの位置かを割り出す。
-	logsAdded uint64
+	// 0 は停止中、1..3 は表示する点の数。
+	restartPhase int
 	// 終了モーダル用に、最後に取れたメモリの値を控える。
 	lastHeap hsperfdata.Memory
 	lastRSS  procstats.Number
@@ -142,17 +141,16 @@ type restartTickMsg struct{}
 const restartTickInterval = 400 * time.Millisecond
 
 func (model *Model) beginRestart() tea.Cmd {
-	model.restartPhase = 0
 	// すでに動いていれば tick を二重に走らせない。
-	if model.restarting {
+	if model.restartPhase != 0 {
+		model.restartPhase = 1
 		return nil
 	}
-	model.restarting = true
+	model.restartPhase = 1
 	return restartTick()
 }
 
 func (model *Model) endRestart() {
-	model.restarting = false
 	model.restartPhase = 0
 }
 
@@ -165,7 +163,7 @@ func restartTick() tea.Cmd {
 // restartDots は "." → ".." → "..." を返す。幅は常に 3 桁で、隣の表示が
 // 点の数で揺れないようにする。
 func (model *Model) restartDots() string {
-	count := model.restartPhase%3 + 1
+	count := model.restartPhase
 	return strings.Repeat(".", count) + strings.Repeat(" ", 3-count)
 }
 
@@ -232,7 +230,7 @@ func (model *Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if model.restart.startedAt.IsZero() {
 			model.restart.startedAt = time.Now()
 		}
-		model.restart.logMark = model.logsAdded
+		model.restart.logMark = model.logs.nextNumber
 		// 新しい世代が立ち上がった時点で復旧とみなす。前世代のクラッシュを
 		// 抱えたままだと、その後に正常停止しても hso が失敗で終わる。
 		model.runErr = nil
@@ -279,10 +277,10 @@ func (model *Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	case exitCountdownMsg:
 		return model.handleExitCountdown(message)
 	case restartTickMsg:
-		if !model.restarting {
+		if model.restartPhase == 0 {
 			break
 		}
-		model.restartPhase++
+		model.restartPhase = model.restartPhase%3 + 1
 		return model, restartTick()
 	}
 	return model, nil

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -127,6 +127,9 @@ type Model struct {
 	restart           restartTracker
 	restarting        bool
 	restartPhase      int
+	// logsAdded は Log ペインへ足した累計。バッファから押し出された分を
+	// 差し引いて、世代の境目が今どの位置かを割り出す。
+	logsAdded uint64
 }
 
 // restartTickMsg は再起動待ちの点を進める。停止から起動まで数十秒かかるので、
@@ -226,6 +229,10 @@ func (model *Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if model.restart.startedAt.IsZero() {
 			model.restart.startedAt = time.Now()
 		}
+		model.restart.logMark = model.logsAdded
+		// 新しい世代が立ち上がった時点で復旧とみなす。前世代のクラッシュを
+		// 抱えたままだと、その後に正常停止しても hso が失敗で終わる。
+		model.runErr = nil
 		model.status = "starting"
 		model.busy = false
 		model.endRestart()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -58,6 +60,9 @@ type JavaFoundMsg struct {
 type ProcessExitedMsg struct {
 	Generation uint64
 	Err        error
+	ExitCode   int
+	StartedAt  time.Time
+	ExitedAt   time.Time
 }
 
 type FatalMsg struct {
@@ -69,6 +74,7 @@ type ServerRestartingMsg struct{}
 
 type ServerStartedMsg struct {
 	Generation uint64
+	StartedAt  time.Time
 }
 
 type ServerAddressMsg struct {
@@ -117,6 +123,44 @@ type Model struct {
 	settings          Settings
 	settingsOpen      bool
 	settingCursor     int
+	exit              *exitState
+	restart           restartTracker
+	restarting        bool
+	restartPhase      int
+}
+
+// restartTickMsg は再起動待ちの点を進める。停止から起動まで数十秒かかるので、
+// 押した操作が生きていることを点の数で見せる。
+type restartTickMsg struct{}
+
+const restartTickInterval = 400 * time.Millisecond
+
+func (model *Model) beginRestart() tea.Cmd {
+	model.restartPhase = 0
+	// すでに動いていれば tick を二重に走らせない。
+	if model.restarting {
+		return nil
+	}
+	model.restarting = true
+	return restartTick()
+}
+
+func (model *Model) endRestart() {
+	model.restarting = false
+	model.restartPhase = 0
+}
+
+func restartTick() tea.Cmd {
+	return tea.Tick(restartTickInterval, func(time.Time) tea.Msg {
+		return restartTickMsg{}
+	})
+}
+
+// restartDots は "." → ".." → "..." を返す。幅は常に 3 桁で、隣の表示が
+// 点の数で揺れないようにする。
+func (model *Model) restartDots() string {
+	count := model.restartPhase%3 + 1
+	return strings.Repeat(".", count) + strings.Repeat(" ", 3-count)
 }
 
 func New(
@@ -126,6 +170,7 @@ func New(
 	settings Settings,
 ) *Model {
 	applyTheme(settings)
+	startedAt := time.Now()
 	return &Model{
 		status:     "starting",
 		actions:    actions,
@@ -135,6 +180,7 @@ func New(
 		mode:     modeFocus,
 		panel:    panelConsole,
 		settings: settings,
+		restart:  restartTracker{startedAt: startedAt},
 	}
 }
 
@@ -171,11 +217,18 @@ func (model *Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	case ServerRestartingMsg:
 		model.status = "restarting"
 		model.busy = true
+		return model, model.beginRestart()
 	case ServerStartedMsg:
 		model.generation = message.Generation
 		model.resetServerState()
+		model.exit = nil
+		model.restart.startedAt = message.StartedAt
+		if model.restart.startedAt.IsZero() {
+			model.restart.startedAt = time.Now()
+		}
 		model.status = "starting"
 		model.busy = false
+		model.endRestart()
 	case ServerAddressMsg:
 		if !model.accepts(message.Generation) {
 			break
@@ -184,7 +237,12 @@ func (model *Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	case ActionResultMsg:
 		model.busy = false
 		if message.Err != nil {
+			model.endRestart()
 			model.status = msg.ActionFailed(message.Err)
+			// 終了モーダルには status 行がないので、失敗の理由をここへ移す。
+			if model.exit != nil {
+				model.exit.notice = model.status
+			}
 			break
 		}
 		if message.Action.Kind == ActionSendCommand {
@@ -198,7 +256,7 @@ func (model *Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if model.runErr == nil {
 			model.runErr = message.Err
 		}
-		return model, tea.Quit
+		return model, model.setProcessExit(message)
 	case FatalMsg:
 		if !model.accepts(message.Generation) {
 			break
@@ -207,7 +265,15 @@ func (model *Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if model.runErr == nil {
 			model.runErr = message.Err
 		}
-		return model, tea.Quit
+		model.setFatalExit(message.Err)
+	case exitCountdownMsg:
+		return model.handleExitCountdown(message)
+	case restartTickMsg:
+		if !model.restarting {
+			break
+		}
+		model.restartPhase++
+		return model, restartTick()
 	}
 	return model, nil
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -1401,3 +1401,25 @@ func TestModelExitKeepsFatalCauseOverLaterProcessExit(t *testing.T) {
 		t.Fatalf("exitCode = %d", model.exit.exitCode)
 	}
 }
+
+func TestModelKeepsPartiallyAvailableHeapForExitModal(t *testing.T) {
+	model := newTestModel()
+	model.resize(80, 24)
+	_, _ = model.Update(MetricsMsg{JVM: hsperfdata.Metrics{Heap: hsperfdata.Memory{
+		Used:      hsperfdata.Number{Value: 3 << 30, Available: true},
+		Committed: hsperfdata.Number{Value: 4 << 30, Available: true},
+	}}})
+	// カウンタの一部だけ読めない採取。まとめて置き換えると committed が消える。
+	_, _ = model.Update(MetricsMsg{JVM: hsperfdata.Metrics{Heap: hsperfdata.Memory{
+		Used: hsperfdata.Number{Value: 2 << 30, Available: true},
+	}}})
+	_, _ = model.Update(ProcessExitedMsg{ExitCode: 1})
+
+	heap := model.exit.snapshot.heap
+	if !heap.Committed.Available || heap.Committed.Value != 4<<30 {
+		t.Fatalf("committed = %#v", heap.Committed)
+	}
+	if heap.Used.Value != 2<<30 {
+		t.Fatalf("used = %#v", heap.Used)
+	}
+}

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -1277,3 +1277,64 @@ func TestModelExitModalShowsRestartProgressAndFailure(t *testing.T) {
 		t.Fatalf("modal = %q", stripANSI(box))
 	}
 }
+
+func TestModelExitErrorLinesStayWithinCurrentGeneration(t *testing.T) {
+	model := newTestModel()
+	model.resize(80, 24)
+	_, _ = model.Update(LogMsg{Entry: serverlog.Entry{
+		Kind: serverlog.KindOther, Message: "[Server thread/ERROR]: 前世代の残骸",
+	}})
+
+	// 再起動でログは消さないので、世代の境目を覚えていないと前の
+	// クラッシュの ERROR を今回の原因として出してしまう。
+	_, _ = model.Update(ServerStartedMsg{Generation: 2, StartedAt: time.Now()})
+	_, _ = model.Update(LogMsg{Generation: 2, Entry: serverlog.Entry{
+		Kind: serverlog.KindOther, Message: "Done (12.114s)!",
+	}})
+	_, _ = model.Update(ProcessExitedMsg{Generation: 2, ExitCode: 1})
+
+	joined := strings.Join(model.exit.errorLines, "\n")
+	if strings.Contains(joined, "前世代の残骸") {
+		t.Fatalf("errorLines = %q", joined)
+	}
+	if !strings.Contains(joined, "Done (12.114s)!") {
+		t.Fatalf("errorLines = %q", joined)
+	}
+}
+
+func TestModelFatalExitDoesNotReuseStaleUptimeAndMemory(t *testing.T) {
+	model := newTestModel()
+	model.resize(80, 24)
+	model.restart.startedAt = time.Now().Add(-3 * time.Hour)
+	model.memory.RSS = procstats.Number{Value: 5 << 30, Available: true}
+
+	// 起動に失敗した世代には稼働時間もメモリもない。前の値を流用すると、
+	// ログを読んでいた時間まで uptime に足された嘘になる。
+	_, _ = model.Update(FatalMsg{Err: errors.New("start the start script")})
+	if model.exit.uptimeKnown || model.exit.snapshot.rss.Available {
+		t.Fatalf("exit = %#v", model.exit)
+	}
+	box, _, _ := model.exitModal()
+	if strings.Count(stripANSI(box), "n/a") < 2 {
+		t.Fatalf("modal = %q", stripANSI(box))
+	}
+}
+
+func TestModelClearsRunErrorAfterSuccessfulRestart(t *testing.T) {
+	model := newTestModel()
+	model.resize(80, 24)
+	_, _ = model.Update(ProcessExitedMsg{Err: errors.New("crashed"), ExitCode: 1})
+	if model.Err() == nil {
+		t.Fatal("crash did not set the run error")
+	}
+
+	// 立ち上がり直した時点で復旧。以後の正常停止で hso は成功で終わる。
+	_, _ = model.Update(ServerStartedMsg{Generation: 2, StartedAt: time.Now()})
+	if model.Err() != nil {
+		t.Fatalf("err = %v", model.Err())
+	}
+	_, _ = model.Update(ProcessExitedMsg{Generation: 2})
+	if model.Err() != nil {
+		t.Fatalf("err after normal stop = %v", model.Err())
+	}
+}

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -295,13 +296,193 @@ func TestModelBoundsCurrentMetricError(t *testing.T) {
 func TestModelReturnsProcessError(t *testing.T) {
 	model := newTestModel()
 	want := errors.New("server failed")
-	_, command := model.Update(ProcessExitedMsg{Err: want})
+	startedAt := time.Date(2026, time.August, 6, 10, 0, 0, 0, time.UTC)
+	exitedAt := startedAt.Add(90 * time.Second)
+	_, command := model.Update(ProcessExitedMsg{
+		Err:       want,
+		ExitCode:  1,
+		StartedAt: startedAt,
+		ExitedAt:  exitedAt,
+	})
 
 	if !errors.Is(model.Err(), want) {
 		t.Fatalf("Err = %v", model.Err())
 	}
+	if command != nil {
+		t.Fatalf("unexpected command = %T", command())
+	}
+	if model.exit == nil || !model.exit.crashed || model.exit.exitCode != 1 ||
+		model.exit.uptime != 90*time.Second || model.exit.button != 0 {
+		t.Fatalf("exit = %#v", model.exit)
+	}
+}
+
+func TestModelSnapshotsExitMetricsAndErrorLines(t *testing.T) {
+	model := newTestModel()
+	model.resize(80, 24)
+	_, _ = model.Update(MetricsMsg{
+		JVM: hsperfdata.Metrics{Heap: hsperfdata.Memory{
+			Used:      hsperfdata.Number{Value: 10, Available: true},
+			Committed: hsperfdata.Number{Value: 20, Available: true},
+		}},
+		Memory: procstats.Memory{
+			RSS: procstats.Number{Value: 30, Available: true},
+		},
+	})
+	model.gcStats.Collections = 4
+	for _, line := range []string{
+		"old ERROR one",
+		"ignored info",
+		"Exception two",
+		"FATAL three",
+		"Caused by four",
+	} {
+		_, _ = model.Update(LogMsg{Entry: serverlog.Entry{
+			Kind: serverlog.KindOther, Message: line,
+		}})
+	}
+
+	wantErr := errors.New("process failed")
+	_, _ = model.Update(ProcessExitedMsg{Err: wantErr, ExitCode: 7})
+	state := model.exit
+	if state.snapshot.heap.Used.Value != 10 ||
+		state.snapshot.heap.Committed.Value != 20 ||
+		state.snapshot.rss.Value != 30 || state.snapshot.gc.Collections != 4 {
+		t.Fatalf("snapshot = %#v", state.snapshot)
+	}
+	wantLines := []string{
+		"process failed", "Exception two", "FATAL three", "Caused by four",
+	}
+	if !slices.Equal(state.errorLines, wantLines) {
+		t.Fatalf("errorLines = %#v, want %#v", state.errorLines, wantLines)
+	}
+
+	// 終了後に元の状態が変わっても、モーダルのスナップショットは変えない。
+	_, _ = model.Update(MetricsMsg{Memory: procstats.Memory{
+		RSS: procstats.Number{Value: 99, Available: true},
+	}})
+	if state.snapshot.rss.Value != 30 {
+		t.Fatalf("snapshot RSS = %d", state.snapshot.rss.Value)
+	}
+}
+
+func TestModelNormalExitCountsDownAndAnyKeyCancelsIt(t *testing.T) {
+	model := newTestModel()
+	_, command := model.Update(ProcessExitedMsg{ExitCode: 0})
+	if command == nil || model.exit == nil || model.exit.crashed ||
+		!model.exit.autoQuit {
+		t.Fatalf("exit = %#v, command = %T", model.exit, command)
+	}
+
+	_, _ = model.Update(tea.KeyPressMsg{Code: 'G', Text: "G"})
+	if model.exit.autoQuit || model.settingsOpen || model.exit.closed {
+		t.Fatalf("key did not only cancel countdown: %#v", model.exit)
+	}
+	_, command = model.Update(exitCountdownMsg{state: model.exit})
+	if command != nil {
+		t.Fatalf("cancelled countdown returned command %T", command)
+	}
+}
+
+func TestModelFatalMessageOpensCrashModalWithoutQuitting(t *testing.T) {
+	model := newTestModel()
+	model.busy = true
+	want := errors.New("fatal monitor error")
+	_, command := model.Update(FatalMsg{Err: want})
+	if command != nil || model.exit == nil || !model.exit.crashed ||
+		model.exit.exitCode != unknownExitCode || model.busy ||
+		!errors.Is(model.Err(), want) {
+		t.Fatalf("exit = %#v, Err = %v, command = %T",
+			model.exit, model.Err(), command)
+	}
+}
+
+func TestModelNormalExitCountdownQuitsAfterDeadline(t *testing.T) {
+	model := newTestModel()
+	_, _ = model.Update(ProcessExitedMsg{})
+	model.exit.autoQuitAt = time.Now().Add(-time.Second)
+	_, command := model.Update(exitCountdownMsg{state: model.exit})
 	if _, ok := command().(tea.QuitMsg); !ok {
 		t.Fatalf("command = %T", command())
+	}
+}
+
+func TestModelExitModalKeysAndStoppedMode(t *testing.T) {
+	actions := make(chan Action, 1)
+	model := New(actions, nil, 1, DefaultSettings())
+	model.resize(80, 24)
+	_, _ = model.Update(ProcessExitedMsg{Err: errors.New("crashed"), ExitCode: 1})
+
+	// モーダルの既定はログで、G を含む無関係なキーは設定へ流さない。
+	if model.exit.button != 0 {
+		t.Fatalf("button = %d", model.exit.button)
+	}
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	if model.exit.button != 1 {
+		t.Fatalf("button = %d", model.exit.button)
+	}
+	_, _ = model.Update(tea.KeyPressMsg{Code: 'G', Text: "G"})
+	if model.settingsOpen || model.exit.button != 1 {
+		t.Fatalf("modal leaked key: settings = %t, button = %d",
+			model.settingsOpen, model.exit.button)
+	}
+
+	model.exit.button = 0
+	_, command := model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if command != nil || !model.exit.closed || model.panel != panelLog {
+		t.Fatalf("exit = %#v, panel = %d, command = %T",
+			model.exit, model.panel, command)
+	}
+
+	_, _ = model.Update(tea.KeyPressMsg{Code: 'R', Text: "R"})
+	if action := <-actions; action.Kind != ActionRestart {
+		t.Fatalf("action = %#v", action)
+	}
+	_, command = model.Update(tea.KeyPressMsg{Code: 'Q', Text: "Q"})
+	if _, ok := command().(tea.QuitMsg); !ok {
+		t.Fatalf("command = %T", command())
+	}
+}
+
+func TestModelExitViewIsFullScreenLogAndRectangular(t *testing.T) {
+	model := newTestModel()
+	model.resize(72, 21)
+	_, _ = model.Update(LogMsg{Entry: serverlog.Entry{
+		Kind: serverlog.KindOther, Message: "last useful log",
+	}})
+	_, _ = model.Update(ProcessExitedMsg{Err: errors.New("crashed"), ExitCode: 1})
+
+	content := stripANSI(model.View().Content)
+	if !strings.Contains(content, "Log · ") ||
+		!strings.Contains(content, "exit 1") ||
+		!strings.Contains(content, "last useful log") {
+		t.Fatalf("stopped view:\n%s", content)
+	}
+	for _, title := range []string{"Meters", "Players", "Chat", "Console"} {
+		if strings.Contains(content, title) {
+			t.Fatalf("stopped view still contains %s:\n%s", title, content)
+		}
+	}
+	lines := strings.Split(model.View().Content, "\n")
+	if len(lines) != 21 {
+		t.Fatalf("height = %d", len(lines))
+	}
+	for index, line := range lines {
+		if width := stringWidth(line); width != 72 {
+			t.Fatalf("line %d width = %d: %q", index, width, stripANSI(line))
+		}
+	}
+}
+
+func TestModelServerStartedClearsExitAndUpdatesRestartTracker(t *testing.T) {
+	model := newTestModel()
+	_, _ = model.Update(ProcessExitedMsg{Err: errors.New("crashed"), ExitCode: 1})
+	startedAt := time.Date(2026, time.August, 6, 12, 0, 0, 0, time.UTC)
+	_, _ = model.Update(ServerStartedMsg{Generation: 2, StartedAt: startedAt})
+	if model.exit != nil || model.restart.startedAt != startedAt || model.generation != 2 {
+		t.Fatalf("model = %#v", model)
 	}
 }
 
@@ -1029,5 +1210,70 @@ func TestGraphRangeAddsMarginAndReportsUnavailable(t *testing.T) {
 	model.samples.Add(memorySample{heap: 1, heapKnown: true})
 	if low, _, ok := model.graphRange(); !ok || low != 0 {
 		t.Fatalf("low = %d, ok = %t", low, ok)
+	}
+}
+
+func TestModelRestartAnimatesUntilServerStarts(t *testing.T) {
+	actions := make(chan Action, 1)
+	model := New(actions, nil, 1, DefaultSettings())
+	model.resize(80, 24)
+	model.consoleFocus = consoleRestart
+
+	_, command := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if action := <-actions; action.Kind != ActionRestart {
+		t.Fatalf("action = %#v", action)
+	}
+	if !model.restarting || command == nil {
+		t.Fatalf("restarting = %t, command = %T", model.restarting, command)
+	}
+	// 点は 3 桁に揃え、コンソールのボタン幅を揺らさない。
+	if console := stripANSI(model.consoleLine()); !strings.Contains(console, "[restarting.  ]") {
+		t.Fatalf("console = %q", console)
+	}
+	_, _ = model.Update(restartTickMsg{})
+	if console := stripANSI(model.consoleLine()); !strings.Contains(console, "[restarting.. ]") {
+		t.Fatalf("console = %q", console)
+	}
+
+	_, _ = model.Update(ServerStartedMsg{Generation: 2, StartedAt: time.Now()})
+	if model.restarting {
+		t.Fatal("animation outlived the restart")
+	}
+	if console := stripANSI(model.consoleLine()); !strings.Contains(console, "[restart]") {
+		t.Fatalf("console = %q", console)
+	}
+	// 止まった後の tick では再武装しない。
+	if _, command := model.Update(restartTickMsg{}); command != nil {
+		t.Fatalf("command = %T", command)
+	}
+}
+
+func TestModelExitModalShowsRestartProgressAndFailure(t *testing.T) {
+	actions := make(chan Action, 1)
+	model := New(actions, nil, 1, DefaultSettings())
+	model.resize(80, 24)
+	_, _ = model.Update(ProcessExitedMsg{Err: errors.New("crashed"), ExitCode: 1})
+
+	model.exit.button = 1
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if action := <-actions; action.Kind != ActionRestart {
+		t.Fatalf("action = %#v", action)
+	}
+	box, _, _ := model.exitModal()
+	if !strings.Contains(stripANSI(box), msg.ExitStateRestarting(model.restartDots())) {
+		t.Fatalf("modal = %q", stripANSI(box))
+	}
+
+	// 失敗はモーダルへ出す。status 行がないので、ここで出さないと消える。
+	_, _ = model.Update(ActionResultMsg{
+		Action: Action{Kind: ActionRestart},
+		Err:    errors.New("no server"),
+	})
+	if model.restarting {
+		t.Fatal("animation outlived the failure")
+	}
+	box, _, _ = model.exitModal()
+	if !strings.Contains(stripANSI(box), "no server") {
+		t.Fatalf("modal = %q", stripANSI(box))
 	}
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -1338,3 +1338,40 @@ func TestModelClearsRunErrorAfterSuccessfulRestart(t *testing.T) {
 		t.Fatalf("err after normal stop = %v", model.Err())
 	}
 }
+
+func TestModelExitKeepsLastKnownMemoryAndSkipsFallbackOnNormalStop(t *testing.T) {
+	model := newTestModel()
+	model.resize(80, 24)
+	_, _ = model.Update(MetricsMsg{
+		JVM: hsperfdata.Metrics{Heap: hsperfdata.Memory{
+			Used:      hsperfdata.Number{Value: 3 << 30, Available: true},
+			Committed: hsperfdata.Number{Value: 4 << 30, Available: true},
+		}},
+		Memory: procstats.Memory{
+			RSS: procstats.Number{Value: 5 << 30, Available: true},
+		},
+	})
+	// プロセスが消えてから終了を検知するまでの隙間で走る、全部 n/a の採取。
+	_, _ = model.Update(MetricsMsg{})
+	_, _ = model.Update(LogMsg{Entry: serverlog.Entry{
+		Kind: serverlog.KindOther, Message: "[Server thread/INFO]: Saving worlds",
+	}})
+	_, _ = model.Update(ProcessExitedMsg{})
+
+	if !model.exit.snapshot.rss.Available || !model.exit.snapshot.heap.Used.Available {
+		t.Fatalf("snapshot = %#v", model.exit.snapshot)
+	}
+	// 正常停止では、拾えるエラーがないのに末尾で埋めない。
+	if len(model.exit.errorLines) != 0 {
+		t.Fatalf("errorLines = %q", model.exit.errorLines)
+	}
+	if box := stripANSI(mustModal(t, model)); strings.Contains(box, msg.ExitErrorLines) {
+		t.Fatalf("modal = %q", box)
+	}
+}
+
+func mustModal(t *testing.T, model *Model) string {
+	t.Helper()
+	box, _, _ := model.exitModal()
+	return box
+}

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -312,7 +312,8 @@ func TestModelReturnsProcessError(t *testing.T) {
 		t.Fatalf("unexpected command = %T", command())
 	}
 	if model.exit == nil || !model.exit.crashed || model.exit.exitCode != 1 ||
-		model.exit.uptime != 90*time.Second || model.exit.button != 0 {
+		!model.exit.uptime.Available ||
+		model.exit.uptime.Value != 90*time.Second || model.exit.button != 0 {
 		t.Fatalf("exit = %#v", model.exit)
 	}
 }
@@ -370,12 +371,12 @@ func TestModelNormalExitCountsDownAndAnyKeyCancelsIt(t *testing.T) {
 	model := newTestModel()
 	_, command := model.Update(ProcessExitedMsg{ExitCode: 0})
 	if command == nil || model.exit == nil || model.exit.crashed ||
-		!model.exit.autoQuit {
+		model.exit.autoQuitAt.IsZero() {
 		t.Fatalf("exit = %#v, command = %T", model.exit, command)
 	}
 
 	_, _ = model.Update(tea.KeyPressMsg{Code: 'G', Text: "G"})
-	if model.exit.autoQuit || model.settingsOpen || model.exit.closed {
+	if !model.exit.autoQuitAt.IsZero() || model.settingsOpen || model.exit.closed {
 		t.Fatalf("key did not only cancel countdown: %#v", model.exit)
 	}
 	_, command = model.Update(exitCountdownMsg{state: model.exit})
@@ -1223,8 +1224,8 @@ func TestModelRestartAnimatesUntilServerStarts(t *testing.T) {
 	if action := <-actions; action.Kind != ActionRestart {
 		t.Fatalf("action = %#v", action)
 	}
-	if !model.restarting || command == nil {
-		t.Fatalf("restarting = %t, command = %T", model.restarting, command)
+	if model.restartPhase == 0 || command == nil {
+		t.Fatalf("restartPhase = %d, command = %T", model.restartPhase, command)
 	}
 	// 点は 3 桁に揃え、コンソールのボタン幅を揺らさない。
 	if console := stripANSI(model.consoleLine()); !strings.Contains(console, "[restarting.  ]") {
@@ -1236,7 +1237,7 @@ func TestModelRestartAnimatesUntilServerStarts(t *testing.T) {
 	}
 
 	_, _ = model.Update(ServerStartedMsg{Generation: 2, StartedAt: time.Now()})
-	if model.restarting {
+	if model.restartPhase != 0 {
 		t.Fatal("animation outlived the restart")
 	}
 	if console := stripANSI(model.consoleLine()); !strings.Contains(console, "[restart]") {
@@ -1269,7 +1270,7 @@ func TestModelExitModalShowsRestartProgressAndFailure(t *testing.T) {
 		Action: Action{Kind: ActionRestart},
 		Err:    errors.New("no server"),
 	})
-	if model.restarting {
+	if model.restartPhase != 0 {
 		t.Fatal("animation outlived the failure")
 	}
 	box, _, _ = model.exitModal()
@@ -1311,7 +1312,7 @@ func TestModelFatalExitDoesNotReuseStaleUptimeAndMemory(t *testing.T) {
 	// 起動に失敗した世代には稼働時間もメモリもない。前の値を流用すると、
 	// ログを読んでいた時間まで uptime に足された嘘になる。
 	_, _ = model.Update(FatalMsg{Err: errors.New("start the start script")})
-	if model.exit.uptimeKnown || model.exit.snapshot.rss.Available {
+	if model.exit.uptime.Available || model.exit.snapshot.rss.Available {
 		t.Fatalf("exit = %#v", model.exit)
 	}
 	box, _, _ := model.exitModal()

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -1375,3 +1375,28 @@ func mustModal(t *testing.T, model *Model) string {
 	box, _, _ := model.exitModal()
 	return box
 }
+
+func TestModelExitKeepsFatalCauseOverLaterProcessExit(t *testing.T) {
+	model := newTestModel()
+	model.resize(80, 24)
+
+	// java を見つけられないと hso が原因を出してから SIGTERM を送る。
+	// 続けて届く終了通知で、その原因を上書きしてはいけない。
+	_, _ = model.Update(FatalMsg{Err: errors.New("java プロセスを見つけられません")})
+	_, _ = model.Update(ProcessExitedMsg{
+		Err:      errors.New("exit status 143"),
+		ExitCode: 143,
+	})
+
+	if !model.exit.crashed {
+		t.Fatalf("exit = %#v", model.exit)
+	}
+	joined := strings.Join(model.exit.errorLines, "\n")
+	if !strings.Contains(joined, "見つけられません") {
+		t.Fatalf("errorLines = %q", joined)
+	}
+	// 終了コードや稼働時間は新しい通知の値を使う。
+	if model.exit.exitCode != 143 {
+		t.Fatalf("exitCode = %d", model.exit.exitCode)
+	}
+}

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -29,11 +29,19 @@ func (model *Model) updateMetrics(message MetricsMsg) {
 // 終了モーダルに出す最終メモリが消える。ダッシュボードの表示は生の値の
 // ままにして、控えはモーダル専用にする。
 func (model *Model) rememberLastMetrics(message MetricsMsg) {
-	if message.JVM.Heap.Used.Available {
-		model.lastHeap = message.JVM.Heap
-	}
+	// 項目ごとに控える。hsperfdata は一部のカウンタだけ読めないことがあり、
+	// まとめて置き換えると取れていた committed が取れない値で消える。
+	rememberNumber(&model.lastHeap.Used, message.JVM.Heap.Used)
+	rememberNumber(&model.lastHeap.Committed, message.JVM.Heap.Committed)
+	rememberNumber(&model.lastHeap.Max, message.JVM.Heap.Max)
 	if message.Memory.RSS.Available {
 		model.lastRSS = message.Memory.RSS
+	}
+}
+
+func rememberNumber(last *hsperfdata.Number, next hsperfdata.Number) {
+	if next.Available {
+		*last = next
 	}
 }
 

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -105,17 +105,10 @@ func (model *Model) addLog(entry serverlog.Entry) {
 	case serverlog.KindChat:
 		model.chat.Add(newLogRecord(entry, entry.Chat))
 	case serverlog.KindCommand:
-		model.addLogRecord(newLogRecord(entry, entry.Command))
+		model.logs.Add(newLogRecord(entry, entry.Command))
 	default:
-		model.addLogRecord(newLogRecord(entry, entry.Message))
+		model.logs.Add(newLogRecord(entry, entry.Message))
 	}
-}
-
-// addLogRecord は Log ペインへ 1 行足す。累計を数えるのは、押し出されて
-// 位置がずれた後でも「どこから今の世代か」を言えるようにするため。
-func (model *Model) addLogRecord(record logRecord) {
-	model.logs.Add(record)
-	model.logsAdded++
 }
 
 func newLogRecord(entry serverlog.Entry, text string) logRecord {

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -20,7 +20,21 @@ func (model *Model) updateMetrics(message MetricsMsg) {
 	model.cpuAvailable = message.CPUAvailable
 	model.updateMetricError("heap", &model.jvmMetricError, message.JVMError)
 	model.updateMetricError("RSS", &model.memoryMetricError, message.MemoryError)
+	model.rememberLastMetrics(message)
 	model.addSample(message)
+}
+
+// rememberLastMetrics は取れた値だけを控える。プロセスが消えてから終了を
+// 検知するまでの隙間に走った採取は全部 n/a で返るので、そのまま持つと
+// 終了モーダルに出す最終メモリが消える。ダッシュボードの表示は生の値の
+// ままにして、控えはモーダル専用にする。
+func (model *Model) rememberLastMetrics(message MetricsMsg) {
+	if message.JVM.Heap.Used.Available {
+		model.lastHeap = message.JVM.Heap
+	}
+	if message.Memory.RSS.Available {
+		model.lastRSS = message.Memory.RSS
+	}
 }
 
 func (model *Model) updateServerAddress(message ServerAddressMsg) {
@@ -53,6 +67,8 @@ func (model *Model) resetServerState() {
 	model.memoryMetricError = ""
 	model.serverIP = ""
 	model.serverPort = 0
+	model.lastHeap = hsperfdata.Memory{}
+	model.lastRSS = procstats.Number{}
 	model.gcStats = gclog.Stats{}
 	model.tracker = serverlog.Tracker{}
 	model.playerList = nil

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -89,10 +89,17 @@ func (model *Model) addLog(entry serverlog.Entry) {
 	case serverlog.KindChat:
 		model.chat.Add(newLogRecord(entry, entry.Chat))
 	case serverlog.KindCommand:
-		model.logs.Add(newLogRecord(entry, entry.Command))
+		model.addLogRecord(newLogRecord(entry, entry.Command))
 	default:
-		model.logs.Add(newLogRecord(entry, entry.Message))
+		model.addLogRecord(newLogRecord(entry, entry.Message))
 	}
+}
+
+// addLogRecord は Log ペインへ 1 行足す。累計を数えるのは、押し出されて
+// 位置がずれた後でも「どこから今の世代か」を言えるようにするため。
+func (model *Model) addLogRecord(record logRecord) {
+	model.logs.Add(record)
+	model.logsAdded++
 }
 
 func newLogRecord(entry serverlog.Entry, text string) logRecord {

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -24,6 +24,14 @@ var (
 	keyStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#282A36")).
 			Background(lipgloss.Color("#BBBBBB"))
+	// 終了モーダルの枠。異常終了と正常終了の区別は配色プリセットに
+	// 左右させない。単色プリセットで両者が同じ色になると意味が壊れる。
+	exitCrashStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#FF5555")).
+			Bold(true)
+	exitStoppedStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#50FA7B")).
+				Bold(true)
 	logTimestampStyle = color("#777777")
 	logReceivedStyle  = color("#5A5A5A").Faint(true)
 	logKindStyles     = map[serverlog.Kind]lipgloss.Style{

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -20,6 +20,18 @@ func (model *Model) View() tea.View {
 			minimumWidth,
 			minimumHeight,
 		)
+	} else if model.exit != nil {
+		content = model.renderBufferPanelWithTitle(
+			msg.StoppedLogTitle(formatExitCode(model.exit.exitCode)),
+			panelLog,
+			&model.logs,
+			model.layout.width,
+			model.layout.height-keybarHeight,
+		) + "\n" + model.keybar()
+		if !model.exit.closed {
+			box, x, y := model.exitModal()
+			content = overlay(content, box, x, y)
+		}
 	} else {
 		stats := renderPanel(
 			model.statsTitle(),
@@ -75,6 +87,9 @@ func (model *Model) View() tea.View {
 
 func (model *Model) consoleLine() string {
 	restart := "[restart]"
+	if model.restarting {
+		restart = "[restarting" + model.restartDots() + "]"
+	}
 	stop := "[stop]"
 	focused := model.mode == modeFocus && model.panel == panelConsole
 	cursor := ""
@@ -123,6 +138,17 @@ func (model *Model) renderBufferPanel(
 	buffer *lineBuffer,
 	width, height int,
 ) string {
+	return model.renderBufferPanelWithTitle(
+		target.title(), target, buffer, width, height,
+	)
+}
+
+func (model *Model) renderBufferPanelWithTitle(
+	title string,
+	target panel,
+	buffer *lineBuffer,
+	width, height int,
+) string {
 	contentHeight := max(0, height-2)
 	innerWidth := max(0, width-2)
 	viewport := bufferViewport{width: innerWidth, height: contentHeight}
@@ -136,7 +162,6 @@ func (model *Model) renderBufferPanel(
 		lines[padding+index] = renderLogLine(window[index], innerWidth)
 	}
 
-	title := target.title()
 	if offset := buffer.Offset(viewport); offset > 0 {
 		title = fmt.Sprintf("%s ↑%d", title, offset)
 	}
@@ -226,6 +251,20 @@ func renderPanelLines(
 func (model *Model) keybar() string {
 	var keys [][2]string
 	switch {
+	case model.exit != nil && !model.exit.closed:
+		keys = [][2]string{
+			{"←→/Tab", msg.BarExitButton},
+			{"Enter", msg.BarConfirm},
+			{"Esc", msg.BarReadLogs},
+			{"^C", msg.BarExit},
+		}
+	case model.exit != nil:
+		keys = [][2]string{
+			{"↑↓/Pg", msg.BarScroll},
+			{"Home/End", msg.BarEnds},
+			{"R", msg.BarRestart},
+			{"Q/Enter", msg.BarExit},
+		}
 	case model.settingsOpen:
 		keys = [][2]string{
 			{"↑↓", msg.BarItem},

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -87,7 +87,7 @@ func (model *Model) View() tea.View {
 
 func (model *Model) consoleLine() string {
 	restart := "[restart]"
-	if model.restarting {
+	if model.restartPhase != 0 {
 		restart = "[restarting" + model.restartDots() + "]"
 	}
 	stop := "[stop]"


### PR DESCRIPTION
## 背景

`ProcessExitedMsg` / `FatalMsg` を受けた時点で `tea.Quit` していたため、クラッシュの原因が書かれた最後の数十行を読む間もなく画面が消えていた。

設計は合意済み（案 B: 中央モーダル + ログ全面）。自動再起動はフェーズ 2 で、本 PR には含まない。

## 変更

- **終了検知で hso を終わらせない** — `exitState` を立ててモーダルを出す。`ProcessExitedMsg` に `ExitCode` / `StartedAt` / `ExitedAt` を追加し、`processExitCode` が `*exec.ExitError` から取る
- **モーダル** — 終了コード・停止時刻・稼働時間・死ぬ直前の RSS/heap/Δ・GC・ログから拾ったエラー行（ERROR / FATAL / Exception / Caused by を末尾から最大 3 行）。異常終了は赤枠、正常終了は緑枠
- **ボタン** — `[ ログを読む ] [ 再起動 ] [ 終了 ]`。既定カーソルは先頭の「ログを読む」。Enter 連打で意図しない再起動が走らないようにするため
- **背景** — 停止後は Stats / Meters / Players / Graph / Chat / Console を畳み、Log だけを全面に。タイトルは `Log · 停止済み (exit 1)`
- **キー** — モーダル中は `←→`/`Tab` でボタン移動、`Enter` で決定、`Esc` で閉じる。閉じた後は既存の `handleBufferKey` でスクロール、`R` で再起動、`Q`/`Enter` で終了。`Ctrl+C` は従来どおり例外なく即終了
- **正常終了** — 3 秒のカウントダウンで自動的に閉じて終了。その間にキーを押せば留まる
- **再起動待ちの表示** — コンソールの `[restart]` とモーダルの状態行が `restarting.` → `..` → `...` と動く。点は常に 3 桁ぶん確保し、ボタン幅が揺れて入力欄の右端が動かないようにしている
- **再起動の失敗** — `exitState.notice` に入れてモーダルへ出す。モーダルには status 行がないので、出さないと握り潰される
- **停止済みからの再起動** — runtime を手放した後なので `restart()` が `ErrServerStopped` に落ちていた。`serverController` に `lastGeneration` を持たせ、stop を挟まずそのまま起動する経路を追加

## 設計上の判断

- 終了モーダルの枠色（`exitCrashStyle` / `exitStoppedStyle`）は `theme.go` に置くが、**配色プリセットには連動させない**。メーターの `flat` のような単色プリセットに乗せると異常終了と正常終了が同じ色になり、区別が壊れるため
- `model.runErr` は保持したまま返す。hso の終了コードは従来どおり
- 短命再起動の判定カウンタ（`restartTracker`）は `exitState` の外＝`Model` 直下に置く。`exitState` は終了のたびに作り直されるので、中に入れるとフェーズ 2 でループを検出できない。本 PR では型と `startedAt` の更新まで

## 確認

- `CGO_ENABLED=0 go build ./...` / `-tags en` / `go vet ./...` / `go test ./...` すべて通過
- 最小端末 72x21 でモーダルが破綻しないことをテストで確認（`TestModelExitViewIsFullScreenLogAndRectangular`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)