### PR TITLE
feat: 設定モーダルを見た目と挙動で区切る

### DIFF
--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -20,6 +20,12 @@ import (
 	"fmt"
 )
 
+// Settings modal section headings.
+const (
+	SectionPreferences = "Preferences"
+	SectionAdvanced    = "Advanced"
+)
+
 // Settings modal item names.
 const (
 	LabelFrame     = "border"

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -18,6 +18,12 @@ import (
 	"fmt"
 )
 
+// 設定モーダルの見出し。
+const (
+	SectionPreferences = "プリファレンス"
+	SectionAdvanced    = "詳細設定"
+)
+
 // 設定モーダルの項目名。
 const (
 	LabelFrame     = "枠"

--- a/internal/msg/msg_test.go
+++ b/internal/msg/msg_test.go
@@ -97,6 +97,8 @@ func TestMessagesAreNotEmpty(t *testing.T) {
 	sample := errors.New("boom")
 
 	messages := map[string]string{
+		"SectionPreferences":    SectionPreferences,
+		"SectionAdvanced":       SectionAdvanced,
 		"LabelFrame":            LabelFrame,
 		"LabelGraphLine":        LabelGraphLine,
 		"LabelMeterBar":         LabelMeterBar,

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -39,7 +39,11 @@ type settingOption struct {
 
 // settingItem は設定 1 項目。値の出し入れだけを持たせることで、モーダルは
 // ↑↓ で項目、←→ で値を動かす操作だけを知っていればよくなる。
+//
+// section が空でない項目は、その手前に見出しを 1 行挟む。見出しはカーソルの
+// 止まらない飾りなので、項目の並びとカーソル位置の対応は変わらない。
 type settingItem struct {
+	section string
 	label   string
 	options []settingOption
 	get     func(Settings) string
@@ -48,7 +52,8 @@ type settingItem struct {
 
 var settingItems = []settingItem{
 	{
-		label: msg.LabelFrame,
+		section: msg.SectionPreferences,
+		label:   msg.LabelFrame,
 		options: []settingOption{
 			{label: msg.OptDefault, value: "dracula"},
 			{label: msg.OptMono, value: "mono"},
@@ -130,7 +135,8 @@ var settingItems = []settingItem{
 		},
 	},
 	{
-		label: msg.LabelAutoRestart,
+		section: msg.SectionAdvanced,
+		label:   msg.LabelAutoRestart,
 		// 値は文字列で持たせる。項目 1 つのために get/set を型で分けると、
 		// モーダルが項目の中身を知らずに済む今の形が崩れる。
 		options: []settingOption{
@@ -219,17 +225,27 @@ func (model *Model) saveSettings() {
 func (model *Model) settingsModal() (string, int, int) {
 	labelWidth := 0
 	valueWidth := 0
+	sectionWidth := 0
 	for _, item := range settingItems {
 		labelWidth = max(labelWidth, stringWidth(item.label))
 		valueWidth = max(valueWidth, stringWidth(item.valueLabel(model.settings)))
+		sectionWidth = max(sectionWidth, stringWidth(item.section))
 	}
-	// " ラベル  ‹ 値 › " の飾りと枠の 2 列を足した幅。
-	width := labelWidth + valueWidth + 10
+	// " ラベル  ‹ 値 › " の飾りと枠の 2 列を足した幅。見出しが長ければそちらに
+	// 合わせる。
+	width := max(labelWidth+valueWidth+10, sectionWidth+4)
 	width = min(width, model.layout.width)
-	height := len(settingItems) + 2
 
-	lines := make([]string, 0, len(settingItems))
+	lines := make([]string, 0, len(settingItems)+2)
 	for index, item := range settingItems {
+		if item.section != "" {
+			// 先頭の見出し以外は、区切りとして 1 行空ける。
+			if len(lines) > 0 {
+				lines = append(lines, "")
+			}
+			lines = append(lines,
+				titleStyle.Render(fitLine(" "+item.section, width-2)))
+		}
 		value := item.valueLabel(model.settings)
 		line := " " + fitLine(item.label, labelWidth) + "  ‹ " +
 			strings.Repeat(" ", max(0, valueWidth-stringWidth(value))) +
@@ -240,6 +256,7 @@ func (model *Model) settingsModal() (string, int, int) {
 		}
 		lines = append(lines, line)
 	}
+	height := len(lines) + 2
 
 	x := max(0, (model.layout.width-width)/2)
 	y := max(0, (model.layout.height-height)/2)

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -101,6 +101,38 @@ func TestSettingsSaveFailureShowsStatus(t *testing.T) {
 	}
 }
 
+// 見出しはカーソルの止まらない飾りなので、↓ の回数と項目の対応は
+// 見出しを挟んでも変わらない。
+func TestSettingsModalShowsSectionHeadings(t *testing.T) {
+	t.Cleanup(func() { applyTheme(DefaultSettings()) })
+	model := New(make(chan Action, 1), func(Settings) error { return nil },
+		0, DefaultSettings())
+	_, _ = model.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	_, _ = model.Update(tea.KeyPressMsg{Code: 'G', Text: "G"})
+
+	content := stripANSI(model.View().Content)
+	preferences := strings.Index(content, msg.SectionPreferences)
+	advanced := strings.Index(content, msg.SectionAdvanced)
+	autoRestart := strings.Index(content, msg.LabelAutoRestart)
+	frame := strings.Index(content, msg.LabelFrame)
+	switch {
+	case preferences < 0 || advanced < 0:
+		t.Fatalf("見出しがない:\n%s", content)
+	case !(preferences < frame && frame < advanced && advanced < autoRestart):
+		t.Fatalf("見出しの位置が違う:\n%s", content)
+	}
+
+	// 見出しの分だけカーソルがずれていないか。
+	for range len(settingItems) - 1 {
+		_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	if !model.settings.AutoRestart {
+		t.Fatalf("settings = %#v", model.settings)
+	}
+}
+
 func TestSettingItemsWrapAroundAndKeepUnknownValues(t *testing.T) {
 	item := settingItems[0]
 	settings := Settings{FramePreset: item.options[0].value}


### PR DESCRIPTION
## 概要

設定モーダルを 2 区画に分けた。配色まわりを「プリファレンス」、コンソールの挙動に影響する設定を「詳細設定」とし、その間に見出しを挟む。

```
┌─ Settings ───────────────┐
│ プリファレンス           │
│ 枠            ‹   既定 › │
│ グラフの線    ‹   既定 › │
│ メーターの棒  ‹   信号 › │
│ タイトル      ‹ シアン › │
│ 選択行        ‹     黄 › │
│ ログ          ‹   既定 › │
│                          │
│ 詳細設定                 │
│ 自動再起動    ‹   無効 › │
└──────────────────────────┘
```

## 実装

- `settingItem` に `section` を追加。値が入っている項目の直前に見出しを 1 行挟むだけで、項目の並び自体は変えない。カーソルは項目の添字のまま動くので、見出しを飛ばす処理は要らない。
- 見出しは `titleStyle`、2 つ目以降は手前に空行。モーダルの高さは行数から算出し、幅は見出しが長ければそちらに合わせる。
- 文言は `msg.SectionPreferences` / `msg.SectionAdvanced`（en: `Preferences` / `Advanced`）。

## テスト

- 見出しの表示順（プリファレンス → 枠 → 詳細設定 → 自動再起動）と、見出しを挟んでもカーソル位置がずれないことを追加。
- `go build` / `-tags en` ビルド / `go vet` / `go test ./...` / `go test -race` / `gofmt -l` すべて通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)