### PR TITLE
feat: 画面の選択とスクロールをマウスでも行えるようにする

### DIFF
--- a/internal/ui/buffer.go
+++ b/internal/ui/buffer.go
@@ -75,6 +75,11 @@ type lineBuffer struct {
 	offsetMinutes int
 }
 
+// Following は最新行へ追従しているかを返す。
+func (buffer *lineBuffer) Following() bool {
+	return buffer.anchor.record == 0
+}
+
 func (buffer *lineBuffer) Add(record logRecord) {
 	if len(buffer.lines) == 0 {
 		return

--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -266,14 +266,18 @@ func (model *Model) renderPlayersPanel() string {
 
 func (model *Model) commandModal() (string, int, int) {
 	width := stringWidth(model.playerTarget) + 5
-	for _, command := range playerCommands {
-		width = max(width, stringWidth(command.label)+4)
+	for index, command := range playerCommands {
+		width = max(width, stringWidth(command.label)+stringWidth(commandAccelerator(index))+4)
 	}
 	height := len(playerCommands) + 2
 
 	lines := make([]string, 0, len(playerCommands))
 	for index, command := range playerCommands {
-		line := fitLine(" "+command.label, width-2)
+		key := commandAccelerator(index)
+		line := command.label + strings.Repeat(
+			" ", max(1, width-2-stringWidth(command.label)-stringWidth(key)),
+		) + key
+		line = fitLine(line, width-2)
 		if index == model.commandCursor {
 			line = selectedStyle.Render(line)
 		}

--- a/internal/ui/frame.go
+++ b/internal/ui/frame.go
@@ -71,17 +71,20 @@ func (box frame) render(value string) string {
 }
 
 func (model *Model) frameFor(target panel) frame {
-	if model.mode == modeSelect && !model.selected {
-		return plainFrame
-	}
-	if model.panel != target {
-		if model.mode == modeSelect && model.hovering && model.hover == target {
+	if model.mode == modeSelect {
+		// ホバーは選択枠を消した後も出す。マウスだけで操作を再開する
+		// とっかかりが無くなるため。
+		if model.hovering && model.hover == target &&
+			(!model.selected || model.panel != target) {
 			return hoverFrame
 		}
+		if !model.selected || model.panel != target {
+			return plainFrame
+		}
+		return selectedFrame
+	}
+	if model.panel != target {
 		return plainFrame
 	}
-	if model.mode == modeFocus {
-		return focusedFrame
-	}
-	return selectedFrame
+	return focusedFrame
 }

--- a/internal/ui/frame.go
+++ b/internal/ui/frame.go
@@ -33,6 +33,15 @@ var (
 			Foreground(lipgloss.Color("#8BE9FD")).
 			Bold(true),
 	}
+	hoverFrame = frame{
+		topLeft:     "┌",
+		topRight:    "┐",
+		bottomLeft:  "└",
+		bottomRight: "┘",
+		horizontal:  "─",
+		vertical:    "│",
+		style:       lipgloss.NewStyle().Foreground(lipgloss.Color("#8BE9FD")),
+	}
 	focusedFrame = frame{
 		topLeft:     "┏",
 		topRight:    "┓",
@@ -62,7 +71,13 @@ func (box frame) render(value string) string {
 }
 
 func (model *Model) frameFor(target panel) frame {
+	if model.mode == modeSelect && !model.selected {
+		return plainFrame
+	}
 	if model.panel != target {
+		if model.mode == modeSelect && model.hovering && model.hover == target {
+			return hoverFrame
+		}
 		return plainFrame
 	}
 	if model.mode == modeFocus {

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -145,6 +145,7 @@ func (model *Model) handlePlayersKey(key tea.Key) (tea.Model, tea.Cmd) {
 	case tea.KeyEscape:
 		model.playerCursor = 0
 		model.mode = modeSelect
+		model.selected = true
 	case tea.KeyEnter, tea.KeyKpEnter:
 		if model.playerCursor < len(model.playerList) {
 			model.playerTarget = model.playerList[model.playerCursor]
@@ -162,17 +163,46 @@ func (model *Model) handlePlayerCommandKey(key tea.Key) (tea.Model, tea.Cmd) {
 	case tea.KeyEscape:
 		model.playerStage = playerStagePlayers
 	case tea.KeyEnter, tea.KeyKpEnter:
-		command := playerCommands[model.commandCursor]
-		// 実行前に Console へ置くことで、破壊的なコマンドにも確認を挟む。
-		model.input = []rune(fmt.Sprintf(command.template, model.playerTarget))
-		model.playerStage = playerStagePlayers
-		model.panel = panelConsole
-		model.consoleFocus = consoleInput
+		model.applyPlayerCommand(model.commandCursor)
 	default:
-		model.commandCursor = moveCursor(key, model.commandCursor,
-			len(playerCommands), model.layout.playerLines())
+		if index, ok := playerCommandIndex(key.Code); ok {
+			model.applyPlayerCommand(index)
+		} else {
+			model.commandCursor = moveCursor(key, model.commandCursor,
+				len(playerCommands), model.layout.playerLines())
+		}
 	}
 	return model, nil
+}
+
+func (model *Model) applyPlayerCommand(index int) {
+	if index < 0 || index >= len(playerCommands) {
+		return
+	}
+	command := playerCommands[index]
+	// 実行前に Console へ置くことで、破壊的なコマンドにも確認を挟む。
+	model.input = []rune(fmt.Sprintf(command.template, model.playerTarget))
+	model.playerStage = playerStagePlayers
+	model.panel = panelConsole
+	model.consoleFocus = consoleInput
+}
+
+const playerCommandAccelerators = "123456789qwertyuio"
+
+func playerCommandIndex(code rune) (int, bool) {
+	for index := range playerCommands {
+		if code == rune(playerCommandAccelerators[index]) {
+			return index, true
+		}
+	}
+	return 0, false
+}
+
+func commandAccelerator(index int) string {
+	if index < 0 || index >= len(playerCommandAccelerators) {
+		return ""
+	}
+	return "( " + string(playerCommandAccelerators[index]) + " )"
 }
 
 func moveCursor(key tea.Key, cursor, count, viewport int) int {
@@ -204,16 +234,29 @@ func (model *Model) handleSelectKey(key tea.Key) (tea.Model, tea.Cmd) {
 	move := neighbors[model.panel]
 	switch key.Code {
 	case tea.KeyUp:
+		model.selected = true
 		model.panel = move.up
 	case tea.KeyDown:
+		model.selected = true
 		model.panel = move.down
 	case tea.KeyLeft:
+		model.selected = true
 		model.panel = move.left
 	case tea.KeyRight:
+		model.selected = true
 		model.panel = move.right
 	case tea.KeyEnter, tea.KeyKpEnter:
+		if !model.selected {
+			return model, nil
+		}
 		model.mode = modeFocus
 		model.consoleFocus = consoleInput
+	case tea.KeyEscape:
+		if buffer, _ := model.bufferFor(model.panel); buffer != nil && !buffer.Following() {
+			buffer.ScrollToEnd()
+		} else if model.panel == panelChat || model.panel == panelLog {
+			model.selected = false
+		}
 	}
 	return model, nil
 }
@@ -225,6 +268,7 @@ func (model *Model) handleConsoleKey(key tea.Key) (tea.Model, tea.Cmd) {
 	switch key.Code {
 	case tea.KeyEscape:
 		model.mode = modeSelect
+		model.selected = true
 	case tea.KeyTab:
 		if model.consoleFocus == consoleInput {
 			candidates := model.completions()
@@ -268,9 +312,12 @@ func (model *Model) handleBufferKey(key tea.Key) (tea.Model, tea.Cmd) {
 
 	switch key.Code {
 	case tea.KeyEscape:
-		// フォーカスを外した後の新着を見落とさないよう最新へ戻す。
-		buffer.ScrollToEnd()
-		model.mode = modeSelect
+		if !buffer.Following() {
+			buffer.ScrollToEnd()
+		} else {
+			model.mode = modeSelect
+			model.selected = true
+		}
 	case tea.KeyUp:
 		buffer.Scroll(1, viewport)
 	case tea.KeyDown:
@@ -294,7 +341,11 @@ func (model *Model) focusedBuffer() (*lineBuffer, bufferViewport) {
 			height: max(0, model.layout.height-3),
 		}
 	}
-	switch model.panel {
+	return model.bufferFor(model.panel)
+}
+
+func (model *Model) bufferFor(target panel) (*lineBuffer, bufferViewport) {
+	switch target {
 	case panelChat:
 		return &model.chat, bufferViewport{
 			width:  model.layout.leftContentWidth(),

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -118,3 +118,30 @@ func (current layout) rightContentWidth() int {
 	}
 	return max(0, current.rightWidth-2)
 }
+
+// panelAt は画面座標にある操作対象のパネルを返す。表示専用パネルと枠線は
+// 選択対象にしないため false を返す。
+func (current layout) panelAt(x, y int) (panel, bool) {
+	if !current.ready || x < 0 || y < 0 || x >= current.width || y >= current.height {
+		return panelPlayers, false
+	}
+	if y < statsHeight {
+		if x < current.statsWidth+current.metersWidth {
+			return panelPlayers, false
+		}
+		return panelPlayers, true
+	}
+	if y < statsHeight+current.bodyHeight {
+		if x < current.leftWidth {
+			if y < statsHeight+current.graphHeight {
+				return panelPlayers, false
+			}
+			return panelChat, true
+		}
+		return panelLog, true
+	}
+	if y < statsHeight+current.bodyHeight+footerHeight {
+		return panelConsole, true
+	}
+	return panelPlayers, false
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -102,14 +102,18 @@ type Model struct {
 	info   ServerInfo
 	// runErr は現世代で最初に起きた終了原因。後続の終了通知でも上書きせず、
 	// ServerStartedMsg で復旧したときだけ消す。
-	runErr            error
-	actions           chan<- Action
-	save              func(Settings) error
-	input             []rune
-	completionOpen    bool
-	completionCursor  int
-	mode              mode
-	panel             panel
+	runErr           error
+	actions          chan<- Action
+	save             func(Settings) error
+	input            []rune
+	completionOpen   bool
+	completionCursor int
+	mode             mode
+	panel            panel
+	// selected は選択モードで選択枠を出すかを表す。フォーカス中は常に枠を出す。
+	selected          bool
+	hover             panel
+	hovering          bool
 	consoleFocus      consoleFocus
 	busy              bool
 	generation        uint64
@@ -211,6 +215,12 @@ func (model *Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	switch message := message.(type) {
 	case tea.KeyPressMsg:
 		return model.handleKey(message)
+	case tea.MouseMotionMsg:
+		return model.handleMouseMotion(message)
+	case tea.MouseClickMsg:
+		return model.handleMouseClick(message)
+	case tea.MouseWheelMsg:
+		return model.handleMouseWheel(message)
 	case tea.WindowSizeMsg:
 		model.resize(message.Width, message.Height)
 	case LogMsg:

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -656,7 +656,7 @@ func TestModelScrollsFocusedBufferAndKeepsPositionOnNewLines(t *testing.T) {
 	}
 }
 
-func TestModelReturnsToLatestWhenFocusIsReleased(t *testing.T) {
+func TestModelEscMovesBufferThroughThreeStages(t *testing.T) {
 	model := newTestModel()
 	_, _ = model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	viewport := model.layout.logLines()
@@ -678,11 +678,26 @@ func TestModelReturnsToLatestWhenFocusIsReleased(t *testing.T) {
 	}
 
 	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
-	if model.mode != modeSelect {
+	if model.mode != modeFocus {
 		t.Fatalf("mode = %d", model.mode)
 	}
 	if model.logs.Offset(logViewport) != 0 {
 		t.Fatalf("offset = %d, want 0", model.logs.Offset(logViewport))
+	}
+	// 最新表示中の Esc はフォーカスを外す。
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if model.mode != modeSelect || !model.selected {
+		t.Fatalf("mode = %d, selected = %t", model.mode, model.selected)
+	}
+	// 選択モードでの Esc は枠を消す。
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if model.selected {
+		t.Fatal("selected frame remains after the third Escape")
+	}
+	// 移動キーで再び選択できる。
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	if !model.selected {
+		t.Fatal("arrow key did not restore selection")
 	}
 	if !strings.Contains(model.View().Content, "line "+fmt.Sprint(viewport*3-1)) {
 		t.Fatalf("view does not show the latest line")
@@ -1072,6 +1087,24 @@ func TestModelPutsPlayerCommandIntoTheConsole(t *testing.T) {
 	action := <-actions
 	if action.Kind != ActionSendCommand || action.Command != "kick bob" {
 		t.Fatalf("action = %#v", action)
+	}
+}
+
+func TestModelPutsAcceleratedPlayerCommandIntoTheConsole(t *testing.T) {
+	model := newTestModel()
+	_, _ = model.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	_, _ = model.Update(LogMsg{Entry: serverlog.Entry{
+		Kind: serverlog.KindPlayerJoin, Player: "alice",
+	}})
+	focusPlayers(t, model)
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	pressRune(model, 'q')
+
+	if got, want := string(model.input), "gamemode adventure alice"; got != want {
+		t.Fatalf("input = %q, want %q", got, want)
+	}
+	if model.panel != panelConsole || model.playerStage != playerStagePlayers {
+		t.Fatalf("panel = %d, stage = %d", model.panel, model.playerStage)
 	}
 }
 

--- a/internal/ui/mouse.go
+++ b/internal/ui/mouse.go
@@ -1,0 +1,95 @@
+package ui
+
+import tea "charm.land/bubbletea/v2"
+
+func (model *Model) mouseDiscarded() bool {
+	return model.settingsOpen || model.timeModal != nil || model.completionOpen ||
+		(model.mode == modeFocus && model.panel == panelPlayers &&
+			model.playerStage == playerStageCommands)
+}
+
+func (model *Model) handleMouseMotion(message tea.MouseMotionMsg) (tea.Model, tea.Cmd) {
+	if model.exit != nil || model.mouseDiscarded() {
+		return model, nil
+	}
+	target, ok := model.layout.panelAt(message.X, message.Y)
+	model.hovering = ok
+	if ok {
+		model.hover = target
+	}
+	return model, nil
+}
+
+func (model *Model) handleMouseClick(message tea.MouseClickMsg) (tea.Model, tea.Cmd) {
+	if model.exit != nil || model.mouseDiscarded() || message.Button != tea.MouseLeft {
+		return model, nil
+	}
+	if index, ok := model.playerAt(message.X, message.Y); ok {
+		model.playerCursor = index
+		model.playerTarget = model.playerList[index]
+		model.mode = modeFocus
+		model.panel = panelPlayers
+		model.playerStage = playerStageCommands
+		model.commandCursor = 0
+		model.selected = true
+		return model, nil
+	}
+	if target, ok := model.layout.panelAt(message.X, message.Y); ok {
+		model.panel = target
+		model.selected = true
+	}
+	return model, nil
+}
+
+func (model *Model) handleMouseWheel(message tea.MouseWheelMsg) (tea.Model, tea.Cmd) {
+	if model.mouseDiscarded() {
+		return model, nil
+	}
+	delta := 0
+	switch message.Button {
+	case tea.MouseWheelUp:
+		delta = 1
+	case tea.MouseWheelDown:
+		delta = -1
+	default:
+		return model, nil
+	}
+	// 終了モーダル中はログが全面に出ており、ダッシュボードとは幅も高さも
+	// 違う。focusedBuffer から全面用の viewport を取る。
+	if model.exit != nil {
+		buffer, viewport := model.focusedBuffer()
+		buffer.Scroll(delta*3, viewport)
+		return model, nil
+	}
+	target, ok := model.layout.panelAt(message.X, message.Y)
+	if !ok {
+		return model, nil
+	}
+	if target == panelPlayers {
+		if len(model.playerList) > 0 {
+			model.playerCursor = clamp(model.playerCursor-delta, 0, len(model.playerList)-1)
+		}
+		return model, nil
+	}
+	buffer, viewport := model.bufferFor(target)
+	if buffer != nil {
+		buffer.Scroll(delta*3, viewport)
+	}
+	return model, nil
+}
+
+// playerAt は Players の本文行に対応するプレイヤー一覧の添字を返す。
+func (model *Model) playerAt(x, y int) (int, bool) {
+	if !model.layout.ready || y < 1 || y > statsHeight-2 {
+		return 0, false
+	}
+	left := model.layout.statsWidth + model.layout.metersWidth
+	if x <= left || x >= left+model.layout.playersWidth-1 {
+		return 0, false
+	}
+	index := windowStart(model.playerCursor, len(model.playerList), model.layout.playerLines()) + y - 1
+	if index < 0 || index >= len(model.playerList) {
+		return 0, false
+	}
+	return index, true
+}

--- a/internal/ui/mouse.go
+++ b/internal/ui/mouse.go
@@ -42,9 +42,6 @@ func (model *Model) handleMouseClick(message tea.MouseClickMsg) (tea.Model, tea.
 }
 
 func (model *Model) handleMouseWheel(message tea.MouseWheelMsg) (tea.Model, tea.Cmd) {
-	if model.mouseDiscarded() {
-		return model, nil
-	}
 	delta := 0
 	switch message.Button {
 	case tea.MouseWheelUp:
@@ -55,10 +52,14 @@ func (model *Model) handleMouseWheel(message tea.MouseWheelMsg) (tea.Model, tea.
 		return model, nil
 	}
 	// 終了モーダル中はログが全面に出ており、ダッシュボードとは幅も高さも
-	// 違う。focusedBuffer から全面用の viewport を取る。
+	// 違う。focusedBuffer から全面用の viewport を取る。開いたままの
+	// モーダルは終了時に閉じないので、キー処理と同じく exit を先に見る。
 	if model.exit != nil {
 		buffer, viewport := model.focusedBuffer()
 		buffer.Scroll(delta*3, viewport)
+		return model, nil
+	}
+	if model.mouseDiscarded() {
 		return model, nil
 	}
 	target, ok := model.layout.panelAt(message.X, message.Y)

--- a/internal/ui/mouse_test.go
+++ b/internal/ui/mouse_test.go
@@ -123,3 +123,19 @@ func TestModelMouseWheelUsesFullScreenViewportOnExit(t *testing.T) {
 		t.Fatalf("offset = %d, want 3", offset)
 	}
 }
+
+// 選択枠を消した後もホバーは出す。マウスで操作を再開するとっかかりが
+// 無くなるため。
+func TestModelHoverFrameShowsWithoutSelection(t *testing.T) {
+	model := newTestModel()
+	model.resize(100, 24)
+	model.mode = modeSelect
+	model.selected = false
+	_, _ = model.Update(tea.MouseMotionMsg{X: model.layout.leftWidth, Y: statsHeight})
+	if got := model.frameFor(panelLog); got.render("─") != hoverFrame.render("─") {
+		t.Fatal("hover frame is not shown while nothing is selected")
+	}
+	if got := model.frameFor(panelChat); got.render("─") != plainFrame.render("─") {
+		t.Fatal("non-hovered panel is not plain")
+	}
+}

--- a/internal/ui/mouse_test.go
+++ b/internal/ui/mouse_test.go
@@ -1,0 +1,125 @@
+package ui
+
+import (
+	"fmt"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestLayoutPanelAt(t *testing.T) {
+	current := calculateLayout(100, 24)
+	tests := []struct {
+		name string
+		x, y int
+		want panel
+		ok   bool
+	}{
+		{name: "Stats", x: 0, y: 0},
+		{name: "Meters", x: current.statsWidth, y: 0},
+		{name: "Players", x: current.statsWidth + current.metersWidth, y: 0, want: panelPlayers, ok: true},
+		{name: "Graph", x: 0, y: statsHeight},
+		{name: "Chat", x: 0, y: statsHeight + current.graphHeight, want: panelChat, ok: true},
+		{name: "Log", x: current.leftWidth, y: statsHeight, want: panelLog, ok: true},
+		{name: "Console", x: 0, y: statsHeight + current.bodyHeight, want: panelConsole, ok: true},
+		{name: "Keybar", x: 0, y: statsHeight + current.bodyHeight + footerHeight},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := current.panelAt(test.x, test.y)
+			if got != test.want || ok != test.ok {
+				t.Fatalf("panelAt(%d, %d) = (%d, %t), want (%d, %t)", test.x, test.y, got, ok, test.want, test.ok)
+			}
+		})
+	}
+	if _, ok := (layout{}).panelAt(0, 0); ok {
+		t.Fatal("unready layout accepted a panel")
+	}
+}
+
+func TestModelMouseWheelScrollsBuffersAndPlayers(t *testing.T) {
+	model := newTestModel()
+	model.resize(100, 24)
+	for _, target := range []panel{panelChat, panelLog} {
+		buffer, viewport := model.bufferFor(target)
+		for index := 0; index < viewport.height*3; index++ {
+			buffer.Add(logRecord{text: fmt.Sprintf("line %d", index)})
+		}
+		x, y := 1, statsHeight+model.layout.graphHeight
+		if target == panelLog {
+			x, y = model.layout.leftWidth, statsHeight
+		}
+		_, _ = model.Update(tea.MouseWheelMsg{X: x, Y: y, Button: tea.MouseWheelUp})
+		if offset := buffer.Offset(viewport); offset != 3 {
+			t.Fatalf("%s offset = %d, want 3", target.title(), offset)
+		}
+	}
+	model.playerList = []string{"alice", "bob"}
+	_, _ = model.Update(tea.MouseWheelMsg{
+		X: model.layout.statsWidth + model.layout.metersWidth,
+		Y: 0, Button: tea.MouseWheelDown,
+	})
+	if model.playerCursor != 1 {
+		t.Fatalf("player cursor = %d, want 1", model.playerCursor)
+	}
+}
+
+func TestModelMouseIgnoresModalAndClickOpensPlayerCommands(t *testing.T) {
+	model := newTestModel()
+	model.resize(100, 24)
+	model.playerList = []string{"alice"}
+	x := model.layout.statsWidth + model.layout.metersWidth + 1
+
+	// 通常のクリックはモードを変えず、選択対象だけを差し替える。
+	_, _ = model.Update(tea.MouseClickMsg{
+		X: model.layout.leftWidth, Y: statsHeight, Button: tea.MouseLeft,
+	})
+	if model.panel != panelLog || model.mode != modeFocus || !model.selected {
+		t.Fatalf("panel click state = panel %d, mode %d, selected %t", model.panel, model.mode, model.selected)
+	}
+
+	_, _ = model.Update(tea.MouseClickMsg{X: x, Y: 1, Button: tea.MouseLeft})
+	if model.panel != panelPlayers || model.mode != modeFocus || model.playerStage != playerStageCommands || model.playerTarget != "alice" {
+		t.Fatalf("click state = panel %d, mode %d, stage %d, target %q", model.panel, model.mode, model.playerStage, model.playerTarget)
+	}
+
+	// コマンドモーダル中は背後のクリックとホイールを捨てる。
+	model.playerCursor = 0
+	_, _ = model.Update(tea.MouseWheelMsg{X: x, Y: 0, Button: tea.MouseWheelDown})
+	_, _ = model.Update(tea.MouseClickMsg{X: 0, Y: statsHeight + model.layout.bodyHeight, Button: tea.MouseLeft})
+	if model.panel != panelPlayers || model.playerCursor != 0 {
+		t.Fatalf("modal accepted mouse input: panel %d, cursor %d", model.panel, model.playerCursor)
+	}
+}
+
+func TestModelMouseMotionOnlyKeepsSelectablePanel(t *testing.T) {
+	model := newTestModel()
+	model.resize(100, 24)
+	model.mode = modeSelect
+	_, _ = model.Update(tea.MouseMotionMsg{
+		X: model.layout.leftWidth, Y: statsHeight,
+	})
+	if !model.hovering || model.hover != panelLog {
+		t.Fatalf("hover = (%d, %t), want Log", model.hover, model.hovering)
+	}
+	_, _ = model.Update(tea.MouseMotionMsg{X: 0, Y: 0})
+	if model.hovering {
+		t.Fatal("Stats panel remained selectable while hovering")
+	}
+}
+
+// 終了モーダル中のログは全面表示で、ダッシュボードとは幅も高さも違う。
+// ダッシュボード側の viewport で遡ると位置がずれる。
+func TestModelMouseWheelUsesFullScreenViewportOnExit(t *testing.T) {
+	model := newTestModel()
+	model.resize(100, 24)
+	model.exit = &exitState{closed: true}
+	_, viewport := model.focusedBuffer()
+	for index := 0; index < viewport.height*3; index++ {
+		model.logs.Add(logRecord{text: fmt.Sprintf("line %d", index)})
+	}
+	_, _ = model.Update(tea.MouseWheelMsg{X: 1, Y: 1, Button: tea.MouseWheelUp})
+	if offset := model.logs.Offset(viewport); offset != 3 {
+		t.Fatalf("offset = %d, want 3", offset)
+	}
+}

--- a/internal/ui/mouse_test.go
+++ b/internal/ui/mouse_test.go
@@ -139,3 +139,20 @@ func TestModelHoverFrameShowsWithoutSelection(t *testing.T) {
 		t.Fatal("non-hovered panel is not plain")
 	}
 }
+
+// 開いたままのモーダルはサーバー停止で閉じない。終了画面ではキー処理と
+// 同じく、モーダルより先に終了モーダルのログを見る。
+func TestModelMouseWheelOnExitIgnoresOpenModal(t *testing.T) {
+	model := newTestModel()
+	model.resize(100, 24)
+	model.settingsOpen = true
+	model.exit = &exitState{closed: true}
+	_, viewport := model.focusedBuffer()
+	for index := 0; index < viewport.height*3; index++ {
+		model.logs.Add(logRecord{text: fmt.Sprintf("line %d", index)})
+	}
+	_, _ = model.Update(tea.MouseWheelMsg{X: 1, Y: 1, Button: tea.MouseWheelUp})
+	if offset := model.logs.Offset(viewport); offset != 3 {
+		t.Fatalf("offset = %d, want 3", offset)
+	}
+}

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -307,6 +307,7 @@ func applyTheme(settings Settings) {
 	frame := preset(framePresets, settings.FramePreset, defaults.FramePreset)
 	plainFrame.style = color(frame.plain)
 	selectedFrame.style = color(frame.selected).Bold(true)
+	hoverFrame.style = color(frame.selected)
 	focusedFrame.style = color(frame.focused).Bold(true)
 	modalFrame.style = focusedFrame.style
 	dimStyle = color(frame.dim)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -102,6 +102,10 @@ func (model *Model) View() tea.View {
 	}
 
 	view := tea.NewView(content)
+	view.MouseMode = tea.MouseModeCellMotion
+	if model.mode == modeSelect {
+		view.MouseMode = tea.MouseModeAllMotion
+	}
 	view.AltScreen = true
 	view.WindowTitle = model.windowTitle()
 	// View の背景指定ならレイアウトを変えず、余白とキーバーまで画面全体を塗れる。
@@ -372,7 +376,7 @@ func (model *Model) keybar() string {
 		model.playerStage == playerStageCommands:
 		keys = [][2]string{
 			{"Esc", msg.BarBack},
-			{"kj/↑↓", msg.BarCommand},
+			{"1-9qwe/kj/↑↓", msg.BarCommand},
 			{"Enter", msg.BarPutInConsole},
 			{"^C", msg.BarExit},
 		}


### PR DESCRIPTION
Closes #103

## WHY

ssh でターミナルを開いて hso を触っているとき、パネルの選択もログのスクロールもキーボードだけだった。マウスが手元にあってもホイールが効かず、ログを遡るのに一度キーボードへ持ち替える必要がある。

## What

- 選択モードでホバーしたパネルを細い選択色の枠で仮表示し、左クリックで選択する
- ホイールはカーソルが乗っているパネルを対象にする。Chat / Log は 3 行ずつ、Players はカーソルを 1 人ずつ動かす
- Players のプレイヤー行を直接クリックすると、選択とコマンド一覧の表示までを 1 回で行う
- コマンド一覧の各行に `( 1 )` 〜 `( e )` のアクセラレータを出し、押すとそのコマンドを Console の入力欄に組み立てる（即実行しない既存の性質は維持）
- Chat / Log の Esc を 3 段階にし、遡り解除 → フォーカス解除 → 選択解除の順に戻す。ホイールで遡った選択モードも最初の Esc で最新へ戻る

ホバーの取得に必要な 1003（AllMotion）は選択モードのときだけ有効にし、フォーカス中はクリックとホイールだけの 1002（CellMotion）へ落とす。設定・時刻・補完・プレイヤーコマンドの各モーダル中は、背後を誤操作しないようマウス操作を受けない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WHjwcmRP3zyDwaBXEnEJR