### PR TITLE
feat: hso delete でサーバー一覧から登録を外せるようにする

### DIFF
--- a/cmd/hso/delete.go
+++ b/cmd/hso/delete.go
@@ -18,6 +18,7 @@ type deleteOptions struct {
 }
 
 type registrySaver func(registry.Registry) error
+type registryLoader func() (registry.Registry, error)
 
 func runDelete(args []string, input io.Reader, output io.Writer, terminal bool) error {
 	options, err := parseDeleteOptions(args)
@@ -28,14 +29,10 @@ func runDelete(args []string, input io.Reader, output io.Writer, terminal bool) 
 	if err != nil {
 		return err
 	}
-	servers, err := registry.Load(path)
-	if err != nil {
-		return err
-	}
 	choose := func(servers registry.Registry) (registry.Server, bool, error) {
 		return chooseServer(servers, pidfile.Running, msg.DeleteTitle)
 	}
-	return deleteFromRegistry(options, servers, terminal, input, output, choose, pidfile.Running,
+	return deleteFromRegistry(options, func() (registry.Registry, error) { return registry.Load(path) }, terminal, input, output, choose, pidfile.Running,
 		func(servers registry.Registry) error { return registry.Save(path, servers) })
 }
 
@@ -57,7 +54,7 @@ func parseDeleteOptions(args []string) (deleteOptions, error) {
 
 func deleteFromRegistry(
 	options deleteOptions,
-	servers registry.Registry,
+	load registryLoader,
 	terminal bool,
 	input io.Reader,
 	output io.Writer,
@@ -65,6 +62,10 @@ func deleteFromRegistry(
 	running func(string) (int, bool, error),
 	save registrySaver,
 ) error {
+	servers, err := load()
+	if err != nil {
+		return err
+	}
 	if len(servers.Servers) == 0 {
 		return msg.NoRegisteredServers()
 	}
@@ -91,12 +92,8 @@ func deleteFromRegistry(
 		}
 	}
 
-	status, err := inspectServer(server, running)
-	if err != nil {
+	if err := ensureStopped(server.Name, running); err != nil {
 		return err
-	}
-	if status.state == serverRunning {
-		return msg.CannotDeleteRunningServer(server.Name, status.pid)
 	}
 
 	if _, err := fmt.Fprintf(output, "%s\n\n", msg.DeleteTarget(server.Name, server.Config)); err != nil {
@@ -110,12 +107,43 @@ func deleteFromRegistry(
 		_, err := fmt.Fprintln(output, msg.Aborted)
 		return err
 	}
+	// 確認は人間が考えている間ずっと開いている。その間に別の端末が一覧を
+	// 変えている（setup で足す・別の delete で消す・start で起動する）ことが
+	// あるので、読み直してから消す。ロックは入れない。単一ユーザー向けの
+	// ツールで、他の書き込み経路も同じ方式のため、複雑さに見合わない。
+	// 読み直しから保存までのわずかな窓は残る。
+	targetName := server.Name
+	servers, err = load()
+	if err != nil {
+		return err
+	}
+	server, found := servers.Find(targetName)
+	if !found {
+		return msg.ServerNotRegistered(targetName)
+	}
+	if err := ensureStopped(server.Name, running); err != nil {
+		return err
+	}
 	servers.Remove(server.Name)
 	if err := save(servers); err != nil {
 		return err
 	}
 	_, err = fmt.Fprintln(output, msg.ServerDeleted(server.Name))
 	return err
+}
+
+// ensureStopped は起動中のサーバーを削除させないための検査。設定ファイルが
+// 見つからない登録でも起動中なら削除させたくないので、設定ファイルの有無を
+// 先に見る inspectServer は使わない。
+func ensureStopped(name string, running func(string) (int, bool, error)) error {
+	pid, alive, err := running(name)
+	if err != nil {
+		return err
+	}
+	if alive {
+		return msg.CannotDeleteRunningServer(name, pid)
+	}
+	return nil
 }
 
 func confirmDelete(input io.Reader, output io.Writer, terminal, yes bool) (bool, error) {

--- a/cmd/hso/delete.go
+++ b/cmd/hso/delete.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
+	"github.com/hijoushoku7/hijo-server-ops/internal/pidfile"
+	"github.com/hijoushoku7/hijo-server-ops/internal/registry"
+)
+
+type deleteOptions struct {
+	name string
+	yes  bool
+}
+
+type registrySaver func(registry.Registry) error
+
+func runDelete(args []string, input io.Reader, output io.Writer, terminal bool) error {
+	options, err := parseDeleteOptions(args)
+	if err != nil {
+		return err
+	}
+	path, err := registry.Path()
+	if err != nil {
+		return err
+	}
+	servers, err := registry.Load(path)
+	if err != nil {
+		return err
+	}
+	choose := func(servers registry.Registry) (registry.Server, bool, error) {
+		return chooseServer(servers, pidfile.Running, msg.DeleteTitle)
+	}
+	return deleteFromRegistry(options, servers, terminal, input, output, choose, pidfile.Running,
+		func(servers registry.Registry) error { return registry.Save(path, servers) })
+}
+
+func parseDeleteOptions(args []string) (deleteOptions, error) {
+	var options deleteOptions
+	for _, argument := range args {
+		switch argument {
+		case "-y", "--yes":
+			options.yes = true
+		default:
+			if options.name != "" || strings.HasPrefix(argument, "-") {
+				return deleteOptions{}, msg.DeleteArgumentsNotAllowed()
+			}
+			options.name = argument
+		}
+	}
+	return options, nil
+}
+
+func deleteFromRegistry(
+	options deleteOptions,
+	servers registry.Registry,
+	terminal bool,
+	input io.Reader,
+	output io.Writer,
+	choose serverChooser,
+	running func(string) (int, bool, error),
+	save registrySaver,
+) error {
+	if len(servers.Servers) == 0 {
+		return msg.NoRegisteredServers()
+	}
+	if options.name == "" && !terminal {
+		return msg.DeleteRequiresTerminal()
+	}
+
+	var server registry.Server
+	if options.name == "" {
+		var chosen bool
+		var err error
+		server, chosen, err = choose(servers)
+		if err != nil || !chosen {
+			return err
+		}
+	} else {
+		if err := registry.ValidateName(options.name); err != nil {
+			return err
+		}
+		var found bool
+		server, found = servers.Find(options.name)
+		if !found {
+			return msg.ServerNotRegistered(options.name)
+		}
+	}
+
+	status, err := inspectServer(server, running)
+	if err != nil {
+		return err
+	}
+	if status.state == serverRunning {
+		return msg.CannotDeleteRunningServer(server.Name, status.pid)
+	}
+
+	if _, err := fmt.Fprintf(output, "%s\n\n", msg.DeleteTarget(server.Name, server.Config)); err != nil {
+		return err
+	}
+	confirmed, err := confirmDelete(input, output, terminal, options.yes)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		_, err := fmt.Fprintln(output, msg.Aborted)
+		return err
+	}
+	servers.Remove(server.Name)
+	if err := save(servers); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(output, msg.ServerDeleted(server.Name))
+	return err
+}
+
+func confirmDelete(input io.Reader, output io.Writer, terminal, yes bool) (bool, error) {
+	if yes {
+		return true, nil
+	}
+	if !terminal {
+		return false, msg.DeleteRequiresConfirmation()
+	}
+	if _, err := io.WriteString(output, msg.DeleteConfirmPrompt); err != nil {
+		return false, err
+	}
+	line, err := bufio.NewReader(input).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, err
+	}
+	return strings.EqualFold(strings.TrimSpace(line), "y"), nil
+}

--- a/cmd/hso/delete.go
+++ b/cmd/hso/delete.go
@@ -112,14 +112,20 @@ func deleteFromRegistry(
 	// あるので、読み直してから消す。ロックは入れない。単一ユーザー向けの
 	// ツールで、他の書き込み経路も同じ方式のため、複雑さに見合わない。
 	// 読み直しから保存までのわずかな窓は残る。
-	targetName := server.Name
+	confirmedServer := server
 	servers, err = load()
 	if err != nil {
 		return err
 	}
-	server, found := servers.Find(targetName)
+	server, found := servers.Find(confirmedServer.Name)
 	if !found {
-		return msg.ServerNotRegistered(targetName)
+		return msg.ServerNotRegistered(confirmedServer.Name)
+	}
+	// 同じ名前でも中身が変わっていれば、ユーザーが確認していない登録を消す
+	// ことになる。確認をやり直させるより、何もせず終わって実行し直して
+	// もらうほうが単純で安全。
+	if server != confirmedServer {
+		return msg.DeleteTargetChanged(confirmedServer.Name)
 	}
 	if err := ensureStopped(server.Name, running); err != nil {
 		return err

--- a/cmd/hso/delete_test.go
+++ b/cmd/hso/delete_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
+	"github.com/hijoushoku7/hijo-server-ops/internal/registry"
+)
+
+func TestDeleteFromRegistry(t *testing.T) {
+	directory := t.TempDir()
+	configPath := filepath.Join(directory, "hso.toml")
+	if err := os.WriteFile(configPath, []byte("[server]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	server := registry.Server{Name: "Survival", Config: configPath}
+
+	tests := []struct {
+		name       string
+		options    deleteOptions
+		input      string
+		terminal   bool
+		running    bool
+		missing    bool
+		wantSaved  bool
+		wantError  string
+		wantOutput string
+	}{
+		{name: "名前指定で削除する", options: deleteOptions{name: "survival"}, input: "y\n", terminal: true, wantSaved: true, wantOutput: msg.ServerDeleted(server.Name)},
+		{name: "確認を拒否する", options: deleteOptions{name: "survival"}, input: "n\n", terminal: true, wantOutput: msg.Aborted},
+		{name: "確認を省略する", options: deleteOptions{name: "survival", yes: true}, wantSaved: true, wantOutput: msg.ServerDeleted(server.Name)},
+		{name: "起動中は拒否する", options: deleteOptions{name: "survival", yes: true}, running: true, wantError: "PID 4321"},
+		{name: "未登録名を拒否する", options: deleteOptions{name: "creative", yes: true}, wantError: "creative"},
+		{name: "設定ファイルがなくても削除する", options: deleteOptions{name: "survival", yes: true}, missing: true, wantSaved: true, wantOutput: msg.ServerDeleted(server.Name)},
+		{name: "端末なしでは確認できない", options: deleteOptions{name: "survival"}, wantError: msg.DeleteRequiresConfirmation().Error()},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := configPath
+			if test.missing {
+				path = filepath.Join(directory, "missing.toml")
+			}
+			servers := registry.Registry{Servers: []registry.Server{{Name: server.Name, Config: path}}}
+			var output bytes.Buffer
+			saved := false
+			err := deleteFromRegistry(test.options, servers, test.terminal, strings.NewReader(test.input), &output,
+				func(registry.Registry) (registry.Server, bool, error) {
+					t.Fatal("名前指定時にピッカーを呼んではいけない")
+					return registry.Server{}, false, nil
+				},
+				func(string) (int, bool, error) { return 4321, test.running, nil },
+				func(got registry.Registry) error {
+					saved = true
+					if len(got.Servers) != 0 {
+						t.Fatalf("保存する一覧 = %#v", got.Servers)
+					}
+					return nil
+				})
+			if test.wantError == "" && err != nil || test.wantError != "" && (err == nil || !strings.Contains(err.Error(), test.wantError)) {
+				t.Fatalf("err = %v", err)
+			}
+			if saved != test.wantSaved {
+				t.Fatalf("saved = %t, want %t", saved, test.wantSaved)
+			}
+			if test.wantOutput != "" && !strings.Contains(output.String(), test.wantOutput) {
+				t.Fatalf("output = %q", output.String())
+			}
+			if test.wantError == "" && !strings.Contains(output.String(), msg.DeleteTarget(server.Name, path)) {
+				t.Fatalf("output = %q", output.String())
+			}
+		})
+	}
+}
+
+func TestDeleteFromRegistryRejectsEmptyList(t *testing.T) {
+	err := deleteFromRegistry(deleteOptions{yes: true}, registry.Registry{}, false, strings.NewReader(""), &bytes.Buffer{}, nil, nil, nil)
+	if err == nil || err.Error() != msg.NoRegisteredServers().Error() {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestDeleteFromRegistryRequiresTerminalToChoose(t *testing.T) {
+	servers := registry.Registry{Servers: []registry.Server{{Name: "survival", Config: "/missing/hso.toml"}}}
+	err := deleteFromRegistry(deleteOptions{yes: true}, servers, false, strings.NewReader(""), &bytes.Buffer{}, nil, nil, nil)
+	if err == nil || err.Error() != msg.DeleteRequiresTerminal().Error() {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestParseDeleteOptions(t *testing.T) {
+	for _, args := range [][]string{{"one", "two"}, {"--unknown"}} {
+		if _, err := parseDeleteOptions(args); err == nil {
+			t.Fatalf("args = %#v はエラーになるべき", args)
+		}
+	}
+	for _, args := range [][]string{{"survival", "--yes"}, {"--yes", "survival"}} {
+		options, err := parseDeleteOptions(args)
+		if err != nil || !options.yes || options.name != "survival" {
+			t.Fatalf("args = %#v, options = %#v, err = %v", args, options, err)
+		}
+	}
+}
+
+func TestDeleteFromRegistryReturnsSaveError(t *testing.T) {
+	want := errors.New("save failed")
+	servers := registry.Registry{Servers: []registry.Server{{Name: "survival", Config: "/missing/hso.toml"}}}
+	err := deleteFromRegistry(deleteOptions{name: "survival", yes: true}, servers, false, strings.NewReader(""), &bytes.Buffer{}, nil,
+		func(string) (int, bool, error) { return 0, false, nil }, func(registry.Registry) error { return want })
+	if !errors.Is(err, want) {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/cmd/hso/delete_test.go
+++ b/cmd/hso/delete_test.go
@@ -131,6 +131,11 @@ func TestDeleteFromRegistryReloadsAfterConfirmation(t *testing.T) {
 		{name: "対象が削除済み", reloaded: registry.Registry{}, wantError: msg.ServerNotRegistered(target.Name).Error()},
 		{name: "対象が起動済み", reloaded: registry.Registry{Servers: []registry.Server{target}}, runningAfter: true, wantError: "PID 4321"},
 		{name: "別のサーバーが追加済み", reloaded: registry.Registry{Servers: []registry.Server{target, added}}, wantSaved: true, wantRemaining: []registry.Server{added}},
+		{
+			name:      "同じ名前で別の設定へ差し替え済み",
+			reloaded:  registry.Registry{Servers: []registry.Server{{Name: target.Name, Config: "/servers/other/hso.toml"}}},
+			wantError: msg.DeleteTargetChanged(target.Name).Error(),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/cmd/hso/delete_test.go
+++ b/cmd/hso/delete_test.go
@@ -37,6 +37,7 @@ func TestDeleteFromRegistry(t *testing.T) {
 		{name: "起動中は拒否する", options: deleteOptions{name: "survival", yes: true}, running: true, wantError: "PID 4321"},
 		{name: "未登録名を拒否する", options: deleteOptions{name: "creative", yes: true}, wantError: "creative"},
 		{name: "設定ファイルがなくても削除する", options: deleteOptions{name: "survival", yes: true}, missing: true, wantSaved: true, wantOutput: msg.ServerDeleted(server.Name)},
+		{name: "設定ファイルがなく起動中なら拒否する", options: deleteOptions{name: "survival", yes: true}, running: true, missing: true, wantError: "PID 4321"},
 		{name: "端末なしでは確認できない", options: deleteOptions{name: "survival"}, wantError: msg.DeleteRequiresConfirmation().Error()},
 	}
 	for _, test := range tests {
@@ -48,7 +49,7 @@ func TestDeleteFromRegistry(t *testing.T) {
 			servers := registry.Registry{Servers: []registry.Server{{Name: server.Name, Config: path}}}
 			var output bytes.Buffer
 			saved := false
-			err := deleteFromRegistry(test.options, servers, test.terminal, strings.NewReader(test.input), &output,
+			err := deleteFromRegistry(test.options, func() (registry.Registry, error) { return servers, nil }, test.terminal, strings.NewReader(test.input), &output,
 				func(registry.Registry) (registry.Server, bool, error) {
 					t.Fatal("名前指定時にピッカーを呼んではいけない")
 					return registry.Server{}, false, nil
@@ -78,7 +79,7 @@ func TestDeleteFromRegistry(t *testing.T) {
 }
 
 func TestDeleteFromRegistryRejectsEmptyList(t *testing.T) {
-	err := deleteFromRegistry(deleteOptions{yes: true}, registry.Registry{}, false, strings.NewReader(""), &bytes.Buffer{}, nil, nil, nil)
+	err := deleteFromRegistry(deleteOptions{yes: true}, func() (registry.Registry, error) { return registry.Registry{}, nil }, false, strings.NewReader(""), &bytes.Buffer{}, nil, nil, nil)
 	if err == nil || err.Error() != msg.NoRegisteredServers().Error() {
 		t.Fatalf("err = %v", err)
 	}
@@ -86,7 +87,7 @@ func TestDeleteFromRegistryRejectsEmptyList(t *testing.T) {
 
 func TestDeleteFromRegistryRequiresTerminalToChoose(t *testing.T) {
 	servers := registry.Registry{Servers: []registry.Server{{Name: "survival", Config: "/missing/hso.toml"}}}
-	err := deleteFromRegistry(deleteOptions{yes: true}, servers, false, strings.NewReader(""), &bytes.Buffer{}, nil, nil, nil)
+	err := deleteFromRegistry(deleteOptions{yes: true}, func() (registry.Registry, error) { return servers, nil }, false, strings.NewReader(""), &bytes.Buffer{}, nil, nil, nil)
 	if err == nil || err.Error() != msg.DeleteRequiresTerminal().Error() {
 		t.Fatalf("err = %v", err)
 	}
@@ -109,9 +110,65 @@ func TestParseDeleteOptions(t *testing.T) {
 func TestDeleteFromRegistryReturnsSaveError(t *testing.T) {
 	want := errors.New("save failed")
 	servers := registry.Registry{Servers: []registry.Server{{Name: "survival", Config: "/missing/hso.toml"}}}
-	err := deleteFromRegistry(deleteOptions{name: "survival", yes: true}, servers, false, strings.NewReader(""), &bytes.Buffer{}, nil,
+	err := deleteFromRegistry(deleteOptions{name: "survival", yes: true}, func() (registry.Registry, error) { return servers, nil }, false, strings.NewReader(""), &bytes.Buffer{}, nil,
 		func(string) (int, bool, error) { return 0, false, nil }, func(registry.Registry) error { return want })
 	if !errors.Is(err, want) {
 		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestDeleteFromRegistryReloadsAfterConfirmation(t *testing.T) {
+	target := registry.Server{Name: "survival", Config: "/servers/survival/hso.toml"}
+	added := registry.Server{Name: "creative", Config: "/servers/creative/hso.toml"}
+	tests := []struct {
+		name          string
+		reloaded      registry.Registry
+		runningAfter  bool
+		wantSaved     bool
+		wantError     string
+		wantRemaining []registry.Server
+	}{
+		{name: "対象が削除済み", reloaded: registry.Registry{}, wantError: msg.ServerNotRegistered(target.Name).Error()},
+		{name: "対象が起動済み", reloaded: registry.Registry{Servers: []registry.Server{target}}, runningAfter: true, wantError: "PID 4321"},
+		{name: "別のサーバーが追加済み", reloaded: registry.Registry{Servers: []registry.Server{target, added}}, wantSaved: true, wantRemaining: []registry.Server{added}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			loads := 0
+			load := func() (registry.Registry, error) {
+				loads++
+				if loads == 1 {
+					return registry.Registry{Servers: []registry.Server{target}}, nil
+				}
+				return test.reloaded, nil
+			}
+			runningChecks := 0
+			running := func(string) (int, bool, error) {
+				runningChecks++
+				return 4321, test.runningAfter && runningChecks == 2, nil
+			}
+			var saved registry.Registry
+			savedCalled := false
+			err := deleteFromRegistry(deleteOptions{name: target.Name, yes: true}, load, false, strings.NewReader(""), &bytes.Buffer{}, nil, running,
+				func(got registry.Registry) error {
+					savedCalled = true
+					saved = got
+					return nil
+				})
+			if test.wantError == "" && err != nil || test.wantError != "" && (err == nil || !strings.Contains(err.Error(), test.wantError)) {
+				t.Fatalf("err = %v", err)
+			}
+			if savedCalled != test.wantSaved {
+				t.Fatalf("saved = %t, want %t", savedCalled, test.wantSaved)
+			}
+			if test.wantSaved && len(saved.Servers) != len(test.wantRemaining) {
+				t.Fatalf("保存する一覧 = %#v, want %#v", saved.Servers, test.wantRemaining)
+			}
+			for index := range test.wantRemaining {
+				if saved.Servers[index] != test.wantRemaining[index] {
+					t.Fatalf("保存する一覧 = %#v, want %#v", saved.Servers, test.wantRemaining)
+				}
+			}
+		})
 	}
 }

--- a/cmd/hso/java.go
+++ b/cmd/hso/java.go
@@ -122,7 +122,7 @@ func runJavaChange(name string, output io.Writer, terminal bool) error {
 		return err
 	}
 	chooseRegistry := func(servers registry.Registry) (registry.Server, bool, error) {
-		return chooseServer(servers, pidfile.Running)
+		return chooseServer(servers, pidfile.Running, msg.StartTitle)
 	}
 	chooseInstallation := func(installed []javaenv.Installation, current string, running bool) (javaenv.Installation, bool, error) {
 		model := newJavaModel(installed, current, running)

--- a/cmd/hso/main.go
+++ b/cmd/hso/main.go
@@ -20,7 +20,7 @@ import (
 
 var version = "dev"
 
-const availableSubcommands = "setup, start, list (ls), java, version, update, uninstall"
+const availableSubcommands = "setup, start, list (ls), delete, java, version, update, uninstall"
 
 func main() {
 	if command, ok := process.SupervisorCommand(os.Args); ok {
@@ -57,6 +57,8 @@ func dispatchCommand(args []string, output io.Writer) (bool, error) {
 			name = args[1]
 		}
 		return true, runStart(name)
+	case "delete":
+		return true, runDelete(args[1:], os.Stdin, output, interactive())
 	case "java":
 		return true, runJava(args[1:], output, os.Stderr, interactive())
 	case "version":

--- a/cmd/hso/start.go
+++ b/cmd/hso/start.go
@@ -37,6 +37,7 @@ type startRow struct {
 
 type startModel struct {
 	rows     []startRow
+	title    string
 	cursor   int
 	selected registry.Server
 	chosen   bool
@@ -81,7 +82,7 @@ func (m *startModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *startModel) View() tea.View {
-	lines := []string{startTitleStyle.Render(msg.StartTitle), ""}
+	lines := []string{startTitleStyle.Render(m.title), ""}
 	nameWidth := 0
 	for _, row := range m.rows {
 		nameWidth = max(nameWidth, ansi.StringWidth(row.server.Name))
@@ -141,7 +142,7 @@ func runStartWithTerminal(name string, terminal bool) error {
 		return msg.StartRequiresTerminal()
 	}
 	choose := func(servers registry.Registry) (registry.Server, bool, error) {
-		return chooseServer(servers, pidfile.Running)
+		return chooseServer(servers, pidfile.Running, msg.StartTitle)
 	}
 	return startFromRegistry(name, servers, choose, pidfile.Running, launchConfig)
 }
@@ -200,6 +201,7 @@ func startFromRegistry(
 func chooseServer(
 	servers registry.Registry,
 	running func(string) (int, bool, error),
+	title string,
 ) (registry.Server, bool, error) {
 	rows := make([]startRow, 0, len(servers.Servers))
 	for _, server := range servers.Servers {
@@ -209,7 +211,7 @@ func chooseServer(
 		}
 		rows = append(rows, startRow{server: server, status: status})
 	}
-	model := &startModel{rows: rows}
+	model := &startModel{rows: rows, title: title}
 	if _, err := tea.NewProgram(model).Run(); err != nil {
 		return registry.Server{}, false, err
 	}

--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -349,6 +349,14 @@ func DuplicateServerName(name string) error {
 	return fmt.Errorf("duplicate server name ignoring case: %s", name)
 }
 
+func DuplicateServerConfig(name, path string) error {
+	return fmt.Errorf("config file is already registered as server %s: %s", name, path)
+}
+
+func ConfigAlreadyRegistered(name, path string) error {
+	return fmt.Errorf("config file is already registered as server %s: %s\nrun hso delete %s to remove it from the list", name, path, name)
+}
+
 func ReadRegistryFailed(err error, path string) error {
 	return fmt.Errorf("read server registry (%s): %w", path, err)
 }
@@ -499,16 +507,18 @@ func FindJavaFailed(err error) error {
 
 // Command line.
 const (
-	Lang             = "en"
-	ConfigFlagUsage  = "path to the config file"
-	Aborted          = "aborted"
-	ListNameHeader   = "Name"
-	ListStatusHeader = "Status"
-	ListPathHeader   = "Path"
-	ServerStopped    = "stopped"
-	ConfigNotFound   = "config not found"
-	EmptyServerList  = "No servers are registered. Run hso setup to register one."
-	StartTitle       = "Choose a server to start"
+	Lang                = "en"
+	ConfigFlagUsage     = "path to the config file"
+	Aborted             = "aborted"
+	ListNameHeader      = "Name"
+	ListStatusHeader    = "Status"
+	ListPathHeader      = "Path"
+	ServerStopped       = "stopped"
+	ConfigNotFound      = "config not found"
+	EmptyServerList     = "No servers are registered. Run hso setup to register one."
+	StartTitle          = "Choose a server to start"
+	DeleteTitle         = "Choose a server to delete"
+	DeleteConfirmPrompt = "Only this registration will be removed. hso.toml and the server directory contents will not be deleted.\nDelete it? [y/N]: "
 )
 
 func ServerRunning(pid int) string {
@@ -537,6 +547,30 @@ func StartArgumentsNotAllowed() error {
 
 func StartRequiresTerminal() error {
 	return errors.New("run start from a terminal when omitting the server name")
+}
+
+func DeleteArgumentsNotAllowed() error {
+	return errors.New("the delete subcommand accepts at most one server name and only the -y or --yes flag")
+}
+
+func DeleteTarget(name, path string) string {
+	return fmt.Sprintf("%s: %s\n%s: %s", ListNameHeader, name, ListPathHeader, path)
+}
+
+func DeleteRequiresTerminal() error {
+	return errors.New("run delete from a terminal when omitting the server name")
+}
+
+func DeleteRequiresConfirmation() error {
+	return errors.New("confirmation requires a terminal; rerun with -y or --yes")
+}
+
+func CannotDeleteRunningServer(name string, pid int) error {
+	return fmt.Errorf("server %s is running (PID %d); stop it before deleting it", name, pid)
+}
+
+func ServerDeleted(name string) string {
+	return fmt.Sprintf("removed server %s from the list", name)
 }
 
 func ServerNotRegistered(name string) error {

--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -569,6 +569,10 @@ func CannotDeleteRunningServer(name string, pid int) error {
 	return fmt.Errorf("server %s is running (PID %d); stop it before deleting it", name, pid)
 }
 
+func DeleteTargetChanged(name string) error {
+	return fmt.Errorf("the registration of server %s changed while you were confirming; run it again", name)
+}
+
 func ServerDeleted(name string) string {
 	return fmt.Sprintf("removed server %s from the list", name)
 }

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -347,6 +347,14 @@ func DuplicateServerName(name string) error {
 	return fmt.Errorf("サーバー名が大文字小文字を区別せず重複しています: %s", name)
 }
 
+func DuplicateServerConfig(name, path string) error {
+	return fmt.Errorf("設定ファイルはサーバー %s として登録済みです: %s", name, path)
+}
+
+func ConfigAlreadyRegistered(name, path string) error {
+	return fmt.Errorf("設定ファイルはサーバー %s として登録済みです: %s\n一覧から外すには hso delete %s を実行してください", name, path, name)
+}
+
 func ReadRegistryFailed(err error, path string) error {
 	return fmt.Errorf("サーバー一覧を読む (%s): %w", path, err)
 }
@@ -497,16 +505,18 @@ func FindJavaFailed(err error) error {
 
 // コマンドライン。
 const (
-	Lang             = "ja"
-	ConfigFlagUsage  = "設定ファイルのパス"
-	Aborted          = "中止しました"
-	ListNameHeader   = "名前"
-	ListStatusHeader = "状態"
-	ListPathHeader   = "パス"
-	ServerStopped    = "停止"
-	ConfigNotFound   = "設定が見つからない"
-	EmptyServerList  = "登録済みのサーバーはありません。hso setup で登録してください。"
-	StartTitle       = "起動するサーバーを選ぶ"
+	Lang                = "ja"
+	ConfigFlagUsage     = "設定ファイルのパス"
+	Aborted             = "中止しました"
+	ListNameHeader      = "名前"
+	ListStatusHeader    = "状態"
+	ListPathHeader      = "パス"
+	ServerStopped       = "停止"
+	ConfigNotFound      = "設定が見つからない"
+	EmptyServerList     = "登録済みのサーバーはありません。hso setup で登録してください。"
+	StartTitle          = "起動するサーバーを選ぶ"
+	DeleteTitle         = "削除するサーバーを選ぶ"
+	DeleteConfirmPrompt = "一覧からこの登録だけを外します。hso.toml とサーバーディレクトリの中身は削除しません。\n削除しますか？ [y/N]: "
 )
 
 func ServerRunning(pid int) string {
@@ -535,6 +545,30 @@ func StartArgumentsNotAllowed() error {
 
 func StartRequiresTerminal() error {
 	return errors.New("サーバー名を省略するには端末から実行してください")
+}
+
+func DeleteArgumentsNotAllowed() error {
+	return errors.New("delete サブコマンドに指定できる名前は1つまでで、フラグは -y または --yes だけです")
+}
+
+func DeleteTarget(name, path string) string {
+	return fmt.Sprintf("%s: %s\n%s: %s", ListNameHeader, name, ListPathHeader, path)
+}
+
+func DeleteRequiresTerminal() error {
+	return errors.New("サーバー名を省略するには端末から実行してください")
+}
+
+func DeleteRequiresConfirmation() error {
+	return errors.New("削除の確認には端末が必要です。-y または --yes を指定してください")
+}
+
+func CannotDeleteRunningServer(name string, pid int) error {
+	return fmt.Errorf("サーバー %s は起動中です（PID %d）。先に停止してから削除してください", name, pid)
+}
+
+func ServerDeleted(name string) string {
+	return fmt.Sprintf("サーバー %s を一覧から削除しました", name)
 }
 
 func ServerNotRegistered(name string) error {

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -567,6 +567,10 @@ func CannotDeleteRunningServer(name string, pid int) error {
 	return fmt.Errorf("サーバー %s は起動中です（PID %d）。先に停止してから削除してください", name, pid)
 }
 
+func DeleteTargetChanged(name string) error {
+	return fmt.Errorf("確認している間にサーバー %s の登録が変わりました。もう一度実行してください", name)
+}
+
 func ServerDeleted(name string) string {
 	return fmt.Sprintf("サーバー %s を一覧から削除しました", name)
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -23,6 +23,13 @@ type Server struct {
 
 // Add は重複を検査してサーバーを一覧へ加える。
 func (r *Registry) Add(server Server) error {
+	if name, found := r.NameForConfig(server.Config); found {
+		return msg.DuplicateServerConfig(name, server.Config)
+	}
+	return r.addWithoutConfigCheck(server)
+}
+
+func (r *Registry) addWithoutConfigCheck(server Server) error {
 	if err := ValidateName(server.Name); err != nil {
 		return err
 	}
@@ -31,6 +38,17 @@ func (r *Registry) Add(server Server) error {
 	}
 	r.Servers = append(r.Servers, server)
 	return nil
+}
+
+// Remove は大文字小文字を区別せず登録名を探して一覧から取り除く。
+func (r *Registry) Remove(name string) (Server, bool) {
+	for index, server := range r.Servers {
+		if strings.EqualFold(server.Name, name) {
+			r.Servers = append(r.Servers[:index], r.Servers[index+1:]...)
+			return server, true
+		}
+	}
+	return Server{}, false
 }
 
 // Find は大文字小文字を区別せず登録名を探す。
@@ -152,7 +170,9 @@ func (r Registry) NameForConfig(path string) (string, bool) {
 func validate(registry Registry) error {
 	var validated Registry
 	for _, server := range registry.Servers {
-		if err := validated.Add(server); err != nil {
+		// 既存のパス重複を Load で拒むと delete で修復できないため、
+		// ここでは名前に関する不変条件だけを検査する。
+		if err := validated.addWithoutConfigCheck(server); err != nil {
 			return err
 		}
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -207,3 +207,54 @@ func writeRegistry(t *testing.T, path, contents string) {
 		t.Fatal(err)
 	}
 }
+
+func TestAddRejectsDuplicateConfigPath(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "server", "..", "hso.toml")
+	servers := Registry{Servers: []Server{{Name: "survival", Config: filepath.Join(directory, "hso.toml")}}}
+	if err := servers.Add(Server{Name: "creative", Config: path}); err == nil || !strings.Contains(err.Error(), "survival") {
+		t.Fatalf("err = %v", err)
+	}
+	if len(servers.Servers) != 1 {
+		t.Fatalf("servers = %#v", servers.Servers)
+	}
+}
+
+func TestRemoveIgnoresCase(t *testing.T) {
+	servers := Registry{Servers: []Server{
+		{Name: "Survival", Config: "/one/hso.toml"},
+		{Name: "creative", Config: "/two/hso.toml"},
+	}}
+	removed, found := servers.Remove("survival")
+	if !found || removed.Name != "Survival" {
+		t.Fatalf("removed = %#v, found = %t", removed, found)
+	}
+	if len(servers.Servers) != 1 || servers.Servers[0].Name != "creative" {
+		t.Fatalf("servers = %#v", servers.Servers)
+	}
+}
+
+func TestRemoveKeepsListWhenNameDoesNotExist(t *testing.T) {
+	servers := Registry{Servers: []Server{{Name: "survival", Config: "/one/hso.toml"}}}
+	removed, found := servers.Remove("creative")
+	if found || removed != (Server{}) {
+		t.Fatalf("removed = %#v, found = %t", removed, found)
+	}
+	if len(servers.Servers) != 1 {
+		t.Fatalf("servers = %#v", servers.Servers)
+	}
+}
+
+func TestLoadAllowsDuplicateConfigPaths(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	writeRegistry(t, path, "[[servers]]\nname = \"survival\"\nconfig = \"/srv/hso.toml\"\n\n"+
+		"[[servers]]\nname = \"creative\"\nconfig = \"/srv/./hso.toml\"\n")
+
+	servers, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers.Servers) != 2 {
+		t.Fatalf("servers = %#v", servers.Servers)
+	}
+}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -31,6 +31,9 @@ func Run(configPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if name, found := servers.NameForConfig(path); found {
+		return "", msg.ConfigAlreadyRegistered(name, path)
+	}
 
 	model := newModel(path, servers)
 	if _, err := tea.NewProgram(model).Run(); err != nil {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -377,3 +377,26 @@ func TestRegisterServerSavesNameAndConfig(t *testing.T) {
 		t.Fatalf("servers = %#v", servers.Servers)
 	}
 }
+
+func TestRunRejectsRegisteredConfigBeforeWizard(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	configPath := filepath.Join(t.TempDir(), "hso.toml")
+	registryPath, err := registry.Path()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.Save(registryPath, registry.Registry{Servers: []registry.Server{
+		{Name: "survival", Config: configPath},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := Run(configPath)
+	if err == nil || !strings.Contains(err.Error(), "hso delete survival") {
+		t.Fatalf("created = %q, err = %v", created, err)
+	}
+	if _, statErr := os.Stat(configPath); !os.IsNotExist(statErr) {
+		t.Fatalf("設定ファイルを作ってはいけない: %v", statErr)
+	}
+}


### PR DESCRIPTION
Closes #71

## 背景

サーバー一覧（`~/.config/hso/config.toml`）に登録したサーバーを外す手段がなかった。また `hso.toml` を消してから `hso setup` をやり直すと、同じ設定ファイルのパスが別名で二重に登録できてしまっていた。

## 変更

### `hso delete [name] [-y|--yes]`

- 一覧の登録だけを外す。`hso.toml` とサーバーディレクトリの中身には触れない（確認画面でも明示）
- 名前を省略したときは `hso start` と同じピッカーで選ばせる。端末でなければエラー
- 起動中のサーバーは削除させない。設定ファイルが見つからない登録は掃除できないと意味がないので削除できる
- 削除対象の名前とパスを出してから `[y/N]` で確認する。`-y` / `--yes` で確認を飛ばす
- 状態判定は `hso list` と共有している `inspectServer` をそのまま使う

### パスの二重登録を拒む

- `registry.Add` が、すでに登録済みの設定ファイルパスと同じものを拒む（判定は既存の `NameForConfig`）
- ただし `Load` / `Save` の検証では拒まない。すでに重複した一覧を読めなくすると `hso delete` で直すことすらできなくなるため。名前の妥当性と名前重複という不変条件だけをこれまで通り検査する
- `setup` はウィザードに入る**前**に登録済みパスを検査する。最後まで進めさせてから、作った `hso.toml` を消して失敗する体験にしないため

## 確認

- `gofmt -l .` / `go vet ./...` / `go test ./...` / `go test -tags en ./...` すべて通過
- 実バイナリで `list` → `delete`（端末なし・`-y`・未登録名）→ `list` の動作を確認済み