### PR TITLE
feat: 一覧の選択を数字キーでも行えるようにする

### DIFF
--- a/cmd/hso/start.go
+++ b/cmd/hso/start.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -71,6 +72,12 @@ func (m *startModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if key.String() == "ctrl+c" {
 			return m, tea.Quit
 		}
+		if len(key.Text) == 1 && key.Text[0] >= '1' && key.Text[0] <= '9' {
+			index := int(key.Text[0] - '1')
+			if index < len(m.rows) {
+				m.cursor = index
+			}
+		}
 	}
 	if m.cursor < 0 {
 		m.cursor = 0
@@ -91,7 +98,11 @@ func (m *startModel) View() tea.View {
 	end := min(start+startListViewport, len(m.rows))
 	for index := start; index < end; index++ {
 		row := m.rows[index]
-		label := row.server.Name + strings.Repeat(" ", nameWidth-ansi.StringWidth(row.server.Name)+2) +
+		number := "  "
+		if index < 9 {
+			number = fmt.Sprintf("%d ", index+1)
+		}
+		label := number + row.server.Name + strings.Repeat(" ", nameWidth-ansi.StringWidth(row.server.Name)+2) +
 			row.status.label()
 		if index == m.cursor {
 			lines = append(lines, "  "+startSelectedStyle.Render(" "+label+" "))
@@ -102,7 +113,7 @@ func (m *startModel) View() tea.View {
 	if end < len(m.rows) {
 		lines = append(lines, startDimStyle.Render("   …"))
 	}
-	keys := startKeyStyle.Render(" ↑↓ ") + " " + msg.KeySelect + "  " +
+	keys := startKeyStyle.Render(" ↑↓ / 1-9 ") + " " + msg.KeySelect + "  " +
 		startKeyStyle.Render(" Enter ") + " " + msg.KeyConfirm + "  " +
 		startKeyStyle.Render(" Esc / Ctrl+C ") + " " + msg.KeyAbort
 	lines = append(lines, "", keys)

--- a/cmd/hso/start_test.go
+++ b/cmd/hso/start_test.go
@@ -191,6 +191,32 @@ func TestStartModelSelectsWithArrowAndEnter(t *testing.T) {
 	}
 }
 
+func TestStartModelSelectsWithNumberAndEnter(t *testing.T) {
+	model := &startModel{rows: []startRow{
+		{server: registry.Server{Name: "survival"}},
+		{server: registry.Server{Name: "creative"}},
+		{server: registry.Server{Name: "adventure"}},
+	}}
+	_, _ = model.Update(tea.KeyPressMsg{Text: "3"})
+	if model.cursor != 2 || model.chosen {
+		t.Fatalf("cursor = %d, chosen = %t", model.cursor, model.chosen)
+	}
+	_, _ = model.Update(tea.KeyPressMsg{Text: "5"})
+	if model.cursor != 2 {
+		t.Fatalf("範囲外の番号で cursor = %d", model.cursor)
+	}
+	_, command := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !model.chosen || model.selected.Name != "adventure" || command == nil {
+		t.Fatalf("chosen = %t, selected = %#v, command = %v", model.chosen, model.selected, command)
+	}
+	view := model.View().Content
+	for _, want := range []string{"1 survival", "2 creative", "3 adventure", "↑↓ / 1-9"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("view = %q に %q がない", view, want)
+		}
+	}
+}
+
 func TestDispatchStartRejectsExtraArguments(t *testing.T) {
 	handled, err := dispatchCommand([]string{"start", "one", "two"}, &strings.Builder{})
 	if !handled || err == nil {

--- a/internal/setup/model.go
+++ b/internal/setup/model.go
@@ -276,6 +276,12 @@ func (m *model) editInput(key tea.Key) {
 }
 
 func moveCursor(key tea.Key, cursor, count int) int {
+	if len(key.Text) == 1 && key.Text[0] >= '1' && key.Text[0] <= '9' {
+		index := int(key.Text[0] - '1')
+		if index < count {
+			cursor = index
+		}
+	}
 	switch key.Code {
 	case tea.KeyUp:
 		cursor--

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -283,6 +283,30 @@ func TestModelCreatesConfig(t *testing.T) {
 	}
 }
 
+func TestModelSelectsCommandWithNumber(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "run.sh"), 0o755)
+	writeFile(t, filepath.Join(dir, "start.sh"), 0o755)
+
+	model := newModel(filepath.Join(dir, "hso.toml"), registry.Registry{})
+	press(t, model, enter, enter)
+	if model.step != stepCommand || len(model.candidates) != 2 {
+		t.Fatalf("step = %d, candidates = %#v", model.step, model.candidates)
+	}
+	press(t, model, typeText("3"))
+	if model.cursor != 2 || model.step != stepCommand {
+		t.Fatalf("cursor = %d, step = %d", model.cursor, model.step)
+	}
+	press(t, model, typeText("9"))
+	if model.cursor != 2 {
+		t.Fatalf("範囲外の番号で cursor = %d", model.cursor)
+	}
+	view := model.View().Content
+	if !strings.Contains(view, "3 "+msg.SetupManualEntry) || !strings.Contains(view, "↑↓ / 1-9") {
+		t.Fatalf("view = %q", view)
+	}
+}
+
 func TestModelManualEntry(t *testing.T) {
 	dir := t.TempDir()
 	server := filepath.Join(dir, "server")

--- a/internal/setup/view.go
+++ b/internal/setup/view.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"fmt"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -119,11 +120,16 @@ func (m *model) candidateLines() []string {
 	end := min(start+listViewport, len(labels))
 	lines := make([]string, 0, end-start)
 	for index := start; index < end; index++ {
+		number := "  "
+		if index < 9 {
+			number = fmt.Sprintf("%d ", index+1)
+		}
+		label := number + labels[index]
 		if index == m.cursor {
-			lines = append(lines, "  "+selectedStyle.Render(" "+labels[index]+" "))
+			lines = append(lines, "  "+selectedStyle.Render(" "+label+" "))
 			continue
 		}
-		lines = append(lines, "   "+labels[index])
+		lines = append(lines, "   "+label)
 	}
 	if end < len(labels) {
 		lines = append(lines, dimStyle.Render("   …"))
@@ -173,7 +179,7 @@ func (m *model) keybar() string {
 		)
 	case stepCommand:
 		keys = append(keys,
-			[2]string{"↑↓", msg.KeySelect},
+			[2]string{"↑↓ / 1-9", msg.KeySelect},
 			[2]string{"Enter", msg.KeyConfirm},
 			[2]string{"Esc", msg.KeyBack},
 		)


### PR DESCRIPTION
Closes #91

## WHY

一覧から選ぶ画面が ↑↓ でしか動かせなかった。サーバー選択（`hso start` / `hso delete` /
`hso java` を引数なしで実行したとき）とセットアップの起動スクリプト候補で、
下のほうの項目を選ぶのにキーを何度も押す必要があった。

## What

- サーバー選択リスト（`cmd/hso/start.go` の `startModel`）とセットアップの候補リスト
  （`internal/setup` の `stepCommand`）の各行の先頭に、1 から始まる番号を表示した
- その数字キーでカーソルをその行へ飛ばせるようにした。**決定は従来どおり Enter**。
  数字で即確定にはしていない。`hso delete` は破壊的な操作で、打ち間違いが
  そのまま実行に繋がるため
- 番号は 1〜9 だけ。10 行目以降は同じ幅の空白で桁を揃え、番号を振らずに ↑↓ で選ぶ。
  複数桁の入力を受けるには打ちかけを保持する状態とタイムアウトが要るが、
  登録サーバーがその数になる想定は薄く、複雑さに見合わない
- 範囲外の番号（項目が 3 件のときの `5` など）を押しても何も起きない
- キーバーの表示を `↑↓ / 1-9  選択` に更新した。キーラベル側だけの変更なので
  `internal/msg` への追加はない
- TUI 本体の設定モーダルは対象外。値を ←→ で変える画面で数字が馴染まないため

## 検証

`go test ./...` / `go test -tags en ./...` が全パッケージ green、`gofmt -l .` は空、`go vet ./...` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)