### PR TITLE
feat: hso list のパス欄をサーバーのディレクトリにする

### DIFF
--- a/cmd/hso/list.go
+++ b/cmd/hso/list.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/x/ansi"
@@ -53,7 +54,7 @@ func printServerList(
 			return err
 		}
 		label := status.label()
-		rows = append(rows, row{server.Name, label, server.Config})
+		rows = append(rows, row{server.Name, label, filepath.Dir(server.Config)})
 		nameWidth = max(nameWidth, ansi.StringWidth(server.Name))
 		statusWidth = max(statusWidth, ansi.StringWidth(label))
 	}

--- a/cmd/hso/list_test.go
+++ b/cmd/hso/list_test.go
@@ -53,11 +53,14 @@ func TestPrintServerListShowsAllStatuses(t *testing.T) {
 		msg.ConfigNotFound,
 		msg.ServerStopped,
 		msg.ServerRunning(4321),
-		stoppedConfig,
+		directory,
 	} {
 		if !strings.Contains(output.String(), want) {
 			t.Errorf("output = %q に %q がない", output.String(), want)
 		}
+	}
+	if strings.Contains(output.String(), stoppedConfig) {
+		t.Errorf("output = %q に設定ファイルのフルパスがある", output.String())
 	}
 }
 
@@ -86,7 +89,7 @@ func TestPrintServerListAlignsColumnsWithFullWidthValues(t *testing.T) {
 	pathColumn := -1
 	for index, line := range lines {
 		status := []string{msg.ListStatusHeader, msg.ServerStopped, msg.ConfigNotFound}[index]
-		path := []string{msg.ListPathHeader, stoppedConfig, filepath.Join(directory, "missing.toml")}[index]
+		path := []string{msg.ListPathHeader, directory, directory}[index]
 		statusIndex := strings.Index(line, status)
 		pathIndex := strings.Index(line, path)
 		if statusIndex < 0 || pathIndex < 0 {


### PR DESCRIPTION
Closes #93

## WHY

`hso list` のパス欄に登録された設定ファイルのパスをそのまま出していた。
`hso.toml` というファイル名は全サーバーで共通なので、一覧に並べても情報量がなく、
ユーザーが知りたいサーバーの置き場所が末尾のファイル名に埋もれていた。

## What

- `printServerList` のパス欄を `filepath.Dir(server.Config)` に変更した。表示だけの変更で、
  レジストリに保存するパスは今までどおり `hso.toml` の絶対パス
- `hso delete` の確認メッセージや `RegisteredConfigNotFound` などのエラーは、
  設定ファイルのパスを出し続ける。どのファイルが無いのかを伝える必要があるのはそちら
- 既存テストを親ディレクトリが出ることの確認に直し、設定ファイルのフルパスが
  出ていないことのアサーションを足した

## 検証

`go test ./...` / `go test -tags en ./...` が全パッケージ green、`gofmt -l .` は空、`go vet ./...` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)