### PR TITLE
feat: hso から送った /tell を Chat ペインにも出す

### DIFF
--- a/internal/serverlog/parser.go
+++ b/internal/serverlog/parser.go
@@ -58,6 +58,7 @@ type Entry struct {
 	Kind            Kind
 	Timestamp       time.Time
 	TimestampSource TimestampSource
+	SentByHSO       bool
 	Raw             string
 	Message         string
 	Player          string
@@ -208,10 +209,40 @@ func IsCrashNotice(entry Entry) bool {
 func SentCommand(command string) Entry {
 	command = strings.TrimRight(command, "\r\n")
 	return Entry{
-		Kind:    KindCommand,
-		Message: command,
-		Command: command,
+		Kind:      KindCommand,
+		SentByHSO: true,
+		Message:   command,
+		Command:   command,
 	}
+}
+
+// Whisper はささやきコマンドから宛先と本文を取り出す。
+// 本文の前後の空白だけを除き、本文中の空白はそのまま残す。
+func Whisper(command string) (target, body string, ok bool) {
+	command = strings.TrimSpace(command)
+	command = strings.TrimPrefix(command, "/")
+
+	nameEnd := strings.IndexAny(command, " \t\r\n")
+	if nameEnd < 0 {
+		return "", "", false
+	}
+	switch command[:nameEnd] {
+	case "tell", "msg", "w":
+	default:
+		return "", "", false
+	}
+
+	remainder := strings.TrimLeft(command[nameEnd:], " \t\r\n")
+	targetEnd := strings.IndexAny(remainder, " \t\r\n")
+	if targetEnd < 0 {
+		return "", "", false
+	}
+	target = remainder[:targetEnd]
+	body = strings.TrimSpace(remainder[targetEnd:])
+	if target == "" || body == "" {
+		return "", "", false
+	}
+	return target, body, true
 }
 
 func extractLogFields(line string) (string, time.Time, TimestampSource) {

--- a/internal/serverlog/parser.go
+++ b/internal/serverlog/parser.go
@@ -242,6 +242,13 @@ func Whisper(command string) (target, body string, ok bool) {
 	if target == "" || body == "" {
 		return "", "", false
 	}
+	// @a[...] のセレクタは引数の中に空白を持てるので、最初の空白で切ると
+	// 宛先が途中で切れる。角括弧が閉じていない時点で切れたと分かるので、
+	// 誤った宛先と本文を Chat に出すくらいなら出さない。コマンドは入力
+	// どおり送られ、Log にも今までどおり残る。
+	if strings.Count(target, "[") != strings.Count(target, "]") {
+		return "", "", false
+	}
 	return target, body, true
 }
 

--- a/internal/serverlog/parser_test.go
+++ b/internal/serverlog/parser_test.go
@@ -244,6 +244,19 @@ func TestWhisper(t *testing.T) {
 			wantBody:   "hello  world",
 			wantOK:     true,
 		},
+		{
+			name:       "selector target",
+			command:    "tell @a[team=red] hi",
+			wantTarget: "@a[team=red]",
+			wantBody:   "hi",
+			wantOK:     true,
+		},
+		// 空白を含むセレクタは最初の空白で宛先が切れる。誤った宛先と
+		// 本文を Chat に出さないよう成立させない。
+		{
+			name:    "selector with spaces",
+			command: `tell @a[nbt={CustomName:'{"text":"A B"}'}] hi`,
+		},
 		{name: "without body", command: "tell bob"},
 		{name: "without target", command: "tell"},
 		{name: "other command", command: "say hello"},

--- a/internal/serverlog/parser_test.go
+++ b/internal/serverlog/parser_test.go
@@ -220,8 +220,52 @@ func TestSentCommand(t *testing.T) {
 	entry := SentCommand("say hello\n")
 
 	assertKind(t, entry, KindCommand)
-	if entry.Command != "say hello" || entry.Message != "say hello" {
+	if !entry.SentByHSO ||
+		entry.Command != "say hello" || entry.Message != "say hello" {
 		t.Fatalf("Entry = %#v", entry)
+	}
+}
+
+func TestWhisper(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    string
+		wantTarget string
+		wantBody   string
+		wantOK     bool
+	}{
+		{name: "tell", command: "tell bob hi", wantTarget: "bob", wantBody: "hi", wantOK: true},
+		{name: "msg with slash", command: "/msg bob hi", wantTarget: "bob", wantBody: "hi", wantOK: true},
+		{name: "w", command: "w bob hi", wantTarget: "bob", wantBody: "hi", wantOK: true},
+		{
+			name:       "keeps spaces in body",
+			command:    "tell bob hello  world",
+			wantTarget: "bob",
+			wantBody:   "hello  world",
+			wantOK:     true,
+		},
+		{name: "without body", command: "tell bob"},
+		{name: "without target", command: "tell"},
+		{name: "other command", command: "say hello"},
+		{name: "similar command", command: "telly bob hi"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			target, body, ok := Whisper(test.command)
+			if target != test.wantTarget || body != test.wantBody || ok != test.wantOK {
+				t.Fatalf(
+					"Whisper(%q) = (%q, %q, %t), want (%q, %q, %t)",
+					test.command,
+					target,
+					body,
+					ok,
+					test.wantTarget,
+					test.wantBody,
+					test.wantOK,
+				)
+			}
+		})
 	}
 }
 

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -803,6 +803,68 @@ func TestModelRecordsOnlySuccessfullySentCommands(t *testing.T) {
 	}
 }
 
+func TestModelRecordsSentWhisperInChatAndLog(t *testing.T) {
+	model := newTestModel()
+	_, _ = model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	action := Action{Kind: ActionSendCommand, Command: "tell bob hi"}
+
+	_, _ = model.Update(ActionResultMsg{Action: action})
+
+	if model.chat.Len() != 1 || model.logs.Len() != 1 {
+		t.Fatalf("chat = %d, logs = %d", model.chat.Len(), model.logs.Len())
+	}
+	chat := model.chat.At(0)
+	log := model.logs.At(0)
+	if chat.line() != "<→ bob> hi" {
+		t.Fatalf("chat = %q", chat.line())
+	}
+	if log.line() != "tell bob hi" {
+		t.Fatalf("log = %q", log.line())
+	}
+	if !chat.timestamp.Equal(log.timestamp) ||
+		chat.timestampSource != log.timestampSource {
+		t.Fatalf("timestamps differ: chat = %#v, log = %#v", chat, log)
+	}
+}
+
+func TestModelDoesNotRecordServerCommandInChat(t *testing.T) {
+	lines := []string{
+		"[12:34:56] [Server thread/INFO]: [alice: Stopping the server]",
+		"[12:34:56] [Server thread/INFO]: " +
+			"alice issued server command: tell bob hi",
+	}
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			model := newTestModel()
+			_, _ = model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+			_, _ = model.Update(LogMsg{Entry: serverlog.Parse(line)})
+
+			if model.chat.Len() != 0 {
+				t.Fatalf("chat = %q", model.chat.At(0).line())
+			}
+			if model.logs.Len() != 1 {
+				t.Fatalf("logs = %d", model.logs.Len())
+			}
+		})
+	}
+}
+
+func TestModelDoesNotRecordSentWhisperWithoutBodyInChat(t *testing.T) {
+	model := newTestModel()
+	_, _ = model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	action := Action{Kind: ActionSendCommand, Command: "tell bob"}
+
+	_, _ = model.Update(ActionResultMsg{Action: action})
+
+	if model.chat.Len() != 0 {
+		t.Fatalf("chat = %q", model.chat.At(0).line())
+	}
+	if model.logs.Len() != 1 || model.logs.At(0).line() != "tell bob" {
+		t.Fatalf("logs = %#v", model.logs)
+	}
+}
+
 func TestModelClearsServerMetricsOnRestart(t *testing.T) {
 	model := newTestModel()
 	_, _ = model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -113,7 +113,18 @@ func (model *Model) addLog(entry serverlog.Entry) {
 	case serverlog.KindChat:
 		model.chat.Add(newLogRecord(entry, entry.Chat))
 	case serverlog.KindCommand:
-		model.logs.Add(newLogRecord(entry, entry.Command))
+		record := newLogRecord(entry, entry.Command)
+		model.logs.Add(record)
+		if entry.SentByHSO {
+			// サーバーログ由来のささやきはバージョンや MOD で形式が変わるため
+			// 分類せず、SentCommand が印を付けた hso 自身の送信だけを扱う。
+			if target, body, ok := serverlog.Whisper(entry.Command); ok {
+				record.kind = serverlog.KindChat
+				record.player = "→ " + target
+				record.text = body
+				model.chat.Add(record)
+			}
+		}
 	default:
 		model.logs.Add(newLogRecord(entry, entry.Message))
 	}


### PR DESCRIPTION
Closes #46

## WHY

Players パネルから `tell` を選ぶと Console の入力欄に `tell <名前> ` が置かれ、
本文を書いて送れる。ところが送った結果は Kind が command になり Log ペインにしか
出ないため、自分が誰に何を囁いたのかが Chat の流れに残らず、会話として読み返せない。
相手の発言は Chat、自分のささやきは Log と分かれていて、やり取りが追えなかった。

## What

- `serverlog.Whisper` で `tell` / `msg` / `w`（先頭の `/` も可）から宛先と本文を
  取り出す。宛先か本文が欠けていれば成立させず、本文中の空白はそのまま残す
- `SentCommand` が付ける `SentByHSO` の印がある Entry だけを対象にする。サーバー
  ログ由来のコマンドは Chat に流さない。Log への記録は今までどおり残したうえで
  Chat にも 1 行足し、時刻は同じレコードから取って 2 つのペインでずれないようにする
- Chat の行は新しい Kind を足さず `KindChat` を使い回し、`<→ bob> hi` の形で出す
- サーバーのログ行に出るささやきの分類は変えない。バージョンや MOD で出力形式が
  変わり確証が取れないため。結果として同じささやきが二重に出ることもない