### PR TITLE
fix: 日本語入力の仮入力をコンソール入力位置に出す

### DIFF
--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -571,6 +571,45 @@ func TestModelMovesBetweenPanelsInSelectMode(t *testing.T) {
 	}
 }
 
+// IME の候補窓は端末のカーソル位置に出るので、入力欄に居る間はキャレットが
+// 入力の末尾に立っていないといけない。
+func TestModelPutsTheCursorAtTheConsoleCaret(t *testing.T) {
+	model := newTestModel()
+	_, _ = model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	for _, character := range "say hi" {
+		_, _ = model.Update(tea.KeyPressMsg{
+			Code: character,
+			Text: string(character),
+		})
+	}
+
+	cursor := model.View().Cursor
+	if cursor == nil {
+		t.Fatal("cursor is hidden while editing the console")
+	}
+	if cursor.X != 3+len("say hi") {
+		t.Fatalf("cursor.X = %d, want %d", cursor.X, 3+len("say hi"))
+	}
+	lines := strings.Split(stripANSI(model.View().Content), "\n")
+	if cursor.Y >= len(lines) {
+		t.Fatalf("cursor.Y = %d, lines = %d", cursor.Y, len(lines))
+	}
+	line := []rune(lines[cursor.Y])
+	if !strings.Contains(string(line), "> say hi") {
+		t.Fatalf("line = %q", string(line))
+	}
+	// キャレットの桁は空けておく。端末のカーソルが文字を覆い隠さないように。
+	if cursor.X >= len(line) || line[cursor.X] != ' ' {
+		t.Fatalf("line = %q, cursor.X = %d", string(line), cursor.X)
+	}
+
+	// 入力欄を離れたらキャレットも消す。
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if model.View().Cursor != nil {
+		t.Fatal("cursor outlived the console focus")
+	}
+}
+
 func TestModelScrollsFocusedBufferAndKeepsPositionOnNewLines(t *testing.T) {
 	model := newTestModel()
 	_, _ = model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
@@ -1220,6 +1259,11 @@ func stripANSI(value string) string {
 	return ansi.Strip(value)
 }
 
+func consoleText(model *Model) string {
+	line, _ := model.consoleLine()
+	return line
+}
+
 func containsBraille(value string) bool {
 	for _, character := range value {
 		if character >= 0x2800 && character <= 0x28ff {
@@ -1302,11 +1346,11 @@ func TestModelRestartAnimatesUntilServerStarts(t *testing.T) {
 		t.Fatalf("restartPhase = %d, command = %T", model.restartPhase, command)
 	}
 	// 点は 3 桁に揃え、コンソールのボタン幅を揺らさない。
-	if console := stripANSI(model.consoleLine()); !strings.Contains(console, "[restarting.  ]") {
+	if console := stripANSI(consoleText(model)); !strings.Contains(console, "[restarting.  ]") {
 		t.Fatalf("console = %q", console)
 	}
 	_, _ = model.Update(restartTickMsg{})
-	if console := stripANSI(model.consoleLine()); !strings.Contains(console, "[restarting.. ]") {
+	if console := stripANSI(consoleText(model)); !strings.Contains(console, "[restarting.. ]") {
 		t.Fatalf("console = %q", console)
 	}
 
@@ -1314,7 +1358,7 @@ func TestModelRestartAnimatesUntilServerStarts(t *testing.T) {
 	if model.restartPhase != 0 {
 		t.Fatal("animation outlived the restart")
 	}
-	if console := stripANSI(model.consoleLine()); !strings.Contains(console, "[restart]") {
+	if console := stripANSI(consoleText(model)); !strings.Contains(console, "[restart]") {
 		t.Fatalf("console = %q", console)
 	}
 	// 止まった後の tick では再武装しない。

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -12,6 +12,8 @@ import (
 
 func (model *Model) View() tea.View {
 	var content string
+	// caretX は入力欄のキャレットの桁。入力欄に居ないときは -1。
+	caretX := -1
 	if !model.layout.ready {
 		content = fmt.Sprintf(
 			"hijo-server-ops\n\nterminal is too small: %dx%d\nminimum: %dx%d",
@@ -59,9 +61,11 @@ func (model *Model) View() tea.View {
 			model.layout.bodyHeight,
 		)
 		body := joinColumns(left, logs)
+		var consoleText string
+		consoleText, caretX = model.consoleLine()
 		footer := renderPanel(
 			panelConsole.title(),
-			[]string{model.consoleLine()},
+			[]string{consoleText},
 			model.layout.width,
 			footerHeight,
 			false,
@@ -88,11 +92,20 @@ func (model *Model) View() tea.View {
 			box, x, y := model.commandModal()
 			content = overlay(content, box, x, y)
 		}
+		// モーダルが重なっている間はキーが入力欄へ届かない。
+		if model.exit != nil || model.timeModal != nil || model.settingsOpen {
+			caretX = -1
+		}
 	}
 
 	view := tea.NewView(content)
 	view.AltScreen = true
 	view.WindowTitle = model.windowTitle()
+	// IME の候補窓は端末のカーソル位置に出る。キャレットを入力欄へ置かないと
+	// 直前の描画位置に取り残され、仮入力が画面の途中に現れる。
+	if caretX >= 0 {
+		view.Cursor = tea.NewCursor(caretX, statsHeight+model.layout.bodyHeight+1)
+	}
 	return view
 }
 
@@ -103,16 +116,19 @@ func (model *Model) windowTitle() string {
 	return model.info.Name + " · hijo-server-ops"
 }
 
-func (model *Model) consoleLine() string {
+// consoleLine は入力欄の行と、そこに置くキャレットの桁を返す。桁は入力欄に
+// 居ないとき -1。キャレットは文字で描かず端末のカーソルそのものを置くので、
+// 行の側では 1 桁ぶんの空きだけ確保する。
+func (model *Model) consoleLine() (string, int) {
 	restart := "[restart]"
 	if model.restartPhase != 0 {
 		restart = "[restarting" + model.restartDots() + "]"
 	}
 	stop := "[stop]"
 	focused := model.mode == modeFocus && model.panel == panelConsole
-	cursor := ""
+	caret := ""
 	if focused && model.consoleFocus == consoleInput {
-		cursor = "█"
+		caret = " "
 	}
 	if focused && model.consoleFocus == consoleRestart {
 		restart = selectedStyle.Render(restart)
@@ -130,8 +146,13 @@ func (model *Model) consoleLine() string {
 		0,
 		model.layout.width-2-stringWidth(buttons)-3,
 	)
-	input := tail(string(model.input), max(0, inputWidth-stringWidth(cursor)))
-	return fitLine("> "+input+cursor+" "+buttons, model.layout.width-2)
+	input := tail(string(model.input), max(0, inputWidth-stringWidth(caret)))
+	caretX := -1
+	if caret != "" {
+		// 枠の 1 桁と "> " の 2 桁の右、入力の末尾がキャレットの位置。
+		caretX = 3 + stringWidth(input)
+	}
+	return fitLine("> "+input+caret+" "+buttons, model.layout.width-2), caretX
 }
 
 func tail(value string, width int) string {


### PR DESCRIPTION
Closes #75

## WHY

日本語入力中、仮入力（プリエディット）と変換候補ウィンドウが画面の途中に現れて、
どこに何を打っているのか分からない状態だった。

IME の候補窓の位置は、端末エミュレータが**ハードウェアカーソルの位置**を基準に決める。
hso は入力欄のキャレットを `█` という文字として描いているだけで、端末のカーソルは
一度も動かしていなかった。Bubble Tea v2 のレンダラは `View.Cursor` が nil のとき
`MoveTo` を呼ばずカーソルを消すので、物理カーソルはその描画で最後に書き換えたセルに
取り残される。hso は毎フレーム全画面を差分描画しているため、その位置はログやグラフの
更新箇所に応じて画面中央あたりをうろつく。これが「仮入力が真ん中に出る」の原因。

## What

- `consoleLine()` が行とキャレットの桁を返すようにした。`█` を文字で描くのをやめ、
  行の側では 1 桁ぶんの空きだけ確保する
- `View()` で、コンソール入力にフォーカスしている間だけ `view.Cursor` を入力の末尾に
  立てる。モーダルが重なっている間はキーが入力欄へ届かないので消す
- キャレットの桁と行が入力行に一致していることを見る回帰テストを追加

実機で日本語入力を確認済み。候補窓が `> ` の直後、入力済み文字列の末尾に付いてくる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)