### PR TITLE
fix: 停止の印を経路ごとに分け、クラッシュ標識を優先する

### DIFF
--- a/cmd/hso/app_test.go
+++ b/cmd/hso/app_test.go
@@ -261,6 +261,61 @@ func TestRuntimeFailedStopCommandKeepsShutdownNotice(t *testing.T) {
 	}
 }
 
+// 送信に失敗した stop で印を立てない。送信の前に立てる書き方だと、
+// 失敗が確定する前に終了判定が走ったときクラッシュを正常停止と読み違える。
+func TestRuntimeFailedStopCommandLeavesNoMark(t *testing.T) {
+	var runtime serverRuntime
+	sendErr := errors.New("server process has exited")
+	var marked bool
+	err := runtime.sendCommand("stop", func(string) error {
+		marked = runtime.expectedExit()
+		return sendErr
+	})
+	if !errors.Is(err, sendErr) {
+		t.Fatalf("send error = %v", err)
+	}
+	// 送信中に読まれても印は立っていない。
+	if marked {
+		t.Fatal("the mark was set before the send finished")
+	}
+	if err := serverExitError(nil, true, runtime.expectedExit()); !errors.Is(err, msg.ErrServerExited) {
+		t.Fatalf("failed stop error = %v", err)
+	}
+}
+
+// 2 回目の stop が失敗しても 1 回目の成功を消さない。印は単調に立つだけ。
+func TestRuntimeFailedStopCommandKeepsEarlierSuccess(t *testing.T) {
+	var runtime serverRuntime
+	if err := runtime.sendCommand("stop", func(string) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	sendErr := errors.New("server process has exited")
+	if err := runtime.sendCommand("/stop", func(string) error {
+		return sendErr
+	}); !errors.Is(err, sendErr) {
+		t.Fatalf("send error = %v", err)
+	}
+	if err := serverExitError(nil, true, runtime.expectedExit()); err != nil {
+		t.Fatalf("expected exit error = %v", err)
+	}
+}
+
+// 標識が告知より後に届いても結論は変わらない。読み手が stdout と stderr に
+// 分かれているので、順序に頼った判定にはしていない。
+func TestRuntimeCrashNoticeAfterShutdownNoticeStillCrashes(t *testing.T) {
+	var runtime serverRuntime
+	for _, line := range []string{
+		"[12:00:00] [Server thread/INFO]: Stopping server",
+		"[12:00:00] [Server thread/ERROR]: Encountered an unexpected exception",
+	} {
+		runtime.noteShutdown(serverlog.Parse(line))
+	}
+	err := serverExitError(nil, true, runtime.expectedExit())
+	if !errors.Is(err, msg.ErrServerExited) {
+		t.Fatalf("late crash notice error = %v", err)
+	}
+}
+
 func TestRuntimeNoteShutdownIgnoresChat(t *testing.T) {
 	var runtime serverRuntime
 	for _, line := range []string{

--- a/cmd/hso/app_test.go
+++ b/cmd/hso/app_test.go
@@ -175,7 +175,7 @@ func TestReadServerOutputObservesEveryLineEvenWhenLogsAreFull(t *testing.T) {
 	if entry := <-logs; entry.Message != "Saving worlds" {
 		t.Fatalf("the shutdown notice survived the queue: %#v", entry)
 	}
-	if !runtime.expectedExit.Load() {
+	if !runtime.expectedExit() {
 		t.Fatal("shutdown notice was not observed")
 	}
 }
@@ -191,7 +191,7 @@ func TestRuntimeNoteShutdownDetectsPlayerStopWithoutAdminLog(t *testing.T) {
 	} {
 		runtime.noteShutdown(serverlog.Parse(line))
 	}
-	if !runtime.expectedExit.Load() {
+	if !runtime.expectedExit() {
 		t.Fatal("an orderly shutdown was not treated as expected")
 	}
 }
@@ -208,8 +208,56 @@ func TestRuntimeNoteShutdownKeepsCrashUnexpected(t *testing.T) {
 	} {
 		runtime.noteShutdown(serverlog.Parse(line))
 	}
-	if runtime.expectedExit.Load() {
+	if runtime.expectedExit() {
 		t.Fatal("a crash was treated as an expected exit")
+	}
+}
+
+// クラッシュ標識は確定状態として扱う。後始末中に hso から stop を正常に
+// 送れて、その後にシャットダウン告知が来ても正常停止へ戻してはいけない。
+// ErrServerExited は UI 側で異常終了として扱われ、自動再起動の対象になる。
+func TestRuntimeStopCommandDoesNotOverrideCrashNotice(t *testing.T) {
+	var runtime serverRuntime
+	runtime.noteShutdown(serverlog.Parse(
+		"[12:00:00] [Server thread/ERROR]: Encountered an unexpected exception",
+	))
+	if err := runtime.sendCommand("stop", func(command string) error {
+		if command != "stop" {
+			t.Fatalf("command = %q", command)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	runtime.noteShutdown(serverlog.Parse(
+		"[12:00:01] [Server thread/INFO]: Stopping server",
+	))
+
+	err := serverExitError(nil, true, runtime.expectedExit())
+	if !errors.Is(err, msg.ErrServerExited) {
+		t.Fatalf("clean crash error = %v", err)
+	}
+}
+
+// ログで整然とした停止を確認した後なら、終了済みプロセスへの stop 送信が
+// 失敗してもログ側の印を消さず、正常停止のままにする。
+func TestRuntimeFailedStopCommandKeepsShutdownNotice(t *testing.T) {
+	var runtime serverRuntime
+	runtime.noteShutdown(serverlog.Parse(
+		"[12:00:00] [Server thread/INFO]: Stopping server",
+	))
+	sendErr := errors.New("server process has exited")
+	err := runtime.sendCommand("stop", func(command string) error {
+		if command != "stop" {
+			t.Fatalf("command = %q", command)
+		}
+		return sendErr
+	})
+	if !errors.Is(err, sendErr) {
+		t.Fatalf("send error = %v", err)
+	}
+	if err := serverExitError(nil, true, runtime.expectedExit()); err != nil {
+		t.Fatalf("orderly shutdown error = %v", err)
 	}
 }
 
@@ -221,7 +269,7 @@ func TestRuntimeNoteShutdownIgnoresChat(t *testing.T) {
 	} {
 		runtime.noteShutdown(serverlog.Parse(line))
 	}
-	if runtime.expectedExit.Load() || runtime.crashNoticed.Load() {
+	if runtime.expectedExit() || runtime.crashNoticed.Load() {
 		t.Fatal("chat was treated as a server notice")
 	}
 }

--- a/cmd/hso/controller.go
+++ b/cmd/hso/controller.go
@@ -48,11 +48,15 @@ func (pipe outputPipe) close() {
 }
 
 type serverRuntime struct {
-	server       *process.Process
-	generation   uint64
-	startedAt    time.Time
-	javaFound    atomic.Bool
-	expectedExit atomic.Bool
+	server     *process.Process
+	generation uint64
+	startedAt  time.Time
+	javaFound  atomic.Bool
+	// stopCommandSent と shutdownNoticed は、意図された停止を確認した経路を
+	// 分けて持つ。送信失敗時に取り消すのは前者だけにし、ログ側の確認を
+	// 消さない。
+	stopCommandSent atomic.Bool
+	shutdownNoticed atomic.Bool
 	// crashNoticed はクラッシュの標識をログで見たか。整然と畳まれること
 	// 自体はクラッシュでも同じなので、これで区別する。
 	crashNoticed atomic.Bool
@@ -88,8 +92,33 @@ func (runtime *serverRuntime) noteShutdown(entry serverlog.Entry) {
 	case serverlog.IsCrashNotice(entry):
 		runtime.crashNoticed.Store(true)
 	case serverlog.IsShutdownStart(entry) && !runtime.crashNoticed.Load():
-		runtime.expectedExit.Store(true)
+		runtime.shutdownNoticed.Store(true)
 	}
+}
+
+// expectedExit は、クラッシュの標識がなく、停止コマンドの送信またはログで
+// 整然とした停止を確認できた場合にだけ true を返す。クラッシュの標識は
+// 確定状態なので、後から停止コマンドやシャットダウン告知が来ても覆さない。
+func (runtime *serverRuntime) expectedExit() bool {
+	expected := runtime.stopCommandSent.Load() || runtime.shutdownNoticed.Load()
+	return expected && !runtime.crashNoticed.Load()
+}
+
+// sendCommand は停止コマンドの送信状態だけを管理する。送信失敗時もログ側が
+// 立てた shutdownNoticed には触れない。
+func (runtime *serverRuntime) sendCommand(
+	command string,
+	send func(string) error,
+) error {
+	isStop := isStopCommand(command)
+	if isStop {
+		runtime.stopCommandSent.Store(true)
+	}
+	err := send(command)
+	if err != nil && isStop {
+		runtime.stopCommandSent.Store(false)
+	}
+	return err
 }
 
 func (runtime *serverRuntime) close() {
@@ -219,14 +248,7 @@ func (controller *serverController) sendCommand(action ui.Action) {
 		controller.program.Send(ui.ActionResultMsg{Action: action, Err: msg.ErrServerStopped})
 		return
 	}
-	isStop := isStopCommand(action.Command)
-	if isStop {
-		runtime.expectedExit.Store(true)
-	}
-	err := runtime.server.Send(action.Command)
-	if err != nil && isStop {
-		runtime.expectedExit.Store(false)
-	}
+	err := runtime.sendCommand(action.Command, runtime.server.Send)
 	controller.program.Send(ui.ActionResultMsg{Action: action, Err: err})
 }
 
@@ -322,7 +344,7 @@ func (controller *serverController) waitForServer(runtime *serverRuntime) {
 		Err: serverExitError(
 			waitErr,
 			runtime.javaFound.Load(),
-			runtime.expectedExit.Load(),
+			runtime.expectedExit(),
 		),
 	})
 }

--- a/cmd/hso/controller.go
+++ b/cmd/hso/controller.go
@@ -84,9 +84,10 @@ type serverRuntime struct {
 // 印が立っていても終了コードが 0 でなければクラッシュのままなので、
 // SIGTERM で畳まれた場合（143）は自動再起動の対象に残る。
 //
-// 順序の前提は 1 本のストリーム内でしか保証されない。標識も告知も log4j の
-// コンソールアペンダから stdout に出るので今は成り立つが、標識だけが
-// stderr に回る作りに変わると逆転しうる。
+// 標識が告知より後に届いても結論は変わらない。expectedExit がクラッシュの
+// 標識を最後に引くので、ここで告知の印を立てた後に標識が立っても覆る。
+// stdout と stderr で読み手が分かれており順序を保証できないため、順序に
+// 頼らない形にしてある。
 func (runtime *serverRuntime) noteShutdown(entry serverlog.Entry) {
 	switch {
 	case serverlog.IsCrashNotice(entry):
@@ -104,19 +105,22 @@ func (runtime *serverRuntime) expectedExit() bool {
 	return expected && !runtime.crashNoticed.Load()
 }
 
-// sendCommand は停止コマンドの送信状態だけを管理する。送信失敗時もログ側が
-// 立てた shutdownNoticed には触れない。
+// sendCommand は停止コマンドの送信状態だけを管理する。印を立てるのは送信が
+// 成功した後で、一度立てたら降ろさない。送信の前に立てて失敗したら降ろす、
+// という書き方だと 2 つの穴ができる。確定前に waitForServer が読むと失敗した
+// 送信が正常停止に見え、2 回目の送信失敗が 1 回目の成功を消す。
+//
+// 送信が成功してから印が立つまでの隙間に終了判定が走ると、意図した停止を
+// 取りこぼす。ただし今書いた stop が効くまでには JVM の停止処理が要るので、
+// その間にプロセスが消えてログも流し切っていることは実際には起こらない。
+// 起きたとしてもログ側の shutdownNoticed が同じ停止を拾う。
 func (runtime *serverRuntime) sendCommand(
 	command string,
 	send func(string) error,
 ) error {
-	isStop := isStopCommand(command)
-	if isStop {
-		runtime.stopCommandSent.Store(true)
-	}
 	err := send(command)
-	if err != nil && isStop {
-		runtime.stopCommandSent.Store(false)
+	if err == nil && isStopCommand(command) {
+		runtime.stopCommandSent.Store(true)
 	}
 	return err
 }


### PR DESCRIPTION
#42・#43 に対する Codex のレビューで見つかった論理競合の修正。

`serverRuntime.expectedExit`（`atomic.Bool`）を、停止コマンドの送信とログ側の確認という別々の根拠が非単調に書いていたのが原因。

## 競合 1: クラッシュ標識を停止コマンドが上書きする

クラッシュの後始末中に `stop` を送ると、ログ側が `crashNoticed` のため付けなかった印をコマンド側が無条件に立てる。終了コード 0 のクラッシュ（クラッシュレポートを書いた後、正常終了の経路を通る）が正常停止扱いになり、自動再起動されない。

## 競合 2: 送信失敗がログ側の印を消す

ログで `Stopping server` を確認して印が立った後、終了済みプロセスへの `stop` 送信が失敗すると、その取り消しがログ側の印まで消す。`waitForServer` はプロセス終了後もログ排出完了まで runtime を切り離さないので、その間に `sendCommand` が同じ runtime を掴める。正常停止が `ErrServerExited` になり、誤って自動再起動される。

## 競合 3: 送信結果の確定前に印が読まれる / 2 回目の失敗が 1 回目の成功を消す

上記の修正後に残っていた穴。印を送信の前に立てて失敗したら降ろす書き方だと、確定前に `waitForServer` が読めば失敗した送信が正常停止に見え、また 1 回目の送信成功のあと 2 回目が失敗すると取り消しが 1 回目の成功を消す（並行実行は不要、逐次で再現）。

## 変更

- 印を `stopCommandSent` と `shutdownNoticed` に分割。送信失敗でログ側の印に触れない
- `stopCommandSent` は単調にする。立てるのは送信成功後だけで、一度立てたら降ろさない
- `expectedExit()` を導出値にする: `(stopCommandSent || shutdownNoticed) && !crashNoticed`。クラッシュ標識を最後に引くので、標識が告知より後に届いても結論は変わらない
- `sendCommand` の印の管理を `serverRuntime` 側へ移し、送信関数を差し替えられるようにしてテスト可能にした

## 入れなかったもの

「`waitForServer` の終了判定と送信処理を同期する仕組み（in-flight 管理か `operation` ロックとの連携）」は入れていない。

単調化した後に残る窓は `send()` が nil を返してから `Store(true)` するまでの数ナノ秒で、ここで終了判定が走るには、その間に JVM が停止処理を終えてプロセスが消え、`logsDone` までのログ排出も完了している必要がある。いま書いた `stop` が効くまでには秒単位かかるので成立しない。成立しても、その停止は `Stopping server` を出すので `shutdownNoticed` が拾う。

一方でロックを増やすと、`Send` がブロックした場合に終了通知まで止まる新しい詰まり方を作る。CLAUDE.md の「堅牢な設計は不要、シンプルで可読性重視」に照らして割に合わないと判断した。

## 検証

回帰テスト 5 本。すべて変異で落ちることを確認済み。

| 変異 | 落ちるテスト |
|---|---|
| `expectedExit()` からクラッシュ標識の veto を外す | `TestRuntimeStopCommandDoesNotOverrideCrashNotice` / `TestRuntimeCrashNoticeAfterShutdownNoticeStillCrashes` |
| 送信失敗で両方の印を落とす（#43 時点の挙動） | `TestRuntimeFailedStopCommandKeepsShutdownNotice` |
| 送信前に印を立てて失敗で降ろす | `TestRuntimeFailedStopCommandLeavesNoMark` / `TestRuntimeFailedStopCommandKeepsEarlierSuccess` |

`go build` / `-tags en` build / `go vet` / `go test` / `go test -tags en` / `go test -race ./cmd/hso/ ./internal/ui/ ./internal/serverlog/` / `gofmt -l` すべて通過。

## 既知の制約（変更なし、ただし範囲が少し広がる）

`crashNoticed` はその世代の間落ちない。MOD やプラグインが標識と同じ文字列を非致命的に吐く環境では、以後の意図した停止もクラッシュ扱いになる。この修正でコンソールからの `stop` もその veto を受けるようになった（＝クラッシュ後の停止を正しく判定するための代償）。

競合 1・2 の修正は Codex（gpt-5.3-codex）、競合 3 と Nit は Claude。

🤖 Generated with [Claude Code](https://claude.com/claude-code)