### PR TITLE
feat: bash / zsh / fish のシェル補完を追加する

### DIFF
--- a/cmd/hso/completion.go
+++ b/cmd/hso/completion.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/hijoushoku7/hijo-server-ops/internal/completion"
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
+	"github.com/hijoushoku7/hijo-server-ops/internal/registry"
+)
+
+func runComplete(words []string, output io.Writer) {
+	var servers []registry.Server
+	if path, err := registry.Path(); err == nil {
+		if loaded, err := registry.Load(path); err == nil {
+			servers = loaded.Servers
+		}
+	}
+	for _, candidate := range completion.Candidates(words, servers) {
+		if candidate.Description == "" {
+			_, _ = fmt.Fprintln(output, candidate.Value)
+		} else {
+			_, _ = fmt.Fprintf(output, "%s\t%s\n", candidate.Value, candidate.Description)
+		}
+	}
+}
+
+func runCompletion(args []string, output io.Writer) error {
+	if len(args) != 1 {
+		return msg.CompletionArgumentsInvalid()
+	}
+	script, ok := completion.Script(args[0])
+	if !ok {
+		return msg.UnsupportedCompletionShell(args[0])
+	}
+	_, err := io.WriteString(output, script)
+	return err
+}

--- a/cmd/hso/completion_test.go
+++ b/cmd/hso/completion_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCompleteWritesTabSeparatedCandidates(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	var output bytes.Buffer
+	handled, err := dispatchCommand([]string{"__complete", "hso", "java", ""}, &output)
+	if err != nil || !handled {
+		t.Fatalf("handled = %t, err = %v", handled, err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(output.String()), "\n") {
+		if !strings.Contains(line, "\t") {
+			t.Errorf("候補がタブ区切りでない: %q", line)
+		}
+	}
+}
+
+func TestCompleteIgnoresBrokenRegistry(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	path := configHome + "/hso/config.toml"
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("broken = ["), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	handled, err := dispatchCommand([]string{"__complete", "hso", ""}, &output)
+	if err != nil || !handled {
+		t.Fatalf("handled = %t, err = %v", handled, err)
+	}
+	if !strings.Contains(output.String(), "setup\t") || strings.Contains(output.String(), "broken") {
+		t.Fatalf("output = %q", output.String())
+	}
+}
+
+func TestCompletionCommandPrintsEmbeddedScript(t *testing.T) {
+	var output bytes.Buffer
+	handled, err := dispatchCommand([]string{"completion", "bash"}, &output)
+	if err != nil || !handled {
+		t.Fatalf("handled = %t, err = %v", handled, err)
+	}
+	if !strings.Contains(output.String(), "hso __complete") {
+		t.Fatalf("output = %q", output.String())
+	}
+}

--- a/cmd/hso/main.go
+++ b/cmd/hso/main.go
@@ -36,6 +36,10 @@ func main() {
 }
 
 func dispatchCommand(args []string, output io.Writer) (bool, error) {
+	if len(args) > 0 && args[0] == "__complete" {
+		runComplete(args[1:], output)
+		return true, nil
+	}
 	// 引数なしの hso は何も起動せずヘルプを出す。設定を読んで起動する経路は
 	// start か -config に集約し、打ち間違いでセットアップが始まらないようにする。
 	if len(args) == 0 {
@@ -73,6 +77,8 @@ func dispatchCommand(args []string, output io.Writer) (bool, error) {
 		return true, runDelete(args[1:], os.Stdin, output, interactive())
 	case "java":
 		return true, runJava(args[1:], output, os.Stderr, interactive())
+	case "completion":
+		return true, runCompletion(args[1:], output)
 	case "version":
 		if len(args) != 1 {
 			return true, msg.VersionArgumentsNotAllowed()

--- a/cmd/hso/main_test.go
+++ b/cmd/hso/main_test.go
@@ -114,7 +114,7 @@ func TestRunExistingConfigBranches(t *testing.T) {
 func TestCommandHelpListsEveryCommand(t *testing.T) {
 	for _, command := range []string{
 		"setup", "start", "list", "ls", "delete",
-		"java change", "java list", "version", "update", "uninstall", "help",
+		"java change", "java list", "completion", "version", "update", "uninstall", "help",
 	} {
 		if !strings.Contains(msg.CommandHelp, command) {
 			t.Errorf("ヘルプに %q がない", command)

--- a/cmd/hso/uninstall.go
+++ b/cmd/hso/uninstall.go
@@ -351,23 +351,33 @@ func removeUninstallTargets(plan uninstallPlan) []removalResult {
 	return results
 }
 
+// uninstallCompletionPaths は install.sh が置いた補完ファイルのうち、実際に
+// あるものだけを返す。無いパスまで削除予定として並べると、確認画面が置いて
+// いないシェルの分まで長くなる。
 func uninstallCompletionPaths(system bool) ([]string, error) {
-	if system {
-		return []string{
-			"/usr/share/bash-completion/completions/hso",
-			"/usr/local/share/zsh/site-functions/_hso",
-			"/usr/share/fish/vendor_completions.d/hso.fish",
-		}, nil
+	candidates := []string{
+		"/usr/share/bash-completion/completions/hso",
+		"/usr/local/share/zsh/site-functions/_hso",
+		"/usr/share/fish/vendor_completions.d/hso.fish",
 	}
-	home, err := uninstallHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("cannot determine completion paths: %w", err)
+	if !system {
+		home, err := uninstallHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine completion paths: %w", err)
+		}
+		candidates = []string{
+			filepath.Join(home, ".local/share/bash-completion/completions/hso"),
+			filepath.Join(home, ".local/share/zsh/site-functions/_hso"),
+			filepath.Join(home, ".config/fish/completions/hso.fish"),
+		}
 	}
-	return []string{
-		filepath.Join(home, ".local/share/bash-completion/completions/hso"),
-		filepath.Join(home, ".local/share/zsh/site-functions/_hso"),
-		filepath.Join(home, ".config/fish/completions/hso.fish"),
-	}, nil
+	var paths []string
+	for _, path := range candidates {
+		if _, err := os.Lstat(path); err == nil {
+			paths = append(paths, path)
+		}
+	}
+	return paths, nil
 }
 
 func removeCompletion(path string) removalResult {

--- a/cmd/hso/uninstall.go
+++ b/cmd/hso/uninstall.go
@@ -17,6 +17,7 @@ import (
 )
 
 var uninstallEUID = os.Geteuid
+var uninstallHomeDir = os.UserHomeDir
 
 type uninstallOptions struct {
 	purge bool
@@ -29,6 +30,7 @@ type uninstallPlan struct {
 	configFile       string
 	configDir        string
 	pidDir           string
+	completionPaths  []string
 	running          []string
 	runningUnchecked bool
 	serverListKept   bool
@@ -97,6 +99,9 @@ func runUninstall(args []string, input io.Reader, output io.Writer, terminal boo
 		if result.state != removalFailed {
 			continue
 		}
+		if plan.isCompletionPath(result.path) {
+			continue
+		}
 		failed = true
 		if result.path == plan.executable &&
 			(errors.Is(result.err, syscall.EACCES) || errors.Is(result.err, syscall.EPERM)) {
@@ -110,6 +115,15 @@ func runUninstall(args []string, input io.Reader, output io.Writer, terminal boo
 		return errors.New("uninstall incomplete; see the removal summary above")
 	}
 	return nil
+}
+
+func (plan uninstallPlan) isCompletionPath(path string) bool {
+	for _, candidate := range plan.completionPaths {
+		if candidate == path {
+			return true
+		}
+	}
+	return false
 }
 
 func parseUninstallOptions(args []string) (uninstallOptions, error) {
@@ -151,6 +165,10 @@ func prepareUninstall(options uninstallOptions) (uninstallPlan, error) {
 	}
 	if !plan.binaryWritable && !options.purge {
 		return plan, nil
+	}
+	plan.completionPaths, err = uninstallCompletionPaths(uninstallEUID() == 0)
+	if err != nil {
+		return uninstallPlan{}, err
 	}
 
 	// root の通常アンインストールはバイナリだけを扱い、root のホームにある
@@ -283,7 +301,7 @@ func printUninstallPlan(output io.Writer, plan uninstallPlan) error {
 }
 
 func (plan uninstallPlan) removalPaths() []string {
-	paths := []string{plan.executable}
+	paths := append([]string{plan.executable}, plan.completionPaths...)
 	if plan.options.purge {
 		paths = append(paths, plan.configDir, plan.pidDir)
 	}
@@ -318,7 +336,7 @@ func confirmUninstall(
 }
 
 func removeUninstallTargets(plan uninstallPlan) []removalResult {
-	results := make([]removalResult, 0, 3)
+	results := make([]removalResult, 0, 6)
 	if plan.options.purge {
 		results = append(results, removeDirectory(plan.configDir), removeDirectory(plan.pidDir))
 	}
@@ -326,8 +344,43 @@ func removeUninstallTargets(plan uninstallPlan) []removalResult {
 		results = append(results, removalResult{path: plan.executable, state: removalKept})
 		return results
 	}
+	for _, path := range plan.completionPaths {
+		results = append(results, removeCompletion(path))
+	}
 	results = append(results, removeExecutable(plan.executable, plan.executableInfo))
 	return results
+}
+
+func uninstallCompletionPaths(system bool) ([]string, error) {
+	if system {
+		return []string{
+			"/usr/share/bash-completion/completions/hso",
+			"/usr/local/share/zsh/site-functions/_hso",
+			"/usr/share/fish/vendor_completions.d/hso.fish",
+		}, nil
+	}
+	home, err := uninstallHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine completion paths: %w", err)
+	}
+	return []string{
+		filepath.Join(home, ".local/share/bash-completion/completions/hso"),
+		filepath.Join(home, ".local/share/zsh/site-functions/_hso"),
+		filepath.Join(home, ".config/fish/completions/hso.fish"),
+	}, nil
+}
+
+func removeCompletion(path string) removalResult {
+	result := removalResult{path: path}
+	if err := os.Remove(path); errors.Is(err, fs.ErrNotExist) {
+		result.state = removalAbsent
+	} else if err != nil {
+		result.state = removalFailed
+		result.err = err
+	} else {
+		result.state = removalRemoved
+	}
+	return result
 }
 
 func removeDirectory(path string) removalResult {

--- a/cmd/hso/uninstall_test.go
+++ b/cmd/hso/uninstall_test.go
@@ -15,9 +15,13 @@ func preserveUninstallGlobals(t *testing.T) {
 	t.Helper()
 	previousExecutablePath := executablePath
 	previousEUID := uninstallEUID
+	previousHomeDir := uninstallHomeDir
+	isolateHome := t.TempDir()
+	uninstallHomeDir = func() (string, error) { return isolateHome, nil }
 	t.Cleanup(func() {
 		executablePath = previousExecutablePath
 		uninstallEUID = previousEUID
+		uninstallHomeDir = previousHomeDir
 	})
 }
 
@@ -257,6 +261,40 @@ func TestRemoveExecutableRefusesChangedTarget(t *testing.T) {
 	}
 	if string(contents) != "new" {
 		t.Fatalf("置換後のファイルが変更された: %q", contents)
+	}
+}
+
+func TestRemoveUninstallTargetsRemovesCompletionsByDefault(t *testing.T) {
+	directory := t.TempDir()
+	executable := filepath.Join(directory, "hso")
+	completionPath := filepath.Join(directory, "completion", "hso")
+	if err := os.MkdirAll(filepath.Dir(completionPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{executable, completionPath} {
+		if err := os.WriteFile(path, []byte("hso"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	executableInfo, err := os.Lstat(executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := removeUninstallTargets(uninstallPlan{
+		executable:      executable,
+		executableInfo:  executableInfo,
+		completionPaths: []string{completionPath},
+		binaryWritable:  true,
+	})
+	if len(results) != 2 || results[0].state != removalRemoved || results[1].state != removalRemoved {
+		t.Fatalf("results = %#v", results)
+	}
+}
+
+func TestCompletionRemovalFailureDoesNotFailUninstall(t *testing.T) {
+	plan := uninstallPlan{completionPaths: []string{"/completion"}}
+	if !plan.isCompletionPath("/completion") || plan.isCompletionPath("/other") {
+		t.Fatalf("completionPaths = %q", plan.completionPaths)
 	}
 }
 

--- a/dev-docs/cli.md
+++ b/dev-docs/cli.md
@@ -3,7 +3,8 @@
 > 管理 issue: hijoushoku7/hijo-server-ops#53（#51 を吸収）
 
 `hso` をサーバーディレクトリに置くバイナリから、どこからでも呼べるコマンドへ広げる。
-全体の仕様と位置づけは [spec.md](spec.md)、ビルド手順は [build.md](build.md)。
+全体の仕様と位置づけは [spec.md](spec.md)、ビルド手順は [build.md](build.md)、
+シェル補完は [completion.md](completion.md)。
 
 ## 目的
 

--- a/dev-docs/cli.md
+++ b/dev-docs/cli.md
@@ -86,6 +86,7 @@ ja / en で 2 本という配布形態はそのまま。言語で実行ファイ
 | `hso java` | Java 関連コマンドの使い方を表示 |
 | `hso java change [name]` | 登録済みサーバーが使う Java を変更 |
 | `hso java list` | 自動検出した JVM と利用中サーバーを表示 |
+| `hso completion <shell>` | bash / zsh / fish の補完スクリプトを標準出力へ出す |
 | `hso version` | バージョン・言語・アーキテクチャ（`-v` / `--v` / `-version` / `--version` も同じ） |
 | `hso update` | 最新リリースへ自己更新 |
 | `hso uninstall` | 自分自身のバイナリを消す。`--purge` で設定と pidfile も |
@@ -408,11 +409,12 @@ tag=$(printf '%s\n' "$body" |
 **入れたものを消すコマンドを持つ。** `curl | sh` で入れた人に「消し方は README を読んで
 `rm` を打て」と言わせない。入れる手順がコマンド 1 本なら、消す手順もコマンド 1 本にする。
 
-やることは 3 つだけ。
+やることは次の 4 つだけ。
 
 1. 自分自身のパス（`os.Executable()`）を確かめ、消してよいか確認を取る
 2. そのファイルを `unlink` する
 3. `--purge` が付いていれば、設定ディレクトリと pidfile も消す
+4. install.sh が設置したシェル補完ファイルを消す（`--purge` の有無にかかわらない）
 
 #### 権限が無いときは、昇格せずエラーで止める
 
@@ -457,6 +459,7 @@ If sudo is not available on this machine, run it as root.
 | | 既定 | `--purge` |
 |---|---|---|
 | バイナリ（自分自身） | 消す | 消す |
+| bash / zsh / fish の補完ファイル | **消す** | **消す** |
 | `~/.config/hso/config.toml`（サーバー一覧） | **残す** | 消す |
 | pidfile のディレクトリ | **残す** | 消す |
 | サーバーディレクトリの `hso.toml` / ワールド | **触れない** | **触れない** |
@@ -729,7 +732,12 @@ https://raw.githubusercontent.com/hijoushoku7/hijo-server-ops/main/install.sh
 4. 最新のタグを取る（**`hso update` と同じ経路を使う** → 未決定の「最新バージョンの取得先」）
 5. `hso_<tag>_linux_<arch>_<lang>.tar.gz` と `checksums.txt` を落として **SHA-256 を照合**
 6. インストール先を `mkdir -p` して、中の `hso` を `0755` で置く
-7. インストール先が `PATH` に無ければ、追記すべき 1 行を添えて警告する
+7. 利用できる bash / zsh / fish の補完スクリプトを、それぞれの標準の場所へ置く
+8. インストール先が `PATH` に無ければ、追記すべき 1 行を添えて警告する
+
+補完ファイルの設置に失敗してもインストールは続け、警告と設置できたパスを表示する。
+ユーザーインストールで zsh の補完を置いた場合だけ、`compinit` より前に
+`fpath=(~/.local/share/zsh/site-functions $fpath)` を加えるよう案内する。rc ファイルは編集しない。
 
 `--system` の有無による権限の検査は 1 より前、**何もダウンロードしないうちに**行う。
 

--- a/dev-docs/commands.md
+++ b/dev-docs/commands.md
@@ -19,6 +19,7 @@ hso <コマンド> [引数]
 | `hso delete [name]` | サーバー一覧から登録を外す |
 | `hso java change [name]` | サーバーが使う Java を変更する |
 | `hso java list` | 自動検出した Java と、それを使っているサーバーを表示する |
+| `hso completion <shell>` | bash / zsh / fish の補完スクリプトを出力する |
 | `hso version` | バージョン・表示言語・アーキテクチャを表示する |
 | `hso update` | 最新リリースへ自己更新する |
 | `hso uninstall` | hso 自身を削除する |
@@ -90,6 +91,11 @@ pidfile のファイル名になるため（→ [cli.md](cli.md) の「サーバ
 `-v` / `--v` / `-version` / `--version` も同じ出力になる。`hso version` は引数を取らないが、
 `-` 付きの書き方は後ろに何が付いていてもバージョンを表示する。
 
+## `hso completion <shell>`
+
+bash / zsh / fish のいずれかを指定し、そのシェル用の補完スクリプトを標準出力へ出す。
+通常は `install.sh` が自動で設置するため、手動で設置し直すときに使う。
+
 ## `hso update`
 
 同じアーキテクチャ・同じ表示言語のバイナリを最新リリースから取得し、SHA-256 で照合してから
@@ -109,6 +115,7 @@ pidfile のファイル名になるため（→ [cli.md](cli.md) の「サーバ
 
 - サーバーディレクトリの `hso.toml` とワールドには**触れない**
 - 既定ではサーバー一覧を残す。入れ直す人のほうが多いため
+- install.sh が設置した bash / zsh / fish の補完ファイルは既定で削除する
 - **`--purge` は root で実行しない。** root の `~/.config` を見に行き、消したい一覧が残る
 - `/usr/local/bin` のバイナリを消すには `sudo hso uninstall`。uninstall 自身が
   `sudo` / `doas` を起動することはない

--- a/dev-docs/completion.md
+++ b/dev-docs/completion.md
@@ -1,0 +1,192 @@
+# シェル補完 設計
+
+`hso` のサブコマンド・フラグ・**登録済みサーバー名**を bash / zsh / fish で Tab 補完できるようにする。
+コマンド体系は [cli.md](cli.md)、配布とインストールも同じく cli.md の「配布とインストール」を前提にする。
+
+## 目的
+
+`hso start` の引数は登録名で、いま何を登録したかは `hso list` を叩かないと分からない。
+打ち間違えれば「そのサーバーは登録されていません」で止まる。**候補はツールが持っているのだから、
+Tab で出す。** サブコマンドとフラグの補完はそのついでに付いてくる。
+
+**やらないこと**:
+
+| やらないこと | 理由 |
+|---|---|
+| cobra / urfave-cli の導入 | 補完のためだけに引数解析を全面書き換えることになる。いまの `dispatchCommand` は 60 行で読み切れる |
+| rc ファイル（`.bashrc` / `.zshrc` / `config.fish`）の自動編集 | install.sh が `.profile` を書き換えず「追記すべき 1 行」を出すのと同じ姿勢を通す |
+| 候補のキャッシュ・常駐 | 読むのは TOML 1 ファイル。キャッシュを持つと「消したサーバーが候補に残る」を作るだけ |
+| `-config` のパス補完を自力で書く | ファイル名の補完はシェルが自前で持っている。`_files` / `compgen -f` に渡す |
+| 起動中サーバーの候補からの除外 | cli.md の「一覧から消すと『登録したはずのものが無い』に見える」と同じ。**選べて、選んだら「すでに起動中」と言われる**ほうが読める |
+
+## 確定仕様
+
+| 項目 | 決定 | 理由 |
+|---|---|---|
+| 候補の決定 | **Go 側に 1 箇所**。シェルスクリプトは候補を持たない | コマンドが増えたとき直す場所を 3 本のスクリプトに散らさない |
+| 問い合わせ口 | 隠しサブコマンド **`hso __complete <words...>`** | すでに `__hso_supervise` で自分自身を再実行する構造がある。分岐が 1 段増えるだけ |
+| スクリプトの配布 | **`hso completion <shell>`** が `go:embed` したスクリプトを stdout へ出す | 配布物はバイナリ 1 本のまま。スクリプトの版とバイナリの版がずれない |
+| スクリプトの中身 | **薄い委譲だけ**。単語列を `__complete` へ渡して結果を並べる | `hso update` でコマンドが増えても、設置済みスクリプトを置き換えずに追随する（→「なぜ委譲するか」） |
+| 絞り込み | **シェル側に任せる。** `__complete` は位置に対する候補を全部返す | 同じ前方一致の規則を Go とシェルの 2 箇所に持たない |
+| 出力形式 | 1 行 1 候補、`候補<TAB>説明`。説明は省略可 | 3 つのシェルが揃って解釈できる最小の形 |
+| エラー | **候補ゼロ・終了コード 0。** stdout には何も出さない | プロンプトの下に Go のエラー文が噴き出す事故を作らない |
+| 副作用 | registry を読むだけ。TUI・ネットワーク・pidfile・`/proc` に触らない | Tab のたびに走る。生死判定は `list` の仕事 |
+| 設置 | install.sh が置く。`hso uninstall` が消す | 入れる手順がコマンド 1 本なら、消えるのも 1 本で消える（cli.md「uninstall」） |
+| 説明文 | `internal/msg` に置いて ja / en 契約に乗せる | zsh と fish は説明を表示する。ユーザー向け文字列なので msg の担当 |
+
+### なぜ委譲するか（静的生成にしない理由）
+
+補完スクリプトに候補を焼き込む形（`hso completion zsh` がコマンド一覧を展開した完成品を出す）でも
+動くが、**`hso update` でバイナリだけ新しくなり、設置済みスクリプトが古いまま残る**。
+補完に出ないコマンドは「無い」と読まれるので、これは黙って壊れる壊れ方になる。
+
+薄いスクリプトが持つのは「`__complete` を呼んで結果を並べる」手順だけで、コマンドが増減しても
+中身が変わらない。置き換えが要るのは出力形式そのものを変えるときだけで、それは滅多に起きない。
+
+代償は Tab ごとに 1 回 exec が増えること。静的リンクの hso は起動して TOML を 1 つ読むだけなので
+数 ms で、体感に出ない。
+
+## 補完する位置
+
+| 打っているもの | 候補 |
+|---|---|
+| `hso <TAB>` | `setup` `start` `list` `ls` `delete` `java` `completion` `version` `update` `uninstall` `help` `-config` |
+| `hso start <TAB>` | 登録済みサーバー名 |
+| `hso delete <TAB>` | 登録済みサーバー名 ＋ `-y` `--yes` |
+| `hso java <TAB>` | `change` `list` |
+| `hso java change <TAB>` | 登録済みサーバー名 |
+| `hso uninstall <TAB>` | `--purge` `-y` `--yes` |
+| `hso completion <TAB>` | `bash` `zsh` `fish` |
+| `hso -config <TAB>` | **シェルのファイル補完**（`__complete` は候補を返さず、その旨を伝える） |
+| 上記以外（`setup` `list` `version` `update` `help` の後ろなど） | 無し |
+
+サーバー名を取る位置は 3 つ（`start` / `delete` / `java change`）で、どれも同じ候補集合を返す。
+
+## 問い合わせのプロトコル
+
+```
+$ hso __complete hso start ''
+survival	/srv/minecraft/hso.toml
+creative	/srv/creative/hso.toml
+
+$ hso __complete hso java ''
+change	サーバーが使う Java を変更する
+list	自動検出した Java と、それを使っているサーバーを表示する
+```
+
+- 渡すのは**いま打たれている単語列そのまま**。末尾はまだ打ちかけの単語（空文字もある）
+- サーバー名の説明には `hso.toml` のパスを添える。同じ名前で迷うことはないが、
+  どこのサーバーかがその場で読める
+- ファイル補完へ回す位置だけは、候補の代わりに 1 行 `:files` を返す。スクリプトはこれを見て
+  シェルのファイル補完に切り替える（候補ゼロと区別が付く形にする）
+
+### `main.go` での分岐位置
+
+**supervisor の判定の直後、`dispatchCommand` の先頭**に置く。
+
+1. `process.SupervisorCommand` — 現行どおり最優先
+2. `__complete` — ここ
+3. 以降は現行の分岐（ヘルプ / バージョン / サブコマンド / `-config`）
+
+`__complete` はヘルプ（`CommandHelp`）にも `UnknownCommand` の案内にも載せない。
+一方 **`completion` は載せる** — 人が叩いて設置し直すコマンドなので、探せないと意味がない。
+
+## Go 側の構造
+
+`internal/completion` に、ディスクに触らない純関数を 1 本置く。
+
+```go
+// Candidates は打たれた単語列に対する補完候補を返す。
+// words は "hso" から始まり、末尾は打ちかけの単語（空文字もある）。
+func Candidates(words []string, servers []registry.Server) []Candidate
+
+type Candidate struct {
+	Value       string
+	Description string
+}
+```
+
+- **位置の判定だけを持つ。** registry の読み込みは `cmd/hso` 側でやって渡す。
+  これで位置ごとの候補はテーブルテストで全部押さえられる
+- `cmd/hso/completion.go` は「`registry.Path` → `registry.Load` → `Candidates` → 印字」だけ。
+  `registry.Load` が失敗したら**エラーを返さずコマンド候補だけ**で応答する
+  （一覧が壊れていてもサブコマンドの補完は効かせる。java.md の「補助機能が主機能を止めない」と同じ）
+
+補完スクリプト 3 本は `internal/completion/scripts/` に置き、`go:embed` で埋める。
+**スクリプトはシェルの構文であって翻訳対象ではない**ので `internal/msg` には入れない
+（→ [i18n.md](../.claude/docs/i18n.md) の線引き）。説明文だけが msg 側に立つ。
+
+## シェル別スクリプト
+
+どれも「単語列を渡す → 返ってきた行を並べる」だけ。骨子のみ示す。
+
+**bash** — 説明は捨てて値だけを `COMPREPLY` へ。`:files` なら `-o default` に任せる。
+
+```bash
+_hso() {
+    local IFS=$'\n' line
+    local out=$(hso __complete "${COMP_WORDS[@]:0:COMP_CWORD+1}" 2>/dev/null)
+    [[ $out == ':files' ]] && return 1   # シェルのファイル補完へ落とす
+    COMPREPLY=($(compgen -W "$(cut -f1 <<<"$out")" -- "${COMP_WORDS[COMP_CWORD]}"))
+}
+complete -o default -F _hso hso
+```
+
+**zsh** — `_describe` がタブ区切りをそのまま説明として扱える。`:files` は `_files` へ。
+
+**fish** — `complete -f -c hso -a '(__hso_complete)'`。fish は候補のタブ以降を説明として表示する
+ので、返した行をそのまま流せる。
+
+## 設置・更新・削除
+
+### 置き場所
+
+| shell | システム（`--system`） | ユーザー（既定） |
+|---|---|---|
+| bash | `/usr/share/bash-completion/completions/hso` | `~/.local/share/bash-completion/completions/hso` |
+| zsh | `/usr/local/share/zsh/site-functions/_hso` | `~/.local/share/zsh/site-functions/_hso` |
+| fish | `/usr/share/fish/vendor_completions.d/hso.fish` | `~/.config/fish/completions/hso.fish` |
+
+### install.sh
+
+バイナリを置いた後に、**インストール先と同じ権限のまま**、上表のうち置ける場所へ書く。
+
+- **失敗しても致命的にしない。** 補完が無くても hso は動く。警告 1 行を出して続ける
+- **置いたパスを出力する。** 後で消すのも読み直すのもユーザーなので、黙って置かない
+- rc ファイルは触らない。**ユーザーインストールの zsh だけは例外的に案内が要る**
+  （`~/.local/share/zsh/site-functions` は既定の `fpath` に入っていない）。
+  PATH の警告と同じ形で、`compinit` より前に足す 1 行を出す:
+
+  ```
+  fpath=(~/.local/share/zsh/site-functions $fpath)
+  ```
+
+  bash は bash-completion 2.8 以降が `$XDG_DATA_HOME/bash-completion/completions` を
+  動的に読むので、fish と同じくファイルを置くだけで効く
+
+### `hso update`
+
+**何もしない。** スクリプトは委譲するだけで版に依存しないので、置き換える必要がない
+（→「なぜ委譲するか」）。
+
+### `hso uninstall`
+
+**既定で消す。`--purge` 送りにしない。** バイナリが消えた後に残っても意味のないファイルで、
+`~/.config/hso/config.toml`（入れ直す人が失うと困るもの）とは性質が違う。
+
+- 上表のパスを列挙し、存在するものを消す。消したパスは最後のまとめに出す
+- 消せなくても `uninstall` を止めない。cli.md の「`y` の後は途中で止まらない」に従う
+
+## テスト
+
+両タグ（ja / en）で回す。
+
+| 対象 | 方法 |
+|---|---|
+| 位置ごとの候補 | `completion.Candidates` のテーブルテスト。上の「補完する位置」の表を 1 行ずつ |
+| 壊れた registry | `Load` 失敗時にコマンド候補だけ返り、エラーが stdout に出ないこと |
+| 出力形式 | `hso __complete` の出力が `値<TAB>説明` であること（`cmd/hso` のテスト） |
+| スクリプトの構文 | `bash -n` / `zsh -n` / `fish --no-execute`。**そのシェルが無い環境ではスキップ**する |
+
+`__complete` はヘルプに出ないので、`msg_test.go` の識別子照合には現れない。
+**説明文を msg に足す以上、ja / en の両方に書く**という契約はそのまま効く。

--- a/install.sh
+++ b/install.sh
@@ -216,6 +216,68 @@ install_binary() {
 }
 
 # shellcheck disable=SC3043
+install_completion_file() {
+    local privileged="$1"
+    local source="$2"
+    local destination="$3"
+    local completion_dir
+
+    completion_dir=$(dirname "$destination")
+    # shellcheck disable=SC2016
+    set -- sh -c '
+        mkdir -p "$2" || exit 1
+        staging=$(mktemp "$2/.hso-completion-XXXXXX") || exit 1
+        trap '\''rm -f "$staging"'\'' 0
+        trap '\''exit 1'\'' 1 2 15
+        cp "$1" "$staging" || exit $?
+        chmod 0644 "$staging" || exit $?
+        mv -f "$staging" "$3" || exit $?
+        trap - 0 1 2 15
+    ' _ "$source" "$completion_dir" "$destination"
+
+    if [ -n "$privileged" ]; then
+        "$privileged" "$@"
+    else
+        "$@"
+    fi
+}
+
+# 表示する $fpath は、案内を実行したときに展開させる。
+# shellcheck disable=SC3043,SC2016
+install_completions() {
+    local privileged="$1"
+    local binary="$2"
+    local system="$3"
+    local work="$4"
+    local shell_name destination generated zsh_installed=false
+
+    for shell_name in bash zsh fish; do
+        command -v "$shell_name" >/dev/null 2>&1 || continue
+        case "$system:$shell_name" in
+            true:bash) destination=/usr/share/bash-completion/completions/hso ;;
+            true:zsh) destination=/usr/local/share/zsh/site-functions/_hso ;;
+            true:fish) destination=/usr/share/fish/vendor_completions.d/hso.fish ;;
+            false:bash) destination=$HOME/.local/share/bash-completion/completions/hso ;;
+            false:zsh) destination=$HOME/.local/share/zsh/site-functions/_hso ;;
+            false:fish) destination=$HOME/.config/fish/completions/hso.fish ;;
+        esac
+        generated=$work/completion-$shell_name
+        if "$binary" completion "$shell_name" > "$generated" 2>/dev/null && \
+            install_completion_file "$privileged" "$generated" "$destination"; then
+            printf '==> shell completion installed to %s\n' "$destination"
+            [ "$shell_name" = zsh ] && zsh_installed=true
+        else
+            printf 'Warning: could not install shell completion to %s\n' "$destination" >&2
+        fi
+    done
+
+    if [ "$system" = false ] && [ "$zsh_installed" = true ]; then
+        printf '\n   Add this before compinit in ~/.zshrc:\n\n'
+        printf '       %s\n' 'fpath=(~/.local/share/zsh/site-functions $fpath)'
+    fi
+}
+
+# shellcheck disable=SC3043
 main() {
     local system=false
     local lang="${HSO_LANG:-en}"
@@ -373,6 +435,7 @@ main() {
 
     if [ -f "$dir/hso" ] && cmp -s "$binary" "$dir/hso"; then
         printf '==> hso %s is already installed at %s/hso\n' "$tag" "$dir"
+        install_completions "$privileged" "$dir/hso" "$system" "$work"
         rm -rf "$work"
         trap - 0 1 2 15
         return
@@ -383,6 +446,7 @@ main() {
     fi
 
     print_path_guidance "$tag" "$dir/hso" "$dir"
+    install_completions "$privileged" "$dir/hso" "$system" "$work"
 
     rm -rf "$work"
     trap - 0 1 2 15

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -1,0 +1,74 @@
+// Package completion は hso のシェル補完候補を決定する。
+package completion
+
+import (
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
+	"github.com/hijoushoku7/hijo-server-ops/internal/registry"
+)
+
+type Candidate struct {
+	Value       string
+	Description string
+}
+
+// Candidates は打たれた単語列に対する補完候補を返す。
+// words は "hso" から始まり、末尾は打ちかけの単語（空文字もある）。
+func Candidates(words []string, servers []registry.Server) []Candidate {
+	if len(words) == 2 {
+		return commandCandidates()
+	}
+	if len(words) == 3 {
+		switch words[1] {
+		case "start":
+			return serverCandidates(servers)
+		case "delete":
+			return append(serverCandidates(servers),
+				Candidate{Value: "-y", Description: msg.CompletionYesDescription},
+				Candidate{Value: "--yes", Description: msg.CompletionYesDescription})
+		case "java":
+			return []Candidate{
+				{Value: "change", Description: msg.CompletionJavaChangeDescription},
+				{Value: "list", Description: msg.CompletionJavaListDescription},
+			}
+		case "uninstall":
+			return []Candidate{
+				{Value: "--purge", Description: msg.CompletionPurgeDescription},
+				{Value: "-y", Description: msg.CompletionYesDescription},
+				{Value: "--yes", Description: msg.CompletionYesDescription},
+			}
+		case "completion":
+			return []Candidate{{Value: "bash"}, {Value: "zsh"}, {Value: "fish"}}
+		case "-config":
+			return []Candidate{{Value: ":files"}}
+		}
+	}
+	if len(words) == 4 && words[1] == "java" && words[2] == "change" {
+		return serverCandidates(servers)
+	}
+	return nil
+}
+
+func commandCandidates() []Candidate {
+	return []Candidate{
+		{Value: "setup", Description: msg.CompletionSetupDescription},
+		{Value: "start", Description: msg.CompletionStartDescription},
+		{Value: "list", Description: msg.CompletionListDescription},
+		{Value: "ls", Description: msg.CompletionListDescription},
+		{Value: "delete", Description: msg.CompletionDeleteDescription},
+		{Value: "java", Description: msg.CompletionJavaDescription},
+		{Value: "completion", Description: msg.CompletionCommandDescription},
+		{Value: "version", Description: msg.CompletionVersionDescription},
+		{Value: "update", Description: msg.CompletionUpdateDescription},
+		{Value: "uninstall", Description: msg.CompletionUninstallDescription},
+		{Value: "help", Description: msg.CompletionHelpDescription},
+		{Value: "-config", Description: msg.CompletionConfigDescription},
+	}
+}
+
+func serverCandidates(servers []registry.Server) []Candidate {
+	candidates := make([]Candidate, 0, len(servers))
+	for _, server := range servers {
+		candidates = append(candidates, Candidate{Value: server.Name, Description: server.Config})
+	}
+	return candidates
+}

--- a/internal/completion/completion_test.go
+++ b/internal/completion/completion_test.go
@@ -1,0 +1,75 @@
+package completion
+
+import (
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/hijoushoku7/hijo-server-ops/internal/registry"
+)
+
+func TestCandidatesByPosition(t *testing.T) {
+	servers := []registry.Server{
+		{Name: "survival", Config: "/srv/minecraft/hso.toml"},
+		{Name: "creative", Config: "/srv/creative/hso.toml"},
+	}
+	serverValues := []string{"survival", "creative"}
+	tests := []struct {
+		name  string
+		words []string
+		want  []string
+	}{
+		{name: "コマンド", words: []string{"hso", ""}, want: []string{"setup", "start", "list", "ls", "delete", "java", "completion", "version", "update", "uninstall", "help", "-config"}},
+		{name: "start", words: []string{"hso", "start", ""}, want: serverValues},
+		{name: "delete", words: []string{"hso", "delete", ""}, want: []string{"survival", "creative", "-y", "--yes"}},
+		{name: "java", words: []string{"hso", "java", ""}, want: []string{"change", "list"}},
+		{name: "java change", words: []string{"hso", "java", "change", ""}, want: serverValues},
+		{name: "uninstall", words: []string{"hso", "uninstall", ""}, want: []string{"--purge", "-y", "--yes"}},
+		{name: "completion", words: []string{"hso", "completion", ""}, want: []string{"bash", "zsh", "fish"}},
+		{name: "config", words: []string{"hso", "-config", ""}, want: []string{":files"}},
+		{name: "その他", words: []string{"hso", "list", ""}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotCandidates := Candidates(test.words, servers)
+			var got []string
+			for _, candidate := range gotCandidates {
+				got = append(got, candidate.Value)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("Candidates(%q) = %q, want %q", test.words, got, test.want)
+			}
+		})
+	}
+}
+
+func TestServerCandidateDescriptionIsConfigPath(t *testing.T) {
+	got := Candidates([]string{"hso", "start", ""}, []registry.Server{{Name: "survival", Config: "/srv/hso.toml"}})
+	if len(got) != 1 || got[0].Description != "/srv/hso.toml" {
+		t.Fatalf("candidates = %#v", got)
+	}
+}
+
+func TestEmbeddedScriptsHaveValidSyntax(t *testing.T) {
+	tests := []struct {
+		shell string
+		args  []string
+		file  string
+	}{
+		{shell: "bash", args: []string{"-n"}, file: "hso.bash"},
+		{shell: "zsh", args: []string{"-n"}, file: "_hso"},
+		{shell: "fish", args: []string{"--no-execute"}, file: "hso.fish"},
+	}
+	for _, test := range tests {
+		t.Run(test.shell, func(t *testing.T) {
+			if _, err := exec.LookPath(test.shell); err != nil {
+				t.Skipf("%s がないためスキップします", test.shell)
+			}
+			path := filepath.Join("scripts", test.file)
+			if output, err := exec.Command(test.shell, append(test.args, path)...).CombinedOutput(); err != nil {
+				t.Fatalf("%s: %v\n%s", path, err, output)
+			}
+		})
+	}
+}

--- a/internal/completion/scripts.go
+++ b/internal/completion/scripts.go
@@ -1,0 +1,26 @@
+package completion
+
+import _ "embed"
+
+//go:embed scripts/hso.bash
+var bashScript string
+
+//go:embed scripts/_hso
+var zshScript string
+
+//go:embed scripts/hso.fish
+var fishScript string
+
+// Script は指定されたシェルの補完スクリプトを返す。
+func Script(shell string) (string, bool) {
+	switch shell {
+	case "bash":
+		return bashScript, true
+	case "zsh":
+		return zshScript, true
+	case "fish":
+		return fishScript, true
+	default:
+		return "", false
+	}
+}

--- a/internal/completion/scripts/_hso
+++ b/internal/completion/scripts/_hso
@@ -1,0 +1,18 @@
+#compdef hso
+
+_hso() {
+    local out
+    local -a candidates
+    # words は 1 始まりだが ${...:offset:length} の offset は 0 始まり。
+    # 先頭の hso から、いま打ちかけの CURRENT 番目までをそのまま渡す。
+    out=$(hso __complete "${words[@]:0:$CURRENT}" 2>/dev/null)
+    if [[ $out == ':files' ]]; then
+        _files
+        return
+    fi
+    candidates=("${(@f)out}")
+    candidates=("${candidates[@]/$'\t'/:}")
+    _describe 'hso' candidates
+}
+
+compdef _hso hso

--- a/internal/completion/scripts/hso.bash
+++ b/internal/completion/scripts/hso.bash
@@ -1,0 +1,10 @@
+_hso() {
+    local IFS=$'\n' out line values=''
+    out=$(hso __complete "${COMP_WORDS[@]:0:COMP_CWORD+1}" 2>/dev/null)
+    [[ $out == ':files' ]] && return 1
+    while IFS=$'\t' read -r line _; do
+        [[ -n $line ]] && values+="$line"$'\n'
+    done <<< "$out"
+    COMPREPLY=($(compgen -W "$values" -- "${COMP_WORDS[COMP_CWORD]}"))
+}
+complete -o default -F _hso hso

--- a/internal/completion/scripts/hso.bash
+++ b/internal/completion/scripts/hso.bash
@@ -1,10 +1,16 @@
 _hso() {
     local IFS=$'\n' out line values=''
     out=$(hso __complete "${COMP_WORDS[@]:0:COMP_CWORD+1}" 2>/dev/null)
-    [[ $out == ':files' ]] && return 1
+    # ファイル補完へ回すのは :files を返した位置だけ。complete に -o default を
+    # 付けると候補ゼロの位置でも既定のファイル補完が出てしまうため、ここで
+    # その位置に限って有効にする。
+    if [[ $out == ':files' ]]; then
+        compopt -o default
+        return 0
+    fi
     while IFS=$'\t' read -r line _; do
         [[ -n $line ]] && values+="$line"$'\n'
     done <<< "$out"
     COMPREPLY=($(compgen -W "$values" -- "${COMP_WORDS[COMP_CWORD]}"))
 }
-complete -o default -F _hso hso
+complete -F _hso hso

--- a/internal/completion/scripts/hso.fish
+++ b/internal/completion/scripts/hso.fish
@@ -1,0 +1,14 @@
+function __hso_complete
+    set -l words (commandline -opc)
+    # 打ちかけの単語は空のこともある。素の (commandline -ct) だと空のときに
+    # 要素が 1 つも増えず、位置が 1 つずれる。
+    set -a words (commandline -ct | string collect --allow-empty)
+    set -l out (hso __complete $words 2>/dev/null)
+    if test "$out" = :files
+        __fish_complete_path (commandline -ct)
+    else
+        printf '%s\n' $out
+    end
+end
+
+complete -f -c hso -a '(__hso_complete)'

--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -738,6 +738,33 @@ func UnknownCommand(command string) error {
 	)
 }
 
+// シェル補完で候補に添える説明。
+const (
+	CompletionSetupDescription      = "Start the setup"
+	CompletionStartDescription      = "Start a registered server"
+	CompletionListDescription       = "Show registered servers"
+	CompletionDeleteDescription     = "Drop a server from the list"
+	CompletionJavaDescription       = "Configure and inspect Java"
+	CompletionCommandDescription    = "Print a shell completion script"
+	CompletionVersionDescription    = "Show version information"
+	CompletionUpdateDescription     = "Update to the latest release"
+	CompletionUninstallDescription  = "Remove hso itself"
+	CompletionHelpDescription       = "Show the command list"
+	CompletionConfigDescription     = "Start with the given hso.toml"
+	CompletionJavaChangeDescription = "Change the Java used by a server"
+	CompletionJavaListDescription   = "Show detected Java and servers using it"
+	CompletionPurgeDescription      = "Also remove config and pidfiles"
+	CompletionYesDescription        = "Skip confirmation"
+)
+
+func CompletionArgumentsInvalid() error {
+	return errors.New("completion requires one of bash, zsh, or fish")
+}
+
+func UnsupportedCompletionShell(shell string) error {
+	return fmt.Errorf("unsupported shell: %s (expected bash, zsh, or fish)", shell)
+}
+
 // CommandHelp は hso / hso help で出すコマンド一覧。オプションは主要なものだけを
 // 載せ、それぞれの細かい説明は dev-docs/commands.md に置く。
 const CommandHelp = `hso — a wrapper-style TUI console for Minecraft servers
@@ -752,6 +779,7 @@ Commands:
   delete [name]           Drop a server from the list. hso.toml and the worlds are kept
   java change [name]      Change the Java a server uses
   java list               Show detected Java installations and the servers using them
+  completion <shell>      Print the completion script for bash, zsh, or fish
   version                 Show the version, interface language and architecture
   update                  Update itself to the latest release
   uninstall               Remove hso itself. --purge also removes the config and the pidfile

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -736,6 +736,33 @@ func UnknownCommand(command string) error {
 	)
 }
 
+// シェル補完で候補に添える説明。
+const (
+	CompletionSetupDescription      = "セットアップを始める"
+	CompletionStartDescription      = "登録済みのサーバーを起動する"
+	CompletionListDescription       = "登録済みのサーバーを表示する"
+	CompletionDeleteDescription     = "サーバー一覧から登録を外す"
+	CompletionJavaDescription       = "Java の設定と確認"
+	CompletionCommandDescription    = "シェル補完スクリプトを出力する"
+	CompletionVersionDescription    = "バージョン情報を表示する"
+	CompletionUpdateDescription     = "最新リリースへ自己更新する"
+	CompletionUninstallDescription  = "hso 自身を削除する"
+	CompletionHelpDescription       = "コマンド一覧を表示する"
+	CompletionConfigDescription     = "指定した hso.toml で起動する"
+	CompletionJavaChangeDescription = "サーバーが使う Java を変更する"
+	CompletionJavaListDescription   = "自動検出した Java と利用中サーバーを表示する"
+	CompletionPurgeDescription      = "設定と pidfile も削除する"
+	CompletionYesDescription        = "確認を省略する"
+)
+
+func CompletionArgumentsInvalid() error {
+	return errors.New("completion には bash、zsh、fish のいずれかを指定してください")
+}
+
+func UnsupportedCompletionShell(shell string) error {
+	return fmt.Errorf("未対応のシェルです: %s（bash、zsh、fish のいずれかを指定してください）", shell)
+}
+
 // CommandHelp は hso / hso help で出すコマンド一覧。オプションは主要なものだけを
 // 載せ、それぞれの細かい説明は dev-docs/commands.md に置く。
 const CommandHelp = `hso — Minecraft サーバー用のラッパー型 TUI コンソール
@@ -750,6 +777,7 @@ const CommandHelp = `hso — Minecraft サーバー用のラッパー型 TUI コ
   delete [name]           サーバー一覧から登録を外す。hso.toml とワールドは消さない
   java change [name]      サーバーが使う Java を変更する
   java list               自動検出した Java と、それを使っているサーバーを表示する
+  completion <shell>      bash / zsh / fish の補完スクリプトを出力する
   version                 バージョン・表示言語・アーキテクチャを表示する
   update                  最新リリースへ自己更新する
   uninstall               hso 自身を削除する。--purge で設定と pidfile も消す


### PR DESCRIPTION
## WHY

`hso start` の引数は登録名だが、いま何が登録されているかは `hso list` を叩かないと分からない。
打ち間違えれば「そのサーバーは登録されていません」で止まる。候補はツールが持っているのだから、
Tab で出せるようにする。サブコマンドとフラグの補完はそのついでに付いてくる。

設計は `dev-docs/completion.md`（このPRの1コミット目で追加）。

## What

- `internal/completion` — ディスクに触らない純関数 `Candidates(words, servers)` に候補の決定を1箇所へ集約。
  bash / zsh / fish のスクリプトは `scripts/` に置いて `go:embed` で埋める
- 隠しサブコマンド `hso __complete <words...>` — 単語列を受けて `値<TAB>説明` を1行1候補で出す。
  エラーは出さず終了コード0。`registry.Load` が失敗してもコマンド候補だけは返す
  （補助機能が主機能を止めない）。`-config` の位置だけは `:files` を返してシェルのファイル補完へ回す
- `hso completion <shell>` — 埋め込んだスクリプトを stdout へ出す。ヘルプにも載せる
  （`__complete` は載せない）
- スクリプトは**薄い委譲だけ**。候補を焼き込まないので、`hso update` でコマンドが増えても
  設置済みスクリプトを置き換えずに追随する
- `install.sh` — バイナリ設置後、入っているシェルの標準パスへ補完を置く。失敗しても致命的にせず
  警告1行で続行し、置いたパスを出力する。rc ファイルは編集せず、ユーザーインストールの zsh のときだけ
  `fpath` に足す1行を案内する
- `hso uninstall` — 上記のパスを既定で消す（`--purge` 送りにしない）。消せなくても uninstall は止めない
- テスト — 位置ごとの候補のテーブルテスト、壊れた registry、`__complete` の出力形式、
  各シェルの構文チェック（そのシェルが無ければスキップ）

## 補足

実装は Codex に投げ、レビュー前に手元で以下を確認した。

- bash スクリプトは実シェルで動作確認済み（全位置で期待どおりの候補）
- zsh スクリプトに実行時バグが2件あったので修正済み。`zsh -n` は通るが実行すると壊れるもので、
  構文チェックだけのテストでは検出できなかった
  - `${words[@]:1:CURRENT}` が `unrecognized modifier` で失敗する（`$CURRENT` が必要）
  - offset が0始まりのため `:1:` だと先頭の `hso` が落ち、位置が1つずれて誤った候補が出る → `:0:`
- fish スクリプトは打ちかけの単語が空のとき `(commandline -ct)` が要素を増やさず位置がずれるため、
  `string collect --allow-empty` を挟んだ。**fish が未導入の環境のため実機確認はできていない**

🤖 Generated with [Claude Code](https://claude.com/claude-code)