### PR TITLE
feat: hjkl でもパネル移動とスクロールができるようにする

### DIFF
--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -18,17 +18,23 @@ func (model *Model) handleKey(message tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if model.exit != nil {
 		return model.handleExitKey(message)
 	}
+	// g/G は既存どおり設定専用にする。vim の gg/G を追加すると既存キーを
+	// 奪うため、先頭・末尾への移動には使わない。
+	if model.timeModal == nil && !model.settingsOpen &&
+		(message.String() == "g" || message.String() == "G") &&
+		!model.editingConsole() {
+		model.settingsOpen = true
+		model.settingCursor = 0
+		return model, nil
+	}
+	if !model.editingConsole() {
+		key = hjklArrowKey(key)
+	}
 	if model.timeModal != nil {
 		return model.handleTimeModalKey(key)
 	}
 	if model.settingsOpen {
 		return model.handleSettingsKey(key)
-	}
-	if (message.String() == "g" || message.String() == "G") &&
-		!model.editingConsole() {
-		model.settingsOpen = true
-		model.settingCursor = 0
-		return model, nil
 	}
 	if model.mode == modeSelect {
 		return model.handleSelectKey(key)
@@ -43,7 +49,7 @@ func (model *Model) handleKey(message tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (model *Model) handleExitKey(message tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	key := message.Key()
+	key := hjklArrowKey(message.Key())
 	// 立ち直った後は Enter で閉じるだけ。裏で復旧していても、落ちた事実を
 	// 読んで消す操作を挟ませる。表示側（exitModal・keybar）も restarted を
 	// 最初に見るので、判定の順番を合わせる。
@@ -99,6 +105,28 @@ func (model *Model) handleExitKey(message tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		}
 	}
 	return model, nil
+}
+
+// hjklArrowKey は修飾なしの vim 風移動キーだけを矢印へ読み替える。
+// Text は文字入力として二重に扱われないよう、変換時に捨てる。
+func hjklArrowKey(key tea.Key) tea.Key {
+	if key.Mod != 0 {
+		return key
+	}
+	switch key.Code {
+	case 'h':
+		key.Code = tea.KeyLeft
+	case 'j':
+		key.Code = tea.KeyDown
+	case 'k':
+		key.Code = tea.KeyUp
+	case 'l':
+		key.Code = tea.KeyRight
+	default:
+		return key
+	}
+	key.Text = ""
+	return key
 }
 
 func (model *Model) editingConsole() bool {

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -1,0 +1,166 @@
+package ui
+
+import (
+	"fmt"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestModelMovesBetweenPanelsWithHJKL(t *testing.T) {
+	tests := []struct {
+		name  string
+		start panel
+		key   rune
+		arrow rune
+	}{
+		{name: "左", start: panelLog, key: 'h', arrow: tea.KeyLeft},
+		{name: "下", start: panelChat, key: 'j', arrow: tea.KeyDown},
+		{name: "上", start: panelChat, key: 'k', arrow: tea.KeyUp},
+		{name: "右", start: panelChat, key: 'l', arrow: tea.KeyRight},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			vimModel := newTestModel()
+			vimModel.mode = modeSelect
+			vimModel.panel = test.start
+			arrowModel := newTestModel()
+			arrowModel.mode = modeSelect
+			arrowModel.panel = test.start
+
+			pressRune(vimModel, test.key)
+			_, _ = arrowModel.Update(tea.KeyPressMsg{Code: test.arrow})
+
+			if vimModel.panel != arrowModel.panel {
+				t.Fatalf("%c の移動先 = %d, 矢印の移動先 = %d",
+					test.key, vimModel.panel, arrowModel.panel)
+			}
+		})
+	}
+}
+
+func TestModelTypesHJKLInConsoleInput(t *testing.T) {
+	model := newTestModel()
+	for _, key := range "hjkl" {
+		pressRune(model, key)
+	}
+
+	if got := string(model.input); got != "hjkl" {
+		t.Fatalf("input = %q, want %q", got, "hjkl")
+	}
+	if model.panel != panelConsole || !model.editingConsole() {
+		t.Fatalf("panel = %d, mode = %d, focus = %d",
+			model.panel, model.mode, model.consoleFocus)
+	}
+}
+
+func TestModelUsesHJKLAsNavigationOnConsoleButtons(t *testing.T) {
+	model := newTestModel()
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	pressRune(model, 'h')
+
+	if got := string(model.input); got != "" {
+		t.Fatalf("input = %q, want empty", got)
+	}
+	if model.consoleFocus != consoleRestart {
+		t.Fatalf("consoleFocus = %d, want %d", model.consoleFocus, consoleRestart)
+	}
+}
+
+func TestModelScrollsChatAndLogWithJK(t *testing.T) {
+	tests := []struct {
+		name  string
+		panel panel
+	}{
+		{name: "Chat", panel: panelChat},
+		{name: "Log", panel: panelLog},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			model := newTestModel()
+			model.resize(80, 24)
+			model.mode = modeFocus
+			model.panel = test.panel
+			buffer, viewport := model.focusedBuffer()
+			for index := 0; index < viewport.height*3; index++ {
+				buffer.Add(logRecord{text: fmt.Sprintf("line %d", index)})
+			}
+
+			pressRune(model, 'k')
+			if offset := buffer.Offset(viewport); offset != 1 {
+				t.Fatalf("k の後の offset = %d, want 1", offset)
+			}
+			pressRune(model, 'j')
+			if offset := buffer.Offset(viewport); offset != 0 {
+				t.Fatalf("j の後の offset = %d, want 0", offset)
+			}
+		})
+	}
+}
+
+func TestModelDoesNotConvertModifiedHJKL(t *testing.T) {
+	model := newTestModel()
+	model.mode = modeSelect
+	model.panel = panelLog
+	_, _ = model.Update(tea.KeyPressMsg{Code: 'h', Mod: tea.ModCtrl})
+
+	if model.panel != panelLog {
+		t.Fatalf("Ctrl+h で panel = %d, want %d", model.panel, panelLog)
+	}
+}
+
+func TestHJKLArrowKeyClearsTextOnlyWhenConverted(t *testing.T) {
+	tests := []struct {
+		key  rune
+		want rune
+	}{
+		{key: 'h', want: tea.KeyLeft},
+		{key: 'j', want: tea.KeyDown},
+		{key: 'k', want: tea.KeyUp},
+		{key: 'l', want: tea.KeyRight},
+	}
+	for _, test := range tests {
+		got := hjklArrowKey(tea.Key{Code: test.key, Text: string(test.key)})
+		if got.Code != test.want || got.Text != "" {
+			t.Errorf("%c: key = %#v, want Code %d and empty Text",
+				test.key, got, test.want)
+		}
+	}
+
+	want := tea.Key{Code: 'h', Text: "h", Mod: tea.ModAlt}
+	if got := hjklArrowKey(want); got != want {
+		t.Fatalf("Alt+h = %#v, want %#v", got, want)
+	}
+}
+
+func TestModelUsesHJKLInExitView(t *testing.T) {
+	model := newTestModel()
+	model.resize(80, 24)
+	model.exit = &exitState{}
+	pressRune(model, 'l')
+	if model.exit.button != 1 {
+		t.Fatalf("l の後の button = %d, want 1", model.exit.button)
+	}
+	pressRune(model, 'h')
+	if model.exit.button != 0 {
+		t.Fatalf("h の後の button = %d, want 0", model.exit.button)
+	}
+
+	model.exit.closed = true
+	_, viewport := model.focusedBuffer()
+	for index := 0; index < viewport.height*3; index++ {
+		model.logs.Add(logRecord{text: fmt.Sprintf("line %d", index)})
+	}
+	pressRune(model, 'k')
+	if offset := model.logs.Offset(viewport); offset != 1 {
+		t.Fatalf("k の後の offset = %d, want 1", offset)
+	}
+	pressRune(model, 'j')
+	if offset := model.logs.Offset(viewport); offset != 0 {
+		t.Fatalf("j の後の offset = %d, want 0", offset)
+	}
+}
+
+func pressRune(model *Model, key rune) {
+	_, _ = model.Update(tea.KeyPressMsg{Code: key, Text: string(key)})
+}

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -737,6 +737,16 @@ func TestKeybarFitsMinimumWidth(t *testing.T) {
 				t.Fatal("settings did not open")
 			}
 		},
+		"timeModal": func(_ *testing.T, model *Model) {
+			model.settingsOpen = true
+			model.timeModal = &timeModalState{}
+		},
+		"exitModal": func(_ *testing.T, model *Model) {
+			model.exit = &exitState{}
+		},
+		"exitLogs": func(_ *testing.T, model *Model) {
+			model.exit = &exitState{closed: true}
+		},
 	}
 
 	for name, focus := range cases {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -272,19 +272,21 @@ func (model *Model) keybar() string {
 		}
 	case model.exit != nil && !model.exit.closed:
 		keys = [][2]string{
-			{"←→/Tab", msg.BarExitButton},
+			{"hl/←→/Tab", msg.BarExitButton},
 			{"Enter", msg.BarConfirm},
 			{"Esc", msg.BarReadLogs},
 			{"^C", msg.BarExit},
 		}
 	case model.exit != nil:
 		keys = [][2]string{
-			{"↑↓/Pg", msg.BarScroll},
+			{"kj/↑↓/Pg", msg.BarScroll},
 			{"Home/End", msg.BarEnds},
 			{"R", msg.BarRestart},
 			{"Q/Enter", msg.BarExit},
 		}
 	case model.timeModal != nil:
+		// 時刻入力だけは hjkl を併記しない。en の説明が長く、足すと最小幅で
+		// 末尾が切れる。Enter / Esc を ↵ / ^[ に縮めてまで載せる案内ではない。
 		keys = [][2]string{
 			{"←→", msg.BarTimeField},
 			{"↑↓", msg.BarTimeAdjust},
@@ -294,14 +296,14 @@ func (model *Model) keybar() string {
 		}
 	case model.settingsOpen:
 		keys = [][2]string{
-			{"↑↓", msg.BarItem},
-			{"←→", msg.BarValue},
+			{"kj/↑↓", msg.BarItem},
+			{"hl/←→", msg.BarValue},
 			{"Enter/Esc", msg.BarClose},
 			{"^C", msg.BarExit},
 		}
 	case model.mode == modeSelect:
 		keys = [][2]string{
-			{"←↑↓→", msg.BarSelectPanel},
+			{"hjkl/←↑↓→", msg.BarSelectPanel},
 			{"Enter", msg.BarFocus},
 			{"G", msg.BarSettings},
 			{"^C", msg.BarExit},
@@ -317,22 +319,22 @@ func (model *Model) keybar() string {
 		model.playerStage == playerStageCommands:
 		keys = [][2]string{
 			{"Esc", msg.BarBack},
-			{"↑↓", msg.BarCommand},
+			{"kj/↑↓", msg.BarCommand},
 			{"Enter", msg.BarPutInConsole},
 			{"^C", msg.BarExit},
 		}
 	case model.panel == panelPlayers:
 		keys = [][2]string{
 			{"Esc", msg.BarBackToSelect},
-			{"↑↓", msg.BarPlayer},
+			{"kj/↑↓", msg.BarPlayer},
 			{"Enter", msg.BarCommandList},
 			{"^C", msg.BarExit},
 		}
 	default:
 		keys = [][2]string{
 			{"Esc", msg.BarBackToSelect},
-			{"↑↓", msg.BarScroll},
-			{"PgUp/PgDn", msg.BarPage},
+			{"kj/↑↓", msg.BarScroll},
+			{"Pg", msg.BarPage},
 			{"End", msg.BarLatest},
 			{"^C", msg.BarExit},
 		}


### PR DESCRIPTION
Closes #49

## WHY

TUI の操作が矢印キー専用で、ホームポジションから手を離さないと画面を移動できない。
Chat / Log のスクロールも Players のカーソルも矢印しか受け付けないため、
コマンドを打ちながら画面を見て回る流れが毎回途切れていた。

## What

- 修飾なしの `h` / `j` / `k` / `l` を矢印として読み替える。変換は `handleKey` と
  `handleExitKey` の入口 1 か所だけで行い、各ハンドラは触らない。変換したときは
  `Text` を落として文字入力として二重に扱われないようにする
- Console の入力欄にいる間は変換しない。ここで hjkl が打てなくなるとコマンドが
  打てない。Tab で `[restart]` / `[stop]` へ移った状態は入力欄ではないので移動キー
  として扱う
- vim の `gg` / `G` は入れない。`g` / `G` は既存どおり設定モーダルを開く
- keybar の移動系の案内に hjkl を併記する。時刻入力だけは en の説明が長く、
  最小幅 72 桁で末尾が切れるため併記しない
- 選択モードの移動・Console 入力中の文字入力・ボタン選択中の移動・バッファの
  スクロール・修飾キー付きの非変換・終了モーダルをテストで固定