### PR TITLE
feat: サーバー名と hso のバージョンを画面に出す

### DIFF
--- a/cmd/hso/app.go
+++ b/cmd/hso/app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"path/filepath"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -22,7 +23,16 @@ func runTUI(configPath string, cfg config.Config) error {
 	save := func(settings ui.Settings) error {
 		return saveSettings(configPath, cfg, settings)
 	}
-	model := ui.New(actions, save, initialGeneration, settingsFrom(cfg))
+	model := ui.New(
+		actions,
+		save,
+		initialGeneration,
+		settingsFrom(cfg),
+		ui.ServerInfo{
+			Name:    serverDisplayName(configPath, cfg, registeredName),
+			Version: version,
+		},
+	)
 	program := tea.NewProgram(model, tea.WithContext(ctx))
 
 	controller := newServerController(ctx, cfg, program)
@@ -45,6 +55,20 @@ func runTUI(configPath string, cfg config.Config) error {
 		return nil
 	}
 	return programErr
+}
+
+func serverDisplayName(
+	configPath string,
+	cfg config.Config,
+	lookup func(string) (string, bool, error),
+) string {
+	if name, found, err := lookup(configPath); err == nil && found {
+		return name
+	}
+	if cfg.Server.WorkDir == "" {
+		return ""
+	}
+	return filepath.Base(cfg.Server.WorkDir)
 }
 
 func settingsFrom(cfg config.Config) ui.Settings {

--- a/cmd/hso/app.go
+++ b/cmd/hso/app.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"path/filepath"
+	"strings"
+	"unicode"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -57,18 +59,42 @@ func runTUI(configPath string, cfg config.Config) error {
 	return programErr
 }
 
+// displayNameRunes は画面に出す名前の上限。サーバー一覧の登録名と同じ長さに
+// 揃える。
+const displayNameRunes = 30
+
 func serverDisplayName(
 	configPath string,
 	cfg config.Config,
 	lookup func(string) (string, bool, error),
 ) string {
 	if name, found, err := lookup(configPath); err == nil && found {
-		return name
+		return sanitizeDisplayName(name)
 	}
 	if cfg.Server.WorkDir == "" {
 		return ""
 	}
-	return filepath.Base(cfg.Server.WorkDir)
+	return sanitizeDisplayName(filepath.Base(cfg.Server.WorkDir))
+}
+
+// sanitizeDisplayName は制御文字を落として長さを切る。ディレクトリ名は
+// registry.ValidateName を通っておらず、ESC や BEL も入りうる。この名前は
+// 端末のウィンドウタイトルとして OSC シーケンスの中へそのまま置かれるので、
+// 落とさないとファイル名でシーケンスを閉じて端末を操作できてしまう。
+// 一覧の登録名も、手で書き換えられた設定ファイルから来るため同じ扱いにする。
+func sanitizeDisplayName(name string) string {
+	cleaned := strings.TrimSpace(strings.Map(func(character rune) rune {
+		if unicode.IsControl(character) {
+			return -1
+		}
+		return character
+	}, name))
+
+	runes := []rune(cleaned)
+	if len(runes) > displayNameRunes {
+		return string(runes[:displayNameRunes])
+	}
+	return cleaned
 }
 
 func settingsFrom(cfg config.Config) ui.Settings {

--- a/cmd/hso/app_test.go
+++ b/cmd/hso/app_test.go
@@ -96,6 +96,30 @@ func TestServerDisplayName(t *testing.T) {
 				return "", false, nil
 			},
 		},
+		{
+			name:    "ディレクトリ名の制御文字を落とす",
+			workDir: "/srv/minecraft/ev\x1b]0;il\aserver",
+			want:    "ev]0;ilserver",
+			lookup: func(string) (string, bool, error) {
+				return "", false, nil
+			},
+		},
+		{
+			name:    "登録名の制御文字も落とす",
+			workDir: "/srv/minecraft/survival",
+			want:    "main-server",
+			lookup: func(string) (string, bool, error) {
+				return "main-\x07server", true, nil
+			},
+		},
+		{
+			name:    "長い名前は 30 文字で切る",
+			workDir: "/srv/minecraft/" + strings.Repeat("a", 40),
+			want:    strings.Repeat("a", 30),
+			lookup: func(string) (string, bool, error) {
+				return "", false, nil
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/hso/app_test.go
+++ b/cmd/hso/app_test.go
@@ -59,6 +59,64 @@ func TestReadServerOutputParsesLines(t *testing.T) {
 	}
 }
 
+func TestServerDisplayName(t *testing.T) {
+	tests := []struct {
+		name    string
+		workDir string
+		lookup  func(string) (string, bool, error)
+		want    string
+	}{
+		{
+			name:    "登録名を優先する",
+			workDir: "/srv/minecraft/survival",
+			want:    "main-server",
+			lookup: func(string) (string, bool, error) {
+				return "main-server", true, nil
+			},
+		},
+		{
+			name:    "未登録なら作業ディレクトリ名を使う",
+			workDir: "/srv/minecraft/creative",
+			want:    "creative",
+			lookup: func(string) (string, bool, error) {
+				return "", false, nil
+			},
+		},
+		{
+			name:    "一覧の読み取り失敗でも作業ディレクトリ名を使う",
+			workDir: "/srv/minecraft/modded",
+			want:    "modded",
+			lookup: func(string) (string, bool, error) {
+				return "", false, errors.New("一覧を読めません")
+			},
+		},
+		{
+			name: "作業ディレクトリも空なら空文字を返す",
+			lookup: func(string) (string, bool, error) {
+				return "", false, nil
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			const configPath = "/etc/hso.toml"
+			lookup := func(path string) (string, bool, error) {
+				if path != configPath {
+					t.Fatalf("lookup path = %q", path)
+				}
+				return test.lookup(path)
+			}
+			got := serverDisplayName(configPath, config.Config{
+				Server: config.Server{WorkDir: test.workDir},
+			}, lookup)
+			if got != test.want {
+				t.Fatalf("serverDisplayName() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestReadServerOutputUsesReceiveTimeWithoutLogTimestamp(t *testing.T) {
 	logs := make(chan serverlog.Entry, 1)
 	readServerOutput(strings.NewReader("plain output\n"), logs, nil)
@@ -420,7 +478,7 @@ func TestServerControllerSendsCommandsAndRestarts(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	actions := make(chan ui.Action, actionQueueSize)
-	model := ui.New(actions, nil, initialGeneration, ui.DefaultSettings())
+	model := ui.New(actions, nil, initialGeneration, ui.DefaultSettings(), ui.ServerInfo{})
 	program := tea.NewProgram(
 		model,
 		tea.WithContext(ctx),
@@ -575,7 +633,7 @@ func TestServerControllerKeepsJavaWarningOffStderr(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	actions := make(chan ui.Action, actionQueueSize)
-	model := ui.New(actions, nil, initialGeneration, ui.DefaultSettings())
+	model := ui.New(actions, nil, initialGeneration, ui.DefaultSettings(), ui.ServerInfo{})
 	program := tea.NewProgram(
 		model,
 		tea.WithContext(ctx),
@@ -686,7 +744,7 @@ func TestPumpLogsDrainsRemainingOutputBeforeDone(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	actions := make(chan ui.Action, 1)
-	model := ui.New(actions, nil, initialGeneration, ui.DefaultSettings())
+	model := ui.New(actions, nil, initialGeneration, ui.DefaultSettings(), ui.ServerInfo{})
 	program := tea.NewProgram(
 		model,
 		tea.WithContext(ctx),

--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -6,13 +6,36 @@ import (
 )
 
 func (model *Model) statsTitle() string {
-	title := fmt.Sprintf(
-		"hijo-server-ops · %s · uptime %s",
-		model.status,
-		formatUptime(model.metrics.Uptime),
-	)
+	name := model.info.Name
+	if name == "" {
+		name = "hijo-server-ops"
+	}
+	uptime := formatUptime(model.metrics.Uptime)
+	degraded := ""
 	if model.jvmMetricError != "" || model.memoryMetricError != "" {
-		title += " · metrics degraded"
+		degraded = " · metrics degraded"
+	}
+	title := fmt.Sprintf(
+		"%s · %s · uptime %s%s",
+		name,
+		model.status,
+		uptime,
+		degraded,
+	)
+	if model.info.Version != "" {
+		withVersion := fmt.Sprintf(
+			"%s · hso %s · %s · uptime %s%s",
+			name,
+			model.info.Version,
+			model.status,
+			uptime,
+			degraded,
+		)
+		// 複数端末を並べたときの識別と運転状況を優先し、
+		// 幅が足りないときはバージョン区画をまとめて省く。
+		if stringWidth(withVersion) <= max(0, model.layout.statsWidth-5) {
+			title = withVersion
+		}
 	}
 	return title
 }

--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"math"
+	"strings"
 )
 
 func (model *Model) statsTitle() string {
@@ -10,34 +11,41 @@ func (model *Model) statsTitle() string {
 	if name == "" {
 		name = "hijo-server-ops"
 	}
-	uptime := formatUptime(model.metrics.Uptime)
+	status := " · " + model.status
+	uptime := " · uptime " + formatUptime(model.metrics.Uptime)
+	version := ""
+	if model.info.Version != "" {
+		version = " · hso " + model.info.Version
+	}
 	degraded := ""
 	if model.jvmMetricError != "" || model.memoryMetricError != "" {
 		degraded = " · metrics degraded"
 	}
-	title := fmt.Sprintf(
-		"%s · %s · uptime %s%s",
-		name,
-		model.status,
-		uptime,
-		degraded,
-	)
-	if model.info.Version != "" {
-		withVersion := fmt.Sprintf(
-			"%s · hso %s · %s · uptime %s%s",
-			name,
-			model.info.Version,
-			model.status,
-			uptime,
-			degraded,
-		)
-		// 複数端末を並べたときの識別と運転状況を優先し、
-		// 幅が足りないときはバージョン区画をまとめて省く。
-		if stringWidth(withVersion) <= max(0, model.layout.statsWidth-5) {
-			title = withVersion
+
+	// タイトルは renderPanelLines が幅 - 5 で切り詰めるので、同じ幅で自分で
+	// 組み立てる。末尾から機械的に切られると、名前が長いだけで運転状況が
+	// 消えてしまう。落とす順はバージョン → uptime で、サーバー名と status・
+	// metrics degraded は最後まで残す。端末を並べたときに最初に要るのは
+	// どのサーバーかと、動いているかどうかのため。
+	budget := max(0, model.layout.statsWidth-5)
+	for _, tail := range []string{
+		version + status + uptime + degraded,
+		status + uptime + degraded,
+		status + degraded,
+	} {
+		if stringWidth(name)+stringWidth(tail) <= budget {
+			return name + tail
 		}
 	}
-	return title
+
+	// それでも入らないときは名前のほうを削る。
+	tail := status + degraded
+	nameWidth := budget - stringWidth(tail)
+	if nameWidth <= 0 {
+		// 名前を入れる余地が無い幅では運転状況だけ残す。
+		return strings.TrimPrefix(tail, " · ")
+	}
+	return truncate(name, nameWidth) + tail
 }
 
 func (model *Model) statsLines() []string {

--- a/internal/ui/dashboard_test.go
+++ b/internal/ui/dashboard_test.go
@@ -1,0 +1,89 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStatsTitleIncludesServerNameAndVersion(t *testing.T) {
+	model := New(
+		make(chan Action, 1),
+		nil,
+		0,
+		DefaultSettings(),
+		ServerInfo{Name: "survival", Version: "v1.2.3"},
+	)
+	model.resize(160, minimumHeight)
+
+	got := model.statsTitle()
+	if !strings.Contains(got, "survival · hso v1.2.3 · starting") {
+		t.Fatalf("title = %q", got)
+	}
+}
+
+func TestStatsTitleFallsBackToProductName(t *testing.T) {
+	model := New(
+		make(chan Action, 1),
+		nil,
+		0,
+		DefaultSettings(),
+		ServerInfo{Version: "dev"},
+	)
+	model.resize(160, minimumHeight)
+
+	if got := model.statsTitle(); !strings.HasPrefix(got, "hijo-server-ops · hso dev · starting") {
+		t.Fatalf("title = %q", got)
+	}
+}
+
+func TestStatsTitleDropsVersionOnNarrowTerminal(t *testing.T) {
+	model := New(
+		make(chan Action, 1),
+		nil,
+		0,
+		DefaultSettings(),
+		ServerInfo{Name: "survival", Version: "v1.2.3"},
+	)
+	model.resize(minimumWidth, minimumHeight)
+
+	got := model.statsTitle()
+	if strings.Contains(got, "hso v1.2.3") ||
+		!strings.Contains(got, "survival") ||
+		!strings.Contains(got, "starting") {
+		t.Fatalf("title = %q", got)
+	}
+}
+
+func TestStatsTitleKeepsMetricsDegraded(t *testing.T) {
+	model := New(
+		make(chan Action, 1),
+		nil,
+		0,
+		DefaultSettings(),
+		ServerInfo{Name: "survival", Version: "dev"},
+	)
+	model.resize(160, minimumHeight)
+	model.jvmMetricError = "unavailable"
+
+	if got := model.statsTitle(); !strings.Contains(got, "metrics degraded") {
+		t.Fatalf("title = %q", got)
+	}
+}
+
+func TestWindowTitleIncludesServerName(t *testing.T) {
+	model := New(
+		make(chan Action, 1),
+		nil,
+		0,
+		DefaultSettings(),
+		ServerInfo{Name: "survival", Version: "dev"},
+	)
+	if got := model.View().WindowTitle; got != "survival · hijo-server-ops" {
+		t.Fatalf("window title = %q", got)
+	}
+
+	model.info.Name = ""
+	if got := model.View().WindowTitle; got != "hijo-server-ops" {
+		t.Fatalf("fallback window title = %q", got)
+	}
+}

--- a/internal/ui/dashboard_test.go
+++ b/internal/ui/dashboard_test.go
@@ -54,6 +54,29 @@ func TestStatsTitleDropsVersionOnNarrowTerminal(t *testing.T) {
 	}
 }
 
+// TestStatsTitleTruncatesLongNameToKeepStatus は、登録名が長いだけで運転状況が
+// 消えないことを見る。名前は 30 文字まで登録できるのに対し、最小幅の Stats の
+// タイトルは 29 桁しかない。
+func TestStatsTitleTruncatesLongNameToKeepStatus(t *testing.T) {
+	model := New(
+		make(chan Action, 1),
+		nil,
+		0,
+		DefaultSettings(),
+		ServerInfo{Name: strings.Repeat("a", 30), Version: "v1.2.3"},
+	)
+	model.resize(minimumWidth, minimumHeight)
+
+	got := model.statsTitle()
+	if !strings.Contains(got, "starting") || !strings.HasPrefix(got, "a") {
+		t.Fatalf("title = %q", got)
+	}
+	if width := stringWidth(got); width > model.layout.statsWidth-5 {
+		t.Fatalf("title = %q, width = %d, budget = %d",
+			got, width, model.layout.statsWidth-5)
+	}
+}
+
 func TestStatsTitleKeepsMetricsDegraded(t *testing.T) {
 	model := New(
 		make(chan Action, 1),

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -32,6 +32,12 @@ type Action struct {
 	Command string
 }
 
+// ServerInfo は画面に出す識別情報。表示専用で、取れなくても動作に影響しない。
+type ServerInfo struct {
+	Name    string
+	Version string
+}
+
 type LogMsg struct {
 	Generation uint64
 	Entry      serverlog.Entry
@@ -93,6 +99,7 @@ type ActionResultMsg struct {
 type Model struct {
 	layout layout
 	status string
+	info   ServerInfo
 	// runErr は現世代で最初に起きた終了原因。後続の終了通知でも上書きせず、
 	// ServerStartedMsg で復旧したときだけ消す。
 	runErr            error
@@ -173,11 +180,13 @@ func New(
 	save func(Settings) error,
 	generation uint64,
 	settings Settings,
+	info ServerInfo,
 ) *Model {
 	applyTheme(settings)
 	startedAt := time.Now()
 	model := &Model{
 		status:     "starting",
+		info:       info,
 		actions:    actions,
 		save:       save,
 		generation: generation,

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -412,7 +412,7 @@ func TestModelNormalExitCountdownQuitsAfterDeadline(t *testing.T) {
 
 func TestModelExitModalKeysAndStoppedMode(t *testing.T) {
 	actions := make(chan Action, 1)
-	model := New(actions, nil, 1, DefaultSettings())
+	model := New(actions, nil, 1, DefaultSettings(), ServerInfo{})
 	model.resize(80, 24)
 	_, _ = model.Update(ProcessExitedMsg{Err: errors.New("crashed"), ExitCode: 1})
 
@@ -491,7 +491,7 @@ func TestModelServerStartedClearsExitAndUpdatesRestartTracker(t *testing.T) {
 
 func TestModelSendsBoundedCommandInput(t *testing.T) {
 	actions := make(chan Action, 1)
-	model := New(actions, nil, 0, DefaultSettings())
+	model := New(actions, nil, 0, DefaultSettings(), ServerInfo{})
 
 	_, _ = model.Update(tea.KeyPressMsg{Text: strings.Repeat("a", maxInputRunes+10)})
 	if len(model.input) != maxInputRunes {
@@ -511,7 +511,7 @@ func TestModelSendsBoundedCommandInput(t *testing.T) {
 
 func TestModelSelectsRestartAndStopWithTab(t *testing.T) {
 	actions := make(chan Action, 1)
-	model := New(actions, nil, 0, DefaultSettings())
+	model := New(actions, nil, 0, DefaultSettings(), ServerInfo{})
 
 	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 	if model.consoleFocus != consoleRestart {
@@ -823,7 +823,7 @@ func TestModelClearsServerMetricsOnRestart(t *testing.T) {
 }
 
 func TestModelIgnoresMessagesFromPreviousServer(t *testing.T) {
-	model := New(make(chan Action, 1), nil, 2, DefaultSettings())
+	model := New(make(chan Action, 1), nil, 2, DefaultSettings(), ServerInfo{})
 	_, _ = model.Update(MetricsMsg{
 		Generation: 1,
 		Memory: procstats.Memory{
@@ -914,7 +914,7 @@ func TestModelScrollsPlayersFromTheTop(t *testing.T) {
 
 func TestModelPutsPlayerCommandIntoTheConsole(t *testing.T) {
 	actions := make(chan Action, 4)
-	model := New(actions, nil, 0, DefaultSettings())
+	model := New(actions, nil, 0, DefaultSettings(), ServerInfo{})
 	_, _ = model.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
 	for _, name := range []string{"alice", "bob"} {
 		_, _ = model.Update(LogMsg{Entry: serverlog.Entry{
@@ -1134,7 +1134,7 @@ func TestModelViewKeepsRectangularWithThreeTopPanels(t *testing.T) {
 }
 
 func newTestModel() *Model {
-	return New(make(chan Action, 8), nil, 0, DefaultSettings())
+	return New(make(chan Action, 8), nil, 0, DefaultSettings(), ServerInfo{})
 }
 
 func modelLogViewport(model *Model) bufferViewport {
@@ -1218,7 +1218,7 @@ func TestGraphRangeAddsMarginAndReportsUnavailable(t *testing.T) {
 
 func TestModelRestartAnimatesUntilServerStarts(t *testing.T) {
 	actions := make(chan Action, 1)
-	model := New(actions, nil, 1, DefaultSettings())
+	model := New(actions, nil, 1, DefaultSettings(), ServerInfo{})
 	model.resize(80, 24)
 	model.consoleFocus = consoleRestart
 
@@ -1253,7 +1253,7 @@ func TestModelRestartAnimatesUntilServerStarts(t *testing.T) {
 
 func TestModelExitModalShowsRestartProgressAndFailure(t *testing.T) {
 	actions := make(chan Action, 1)
-	model := New(actions, nil, 1, DefaultSettings())
+	model := New(actions, nil, 1, DefaultSettings(), ServerInfo{})
 	model.resize(80, 24)
 	_, _ = model.Update(ProcessExitedMsg{Err: errors.New("crashed"), ExitCode: 1})
 
@@ -1506,7 +1506,7 @@ func TestModelKeepsPartiallyAvailableHeapForExitModal(t *testing.T) {
 func newAutoRestartModel(actions chan Action) *Model {
 	settings := DefaultSettings()
 	settings.AutoRestart = true
-	model := New(actions, nil, 0, settings)
+	model := New(actions, nil, 0, settings, ServerInfo{})
 	model.resize(80, 24)
 	return model
 }

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -18,7 +18,7 @@ func TestSettingsModalOpensWithGAndChangesFrameColor(t *testing.T) {
 		saved = append(saved, settings)
 		return nil
 	}
-	model := New(make(chan Action, 1), save, 0, DefaultSettings())
+	model := New(make(chan Action, 1), save, 0, DefaultSettings(), ServerInfo{})
 	_, _ = model.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
 	// Console フォーカス中の g は文字入力。
 	_, _ = model.Update(tea.KeyPressMsg{Code: 'g', Text: "g"})
@@ -67,7 +67,7 @@ func TestSettingsAreSavedEveryTimeTheModalCloses(t *testing.T) {
 	// 容量 0 の相当として、詰まったままのキューを渡す。
 	actions := make(chan Action, 1)
 	actions <- Action{Kind: ActionRestart}
-	model := New(actions, save, 0, DefaultSettings())
+	model := New(actions, save, 0, DefaultSettings(), ServerInfo{})
 	_, _ = model.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
 	model.busy = true
 	// Console の入力欄から離れないと G は文字入力になる。
@@ -90,7 +90,7 @@ func TestSettingsAreSavedEveryTimeTheModalCloses(t *testing.T) {
 func TestSettingsSaveFailureShowsStatus(t *testing.T) {
 	t.Cleanup(func() { applyTheme(DefaultSettings()) })
 	save := func(Settings) error { return errors.New("書けません") }
-	model := New(make(chan Action, 1), save, 0, DefaultSettings())
+	model := New(make(chan Action, 1), save, 0, DefaultSettings(), ServerInfo{})
 	_, _ = model.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
 	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 
@@ -106,7 +106,7 @@ func TestSettingsSaveFailureShowsStatus(t *testing.T) {
 func TestSettingsModalShowsSectionHeadings(t *testing.T) {
 	t.Cleanup(func() { applyTheme(DefaultSettings()) })
 	model := New(make(chan Action, 1), func(Settings) error { return nil },
-		0, DefaultSettings())
+		0, DefaultSettings(), ServerInfo{})
 	_, _ = model.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
 	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	_, _ = model.Update(tea.KeyPressMsg{Code: 'G', Text: "G"})
@@ -177,7 +177,7 @@ func TestSettingsToggleAutoRestart(t *testing.T) {
 		saved = append(saved, settings)
 		return nil
 	}
-	model := New(make(chan Action, 1), save, 0, DefaultSettings())
+	model := New(make(chan Action, 1), save, 0, DefaultSettings(), ServerInfo{})
 	_, _ = model.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
 	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	_, _ = model.Update(tea.KeyPressMsg{Code: 'G', Text: "G"})

--- a/internal/ui/timezone_test.go
+++ b/internal/ui/timezone_test.go
@@ -74,7 +74,7 @@ func TestReopenAndConfirmKeepsOffset(t *testing.T) {
 	for _, offset := range []int{0, 30, 60, 90, -90, -690, 720} {
 		settings := DefaultSettings()
 		settings.TimeOffsetMinutes = offset
-		model := New(make(chan Action, 1), func(Settings) error { return nil }, 0, settings)
+		model := New(make(chan Action, 1), func(Settings) error { return nil }, 0, settings, ServerInfo{})
 		model.resize(100, 40)
 
 		model.openTimeModal()
@@ -98,7 +98,7 @@ func TestReopenAndConfirmKeepsOffset(t *testing.T) {
 func TestConfirmIgnoresClockDriftWhileOpen(t *testing.T) {
 	settings := DefaultSettings()
 	settings.TimeOffsetMinutes = 60
-	model := New(make(chan Action, 1), func(Settings) error { return nil }, 0, settings)
+	model := New(make(chan Action, 1), func(Settings) error { return nil }, 0, settings, ServerInfo{})
 	model.resize(100, 40)
 
 	// 30 分前に開いたモーダルを、そのときの openTimeModal が作るとおりに
@@ -118,7 +118,7 @@ func TestConfirmIgnoresClockDriftWhileOpen(t *testing.T) {
 // TestConfirmAppliesEditedHours は編集した分だけがオフセットに乗ることを
 // 見る。↑ 1 回で 1 時間、分のトグルで 30 分。
 func TestConfirmAppliesEditedHours(t *testing.T) {
-	model := New(make(chan Action, 1), func(Settings) error { return nil }, 0, DefaultSettings())
+	model := New(make(chan Action, 1), func(Settings) error { return nil }, 0, DefaultSettings(), ServerInfo{})
 	model.resize(100, 40)
 
 	model.openTimeModal()
@@ -152,7 +152,7 @@ func TestTimeOffsetForStaysInRange(t *testing.T) {
 }
 
 func TestTimeModalOpensFromSettingsAndHandlesKeys(t *testing.T) {
-	model := New(make(chan Action, 1), nil, 0, DefaultSettings())
+	model := New(make(chan Action, 1), nil, 0, DefaultSettings(), ServerInfo{})
 	model.resize(100, 40)
 	model.settingsOpen = true
 	model.settingCursor = len(settingItems) - 1
@@ -206,7 +206,7 @@ func TestTimeModalOKSavesAndInvalidatesExistingLogTimestamps(t *testing.T) {
 	model := New(make(chan Action, 1), func(settings Settings) error {
 		saved = append(saved, settings)
 		return nil
-	}, 0, DefaultSettings())
+	}, 0, DefaultSettings(), ServerInfo{})
 	model.resize(100, 40)
 	timestamp := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
 	record := logRecord{
@@ -246,7 +246,7 @@ func TestTimeModalOKSavesAndInvalidatesExistingLogTimestamps(t *testing.T) {
 func TestExitModalUsesTimeOffset(t *testing.T) {
 	settings := DefaultSettings()
 	settings.TimeOffsetMinutes = 90
-	model := New(make(chan Action, 1), nil, 0, settings)
+	model := New(make(chan Action, 1), nil, 0, settings, ServerInfo{})
 	model.resize(100, 40)
 	model.exit = &exitState{
 		exitedAt: time.Date(2026, 8, 8, 23, 15, 0, 0, time.UTC),

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -92,8 +92,15 @@ func (model *Model) View() tea.View {
 
 	view := tea.NewView(content)
 	view.AltScreen = true
-	view.WindowTitle = "hijo-server-ops"
+	view.WindowTitle = model.windowTitle()
 	return view
+}
+
+func (model *Model) windowTitle() string {
+	if model.info.Name == "" {
+		return "hijo-server-ops"
+	}
+	return model.info.Name + " · hijo-server-ops"
 }
 
 func (model *Model) consoleLine() string {


### PR DESCRIPTION
Closes #55

## WHY

サーバーは複数登録して使えるのに、TUI にはどのサーバーを見ているのかが出ていない。
端末を並べると区別が付かず、restart や stop を別のサーバーで押しかねない。
hso のバージョンも画面のどこにも無く、`hso version` を打たないと目の前の画面が
どのバージョンなのか分からなかった。

## What

- Stats のタイトルを `<サーバー名> · hso <version> · <status> · uptime <t>` にする
- 名前はサーバー一覧の登録名、無ければ workdir のベース名。一覧の読み取りに失敗
  しても握り潰して起動は続ける。表示用の付加情報が主機能を止めないため
- 幅が足りないときは `hso <version>` の区画をまとめて省き、サーバー名と status を
  最後まで残す。Stats の幅は狭く、最小端末幅では全部は入らない
- 端末のウィンドウタイトルにもサーバー名を出す
- 表示に使う識別情報は `ui.ServerInfo` にまとめ、`ui.New` の引数で渡す