### PR TITLE
feat: hso start で最後に起動したサーバーにカーソルを合わせる

### DIFF
--- a/cmd/hso/list_test.go
+++ b/cmd/hso/list_test.go
@@ -175,3 +175,48 @@ func TestTrackUnregisteredServerDoesNotCreatePIDFile(t *testing.T) {
 		t.Fatal("一覧にない設定へ pidfile が作られた")
 	}
 }
+
+func TestTrackRegisteredServerRecordsLastPlayed(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	configPath := filepath.Join(t.TempDir(), "hso.toml")
+	registryPath, err := registry.Path()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.Save(registryPath, registry.Registry{Servers: []registry.Server{
+		{Name: "survival", Config: configPath},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := trackRegisteredServer(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(file.Close)
+	servers, err := registry.Load(registryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if servers.LastPlayed != "survival" {
+		t.Fatalf("LastPlayed = %q, want %q", servers.LastPlayed, "survival")
+	}
+
+	// pidfile を取れなかった呼び出しは TUI を開かないので記録も書き換えない。
+	servers.LastPlayed = "creative"
+	if err := registry.Save(registryPath, servers); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := trackRegisteredServer(configPath); err == nil {
+		t.Fatal("二重起動が弾かれなかった")
+	}
+	servers, err = registry.Load(registryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if servers.LastPlayed != "creative" {
+		t.Fatalf("pidfile 失敗後の LastPlayed = %q, want %q", servers.LastPlayed, "creative")
+	}
+}

--- a/cmd/hso/start.go
+++ b/cmd/hso/start.go
@@ -209,6 +209,17 @@ func startFromRegistry(
 	}
 }
 
+// lastPlayedIndex は最後に起動したサーバーの位置を返す。覚えていない、または
+// 一覧から消えているときは先頭を指す。
+func lastPlayedIndex(servers registry.Registry) int {
+	for index, server := range servers.Servers {
+		if strings.EqualFold(server.Name, servers.LastPlayed) {
+			return index
+		}
+	}
+	return 0
+}
+
 func chooseServer(
 	servers registry.Registry,
 	running func(string) (int, bool, error),
@@ -222,7 +233,7 @@ func chooseServer(
 		}
 		rows = append(rows, startRow{server: server, status: status})
 	}
-	model := &startModel{rows: rows, title: title}
+	model := &startModel{rows: rows, title: title, cursor: lastPlayedIndex(servers)}
 	if _, err := tea.NewProgram(model).Run(); err != nil {
 		return registry.Server{}, false, err
 	}

--- a/cmd/hso/start_test.go
+++ b/cmd/hso/start_test.go
@@ -232,3 +232,21 @@ func writeStartConfig(t *testing.T, name string) string {
 	}
 	return path
 }
+
+func TestLastPlayedIndex(t *testing.T) {
+	servers := registry.Registry{Servers: []registry.Server{
+		{Name: "survival", Config: "/srv/survival/hso.toml"},
+		{Name: "creative", Config: "/srv/creative/hso.toml"},
+	}}
+	if got := lastPlayedIndex(servers); got != 0 {
+		t.Fatalf("覚えていないとき index = %d, want 0", got)
+	}
+	servers.LastPlayed = "CREATIVE"
+	if got := lastPlayedIndex(servers); got != 1 {
+		t.Fatalf("index = %d, want 1", got)
+	}
+	servers.LastPlayed = "removed"
+	if got := lastPlayedIndex(servers); got != 0 {
+		t.Fatalf("一覧から消えたとき index = %d, want 0", got)
+	}
+}

--- a/cmd/hso/tracking.go
+++ b/cmd/hso/tracking.go
@@ -12,8 +12,14 @@ func trackRegisteredServer(configPath string) (*pidfile.File, error) {
 	if err != nil || !found {
 		return nil, err
 	}
+	file, err := pidfile.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	// 記録は pidfile を取れてから。二重起動で弾かれた呼び出しは TUI を開かない
+	// ので、最後に起動したサーバーとして数えない。
 	recordLastPlayed(name)
-	return pidfile.Create(name)
+	return file, nil
 }
 
 // recordLastPlayed は起動したサーバーを覚えて、次の hso start でカーソルを

--- a/cmd/hso/tracking.go
+++ b/cmd/hso/tracking.go
@@ -12,7 +12,26 @@ func trackRegisteredServer(configPath string) (*pidfile.File, error) {
 	if err != nil || !found {
 		return nil, err
 	}
+	recordLastPlayed(name)
 	return pidfile.Create(name)
+}
+
+// recordLastPlayed は起動したサーバーを覚えて、次の hso start でカーソルを
+// 合わせられるようにする。一覧に書けなくても起動は止めない。
+func recordLastPlayed(name string) {
+	path, err := registry.Path()
+	if err != nil {
+		return
+	}
+	servers, err := registry.Load(path)
+	if err != nil {
+		return
+	}
+	if servers.LastPlayed == name {
+		return
+	}
+	servers.LastPlayed = name
+	_ = registry.Save(path, servers)
 }
 
 func registeredName(configPath string) (string, bool, error) {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -13,7 +13,12 @@ import (
 )
 
 type Registry struct {
-	Servers []Server `toml:"servers"`
+	// LastPlayed は最後に起動したサーバーの登録名。次の hso start で
+	// カーソルを合わせるためだけに使う。servers より前に置くのは、
+	// TOML では配列テーブルの後ろに書いた素のキーがその表に属して
+	// しまうため。
+	LastPlayed string   `toml:"last_played"`
+	Servers    []Server `toml:"servers"`
 }
 
 type Server struct {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -323,3 +323,27 @@ func TestLoadAllowsDuplicateConfigPaths(t *testing.T) {
 		t.Fatalf("servers = %#v", servers.Servers)
 	}
 }
+
+func TestSaveRoundTripsLastPlayed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hso", "config.toml")
+	want := Registry{
+		LastPlayed: "creative",
+		Servers: []Server{
+			{Name: "survival", Config: "/srv/survival/hso.toml"},
+			{Name: "creative", Config: "/srv/creative/hso.toml"},
+		},
+	}
+	if err := Save(path, want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.LastPlayed != "creative" {
+		t.Fatalf("LastPlayed = %q, want %q", got.LastPlayed, "creative")
+	}
+	if len(got.Servers) != 2 {
+		t.Fatalf("Servers = %#v", got.Servers)
+	}
+}


### PR DESCRIPTION
Closes #101

## WHY
サーバーが増えると `hso start` の選択画面は毎回先頭から開き、普段触っている 1 台へ
たどり着くまでにカーソルを動かす必要がある。実際には直前に起動したサーバーを
もう一度立てることがほとんどで、その一番多い操作に一番手数がかかっていた。

## What
- サーバー一覧（`~/.config/hso/config.toml`）に `last_played` を追加。TUI を開いた
  登録名を書き戻す
- 書き込みは `trackRegisteredServer` の 1 箇所。`hso start` / `hso -config` / `setup`
  のどの経路も通るため、ここだけで全経路をカバーする。一覧へ書けなくても起動は止めない
- `hso start`（名前なし）の選択画面が `last_played` からカーソルを開始する。覚えて
  いない／一覧から消えている名前なら従来どおり先頭
- 選択画面そのものは出したまま。他のサーバーを選ぶ手数は変わらない

`last_played` はカーソルの初期位置にしか使わないので、`hso delete` での掃除はしない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFsQedu2dYqE9xNKKMpRNt