### PR TITLE
chore: ローカル検証用の scripts/test.sh を無視する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /hso_en
 /dist/
 /mc-server-test/
+/scripts/test.sh
 *.test
 *.out
 


### PR DESCRIPTION
ビルドして `mc-server-test/` へバイナリを置き、日本語版を起動するだけの手元用スクリプトなので追跡しない。`mc-server-test/` と同じ扱いで `.gitignore` に 1 行追加した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)