### PR TITLE
feat: sudo のパスワードを聞く前に理由を説明する

### DIFF
--- a/cmd/hso/update.go
+++ b/cmd/hso/update.go
@@ -230,17 +230,23 @@ func replacementPrivilege(target string) (string, error) {
 	if os.Geteuid() == 0 {
 		return "", msg.ReplaceExecutableFailed(target, syscall.EACCES)
 	}
+	return authenticatePrivilege(target, isTerminal(os.Stderr), os.Stderr)
+}
 
+func authenticatePrivilege(target string, interactive bool, notice io.Writer) (string, error) {
 	for _, name := range []string{"sudo", "doas"} {
 		path, err := exec.LookPath(name)
 		if err != nil {
 			continue
 		}
-		args := []string{"true"}
-		if !isTerminal(os.Stderr) {
-			args = []string{"-n", "true"}
-		} else if name == "sudo" {
-			args = []string{"-v"}
+		args := []string{"-n", "true"}
+		if interactive {
+			// パスワードを聞かれる前に、なぜ root 権限が要るのかを出す。
+			fmt.Fprintln(notice, msg.PrivilegeExplanation(target, name))
+			args = []string{"true"}
+			if name == "sudo" {
+				args = []string{"-v"}
+			}
 		}
 		command := exec.Command(path, args...)
 		command.Stdin = os.Stdin

--- a/cmd/hso/update_test.go
+++ b/cmd/hso/update_test.go
@@ -273,6 +273,32 @@ func TestReplacementPrivilegeUsesSudoForProtectedDirectory(t *testing.T) {
 	}
 }
 
+func TestAuthenticatePrivilegeExplainsWhyRootIsNeeded(t *testing.T) {
+	commandDirectory := t.TempDir()
+	sudo := filepath.Join(commandDirectory, "sudo")
+	if err := os.WriteFile(sudo, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", commandDirectory)
+	target := "/usr/local/bin/hso"
+
+	var notice bytes.Buffer
+	if _, err := authenticatePrivilege(target, true, &notice); err != nil {
+		t.Fatal(err)
+	}
+	if notice.String() != msg.PrivilegeExplanation(target, "sudo")+"\n" {
+		t.Fatalf("notice = %q", notice.String())
+	}
+
+	notice.Reset()
+	if _, err := authenticatePrivilege(target, false, &notice); err != nil {
+		t.Fatal(err)
+	}
+	if notice.Len() != 0 {
+		t.Fatalf("notice = %q, want empty when not interactive", notice.String())
+	}
+}
+
 func TestPrivilegedReplacementRunsCreateCopyChmodMove(t *testing.T) {
 	directory := t.TempDir()
 	source := filepath.Join(directory, "downloaded-hso")

--- a/install.sh
+++ b/install.sh
@@ -335,6 +335,7 @@ main() {
         if command -v sudo >/dev/null 2>&1; then
             privileged=sudo
             if [ -t 2 ]; then
+                printf 'Installing into %s needs root, so sudo will ask for your password:\n' "$dir" >&2
                 sudo -v || die "sudo authentication failed"
             else
                 sudo -n true || die "sudo requires a terminal or cached credentials"
@@ -342,6 +343,7 @@ main() {
         elif command -v doas >/dev/null 2>&1; then
             privileged=doas
             if [ -t 2 ]; then
+                printf 'Installing into %s needs root, so doas will ask for your password:\n' "$dir" >&2
                 doas true || die "doas authentication failed"
             else
                 doas -n true || die "doas requires a terminal or cached credentials"

--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -715,6 +715,10 @@ func BinaryMissingFromArchive() error {
 	return errors.New("the update archive does not contain hso")
 }
 
+func PrivilegeExplanation(target, tool string) string {
+	return fmt.Sprintf("hso needs root to replace %s, so it will ask %s for your password:", target, tool)
+}
+
 func PrivilegeAuthenticationFailed(tool string, err error) error {
 	return fmt.Errorf("could not authenticate with %s: %w", tool, err)
 }

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -713,6 +713,10 @@ func BinaryMissingFromArchive() error {
 	return errors.New("更新用アーカイブに hso がありません")
 }
 
+func PrivilegeExplanation(target, tool string) string {
+	return fmt.Sprintf("%s を置き換えるには root 権限が必要なため、%s でパスワードを確認します:", target, tool)
+}
+
 func PrivilegeAuthenticationFailed(tool string, err error) error {
 	return fmt.Errorf("%s で権限を確認できませんでした: %w", tool, err)
 }


### PR DESCRIPTION
Closes #85

## WHY
`hso update` と `install.sh --system` は、対象が root しか書けない場所にあると sudo / doas の認証を挟む。
しかしこれまでは何の前置きもなくパスワード入力だけが出ていたため、ユーザーからは
「なぜ hso がパスワードを要求してくるのか」が分からず、入力してよいのか判断できなかった。

なお uninstall は `sudo hso uninstall` とコマンド自体に sudo を書いてもらう案内なので、対象外。

## What
- `internal/msg` に `PrivilegeExplanation(target, tool)` を追加（ja / en 両方）
- `cmd/hso/update.go`: 昇格コマンドを叩く直前に、置き換える対象パスと使う昇格コマンドを stderr に出す
  - `replacementPrivilege` から `authenticatePrivilege(target, interactive, notice)` を切り出し、
    端末判定を引数にして案内の有無をテストできるようにした
  - 非対話（`-n` を付けて即座に失敗させる経路）では従来どおり何も出さない
- `install.sh`: `--system` で sudo / doas を呼ぶ直前に、インストール先と理由を出す（対話端末のときだけ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)