### PR TITLE
fix: GC 回数が未取得のときに n/a と出す

### DIFF
--- a/internal/gclog/stats.go
+++ b/internal/gclog/stats.go
@@ -7,8 +7,13 @@ type Rate struct {
 	Available bool
 }
 
+type Count struct {
+	Value     uint64
+	Available bool
+}
+
 type Stats struct {
-	Collections uint64
+	Collections Count
 	PostGC      Bytes
 	LastPause   Duration
 	TotalPause  time.Duration
@@ -23,7 +28,8 @@ type Stats struct {
 
 func (s *Stats) Add(event Event) {
 	if !s.hasCollectionID || event.ID > s.highestCollectionID {
-		s.Collections++
+		s.Collections.Value++
+		s.Collections.Available = true
 		s.highestCollectionID = event.ID
 		s.hasCollectionID = true
 

--- a/internal/gclog/stats_test.go
+++ b/internal/gclog/stats_test.go
@@ -21,8 +21,8 @@ func TestStatsTracksPostGCAndPauses(t *testing.T) {
 		Pause:  Duration{Value: 20 * time.Millisecond, Available: true},
 	})
 
-	if stats.Collections != 2 {
-		t.Fatalf("Collections = %d", stats.Collections)
+	if stats.Collections.Value != 2 || !stats.Collections.Available {
+		t.Fatalf("Collections = %#v", stats.Collections)
 	}
 	assertBytes(t, stats.PostGC, 300)
 	assertDuration(t, stats.LastPause, 20*time.Millisecond)
@@ -47,8 +47,8 @@ func TestStatsDoesNotCountSameCollectionTwice(t *testing.T) {
 		Pause: Duration{Value: time.Millisecond, Available: true},
 	})
 
-	if stats.Collections != 1 {
-		t.Fatalf("Collections = %d", stats.Collections)
+	if stats.Collections.Value != 1 || !stats.Collections.Available {
+		t.Fatalf("Collections = %#v", stats.Collections)
 	}
 	assertBytes(t, stats.PostGC, 400)
 	assertDuration(t, stats.LastPause, time.Millisecond)
@@ -65,8 +65,8 @@ func TestStatsCountsPauseOnlyCollection(t *testing.T) {
 		Pause:  Duration{Value: time.Millisecond, Available: true},
 	})
 
-	if stats.Collections != 1 {
-		t.Fatalf("Collections = %d", stats.Collections)
+	if stats.Collections.Value != 1 || !stats.Collections.Available {
+		t.Fatalf("Collections = %#v", stats.Collections)
 	}
 	if stats.PostGC.Available {
 		t.Fatalf("PostGC = %#v", stats.PostGC)

--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -102,8 +102,12 @@ func ExitMemory(rss, heapUsed, heapCommitted, delta string) string {
 	)
 }
 
-func ExitGC(collections uint64, last string) string {
-	return fmt.Sprintf("GC  %d collections · last pause %s", collections, last)
+func ExitGC(collections uint64, available bool, last string) string {
+	count := "n/a"
+	if available {
+		count = fmt.Sprintf("%d collections", collections)
+	}
+	return fmt.Sprintf("GC  %s · last pause %s", count, last)
 }
 
 func ExitStateRestarting(dots string) string {

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -100,8 +100,12 @@ func ExitMemory(rss, heapUsed, heapCommitted, delta string) string {
 	)
 }
 
-func ExitGC(collections uint64, last string) string {
-	return fmt.Sprintf("GC  %d 回 · 最終停止 %s", collections, last)
+func ExitGC(collections uint64, available bool, last string) string {
+	count := "n/a"
+	if available {
+		count = fmt.Sprintf("%d 回", collections)
+	}
+	return fmt.Sprintf("GC  %s · 最終停止 %s", count, last)
 }
 
 func ExitStateRestarting(dots string) string {

--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -39,8 +39,8 @@ func (model *Model) statsLines() []string {
 		),
 		model.rssLine(),
 		fmt.Sprintf(
-			"GC   %d collections  total %s  last %s  freq %s",
-			model.gcStats.Collections,
+			"GC   %s  total %s  last %s  freq %s",
+			formatCollections(model.gcStats.Collections),
 			formatPause(
 				model.gcStats.TotalPause,
 				model.gcStats.LastPause.Available,

--- a/internal/ui/exit.go
+++ b/internal/ui/exit.go
@@ -372,7 +372,8 @@ func (model *Model) exitModal() (string, int, int) {
 			formatDelta(state.snapshot.rss, state.snapshot.heap.Committed),
 		),
 		msg.ExitGC(
-			state.snapshot.gc.Collections,
+			state.snapshot.gc.Collections.Value,
+			state.snapshot.gc.Collections.Available,
 			formatPause(
 				state.snapshot.gc.LastPause.Value,
 				state.snapshot.gc.LastPause.Available,

--- a/internal/ui/format.go
+++ b/internal/ui/format.go
@@ -119,7 +119,7 @@ func formatPause(duration time.Duration, available bool) string {
 	}
 }
 
-// formatCollections は GC 回数を単位ごと返す。GC ログが 1 行も届いていない
+// formatCollections は GC 回数を単位付きで返す。GC ログが 1 行も届いていない
 // 間は 0 回と区別が付かないので n/a にする。
 func formatCollections(count gclog.Count) string {
 	if !count.Available {

--- a/internal/ui/format.go
+++ b/internal/ui/format.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hijoushoku7/hijo-server-ops/internal/gclog"
 	"github.com/hijoushoku7/hijo-server-ops/internal/hsperfdata"
 	"github.com/hijoushoku7/hijo-server-ops/internal/procstats"
 )
@@ -116,6 +117,15 @@ func formatPause(duration time.Duration, available bool) string {
 	default:
 		return fmt.Sprintf("%.2fs", duration.Seconds())
 	}
+}
+
+// formatCollections は GC 回数を単位ごと返す。GC ログが 1 行も届いていない
+// 間は 0 回と区別が付かないので n/a にする。
+func formatCollections(count gclog.Count) string {
+	if !count.Available {
+		return "n/a"
+	}
+	return fmt.Sprintf("%d collections", count.Value)
 }
 
 func formatFrequency(value float64, available bool) string {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
 
+	"github.com/hijoushoku7/hijo-server-ops/internal/gclog"
 	"github.com/hijoushoku7/hijo-server-ops/internal/hsperfdata"
 	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
 	"github.com/hijoushoku7/hijo-server-ops/internal/procstats"
@@ -330,7 +331,7 @@ func TestModelSnapshotsExitMetricsAndErrorLines(t *testing.T) {
 			RSS: procstats.Number{Value: 30, Available: true},
 		},
 	})
-	model.gcStats.Collections = 4
+	model.gcStats.Collections = gclog.Count{Value: 4, Available: true}
 	for _, line := range []string{
 		"old ERROR one",
 		"ignored info",
@@ -348,7 +349,7 @@ func TestModelSnapshotsExitMetricsAndErrorLines(t *testing.T) {
 	state := model.exit
 	if state.snapshot.heap.Used.Value != 10 ||
 		state.snapshot.heap.Committed.Value != 20 ||
-		state.snapshot.rss.Value != 30 || state.snapshot.gc.Collections != 4 {
+		state.snapshot.rss.Value != 30 || state.snapshot.gc.Collections.Value != 4 {
 		t.Fatalf("snapshot = %#v", state.snapshot)
 	}
 	wantLines := []string{
@@ -1722,5 +1723,25 @@ func TestExitModalMessagesFitTheModal(t *testing.T) {
 		if width := stringWidth(line); width > exitModalWidth-2 {
 			t.Errorf("width %d > %d: %q", width, exitModalWidth-2, line)
 		}
+	}
+}
+
+func TestModelShowsGCCollectionsAsUnavailableUntilFirstEvent(t *testing.T) {
+	model := newTestModel()
+	_, _ = model.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+
+	stats := strings.Join(model.statsLines(), "\n")
+	if !strings.Contains(stats, "GC   n/a  total") {
+		t.Fatalf("stats = %q", stats)
+	}
+
+	_, _ = model.Update(GCMsg{Event: gclog.Event{
+		ID:    1,
+		Pause: gclog.Duration{Value: time.Millisecond, Available: true},
+	}})
+
+	stats = strings.Join(model.statsLines(), "\n")
+	if !strings.Contains(stats, "GC   1 collections  total") {
+		t.Fatalf("stats = %q", stats)
 	}
 }


### PR DESCRIPTION
## 背景

`gclog.Stats.Collections` が素の `uint64` だったため、GC ログを 1 行も読めていない状態でも `0 collections` と表示されていた。実際に GC が 0 回なのか、取得に失敗しているのかを区別できず、設計原則 4（取れない情報は n/a と出す）に反していた。

## 変更

- `gclog.Count{Value, Available}` を追加し、`Stats.Collections` をこの型に変更。イベントを 1 件でも受け取った時点で `Available` が立つ
- ダッシュボードの GC 行: `formatCollections` 経由で `n/a` / `12 collections` を出す
- 終了モーダル: `msg.ExitGC` に `available` を渡し、ja/en 両方で `n/a` を出す
- テスト: 初期状態で `GC   n/a`、GC イベント 1 件後に `1 collections` になることを確認

## 検証

`go build ./...` / `go build -tags en ./...` / `go vet ./...` / `go test ./...` / `go test -tags en ./...` / `go test -race ./cmd/hso/ ./internal/ui/` / `gofmt -l internal cmd` すべて通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)