### PR TITLE
fix: --purge を root で実行したときのエラーに sudo hso uninstall の案内を足す

### DIFF
--- a/cmd/hso/uninstall.go
+++ b/cmd/hso/uninstall.go
@@ -148,8 +148,10 @@ func validateUninstallRoot(purge bool, euid int) error {
 	}
 	return errors.New("--purge must not be run as root.\n\n" +
 		"As root, hso would look for the config in root's home directory, not yours.\n" +
-		"Run it as your normal user:\n\n" +
-		"    hso uninstall --purge")
+		"Run it as your normal user first:\n\n" +
+		"    hso uninstall --purge\n\n" +
+		"If that reports the binary itself needs root, finish with:\n\n" +
+		"    sudo hso uninstall")
 }
 
 func prepareUninstall(options uninstallOptions) (uninstallPlan, error) {

--- a/cmd/hso/uninstall_test.go
+++ b/cmd/hso/uninstall_test.go
@@ -64,7 +64,7 @@ func TestValidateUninstallRootRejectsOnlyPurge(t *testing.T) {
 	if err == nil {
 		t.Fatal("root の --purge が通った")
 	}
-	for _, want := range []string{"must not be run as root", "hso uninstall --purge"} {
+	for _, want := range []string{"must not be run as root", "hso uninstall --purge", "sudo hso uninstall"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error = %q に %q がない", err, want)
 		}

--- a/dev-docs/cli.md
+++ b/dev-docs/cli.md
@@ -482,9 +482,13 @@ If sudo is not available on this machine, run it as root.
 Error: --purge must not be run as root.
 
 As root, hso would look for the config in root's home directory, not yours.
-Run it as your normal user:
+Run it as your normal user first:
 
     hso uninstall --purge
+
+If that reports the binary itself needs root, finish with:
+
+    sudo hso uninstall
 ```
 
 `SUDO_UID` から呼び出し元のホームを推測して消しにいく、という実装はしない。


### PR DESCRIPTION
Closes #78

## WHY
`/usr/local/bin` のようなシステムディレクトリに hso が入っている場合、`sudo hso uninstall --purge` は root のホームディレクトリを見に行ってしまうため意図的にエラーで止まる設計になっている（`--purge` は一般ユーザーで実行する必要がある）。しかし、そのエラーメッセージが「一般ユーザーで `hso uninstall --purge` を実行してください」としか案内しておらず、バイナリ自体の削除には別途 `sudo hso uninstall`（`--purge` なし）が必要なことを伝えていなかった。そのため、ユーザーは「`--purge` を sudo で実行できない＝アンインストールが実行不可能」と感じてしまっていた（issue #78）。

## What
- `validateUninstallRoot` のエラーメッセージに、一般ユーザーで `hso uninstall --purge` を実行した後、バイナリの削除には `sudo hso uninstall` が必要になる旨を追記
- `dev-docs/cli.md` の該当するエラー文面の引用箇所を実装に合わせて更新
- メッセージに `sudo hso uninstall` が含まれることを確認するテストを追加

挙動（`--purge` を root で実行させない、`SUDO_UID` から推測しない）は変更していない。案内メッセージのみの修正。