### PR TITLE
fix: サーバー一覧の書き込みをプロセス間で排他する

### DIFF
--- a/cmd/hso/delete.go
+++ b/cmd/hso/delete.go
@@ -17,8 +17,8 @@ type deleteOptions struct {
 	yes  bool
 }
 
-type registrySaver func(registry.Registry) error
 type registryLoader func() (registry.Registry, error)
+type registryUpdater func(func(*registry.Registry) error) error
 
 func runDelete(args []string, input io.Reader, output io.Writer, terminal bool) error {
 	options, err := parseDeleteOptions(args)
@@ -33,7 +33,7 @@ func runDelete(args []string, input io.Reader, output io.Writer, terminal bool) 
 		return chooseServer(servers, pidfile.Running, msg.DeleteTitle)
 	}
 	return deleteFromRegistry(options, func() (registry.Registry, error) { return registry.Load(path) }, terminal, input, output, choose, pidfile.Running,
-		func(servers registry.Registry) error { return registry.Save(path, servers) })
+		func(mutate func(*registry.Registry) error) error { return registry.Update(path, mutate) })
 }
 
 func parseDeleteOptions(args []string) (deleteOptions, error) {
@@ -60,7 +60,7 @@ func deleteFromRegistry(
 	output io.Writer,
 	choose serverChooser,
 	running func(string) (int, bool, error),
-	save registrySaver,
+	update registryUpdater,
 ) error {
 	servers, err := load()
 	if err != nil {
@@ -109,29 +109,26 @@ func deleteFromRegistry(
 	}
 	// 確認は人間が考えている間ずっと開いている。その間に別の端末が一覧を
 	// 変えている（setup で足す・別の delete で消す・start で起動する）ことが
-	// あるので、読み直してから消す。ロックは入れない。単一ユーザー向けの
-	// ツールで、他の書き込み経路も同じ方式のため、複雑さに見合わない。
-	// 読み直しから保存までのわずかな窓は残る。
+	// あるので、確認後にロックを取って読み直してから消す。
 	confirmedServer := server
-	servers, err = load()
-	if err != nil {
-		return err
-	}
-	server, found := servers.Find(confirmedServer.Name)
-	if !found {
-		return msg.ServerNotRegistered(confirmedServer.Name)
-	}
-	// 同じ名前でも中身が変わっていれば、ユーザーが確認していない登録を消す
-	// ことになる。確認をやり直させるより、何もせず終わって実行し直して
-	// もらうほうが単純で安全。
-	if server != confirmedServer {
-		return msg.DeleteTargetChanged(confirmedServer.Name)
-	}
-	if err := ensureStopped(server.Name, running); err != nil {
-		return err
-	}
-	servers.Remove(server.Name)
-	if err := save(servers); err != nil {
+	if err := update(func(servers *registry.Registry) error {
+		var found bool
+		server, found = servers.Find(confirmedServer.Name)
+		if !found {
+			return msg.ServerNotRegistered(confirmedServer.Name)
+		}
+		// 同じ名前でも中身が変わっていれば、ユーザーが確認していない登録を消す
+		// ことになる。確認をやり直させるより、何もせず終わって実行し直して
+		// もらうほうが単純で安全。
+		if server != confirmedServer {
+			return msg.DeleteTargetChanged(confirmedServer.Name)
+		}
+		if err := ensureStopped(server.Name, running); err != nil {
+			return err
+		}
+		servers.Remove(server.Name)
+		return nil
+	}); err != nil {
 		return err
 	}
 	_, err = fmt.Fprintln(output, msg.ServerDeleted(server.Name))

--- a/cmd/hso/delete_test.go
+++ b/cmd/hso/delete_test.go
@@ -182,6 +182,9 @@ func updateRegistry(servers *registry.Registry, save func(registry.Registry) err
 	}
 }
 
+// 削除と last_played の記録を実際に並行させる。順序はスケジューラ任せなので、
+// 排他そのものの検証は registry.TestUpdateSerializesConcurrentChanges が受け持ち、
+// ここは 2 つのコマンド経路が同じロックを通っていることを繰り返して確かめる。
 func TestDeleteAndRecordLastPlayedDoNotRestoreDeletedServer(t *testing.T) {
 	configHome := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", configHome)

--- a/cmd/hso/delete_test.go
+++ b/cmd/hso/delete_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
@@ -55,13 +56,13 @@ func TestDeleteFromRegistry(t *testing.T) {
 					return registry.Server{}, false, nil
 				},
 				func(string) (int, bool, error) { return 4321, test.running, nil },
-				func(got registry.Registry) error {
+				updateRegistry(&servers, func(got registry.Registry) error {
 					saved = true
 					if len(got.Servers) != 0 {
 						t.Fatalf("保存する一覧 = %#v", got.Servers)
 					}
 					return nil
-				})
+				}))
 			if test.wantError == "" && err != nil || test.wantError != "" && (err == nil || !strings.Contains(err.Error(), test.wantError)) {
 				t.Fatalf("err = %v", err)
 			}
@@ -111,7 +112,7 @@ func TestDeleteFromRegistryReturnsSaveError(t *testing.T) {
 	want := errors.New("save failed")
 	servers := registry.Registry{Servers: []registry.Server{{Name: "survival", Config: "/missing/hso.toml"}}}
 	err := deleteFromRegistry(deleteOptions{name: "survival", yes: true}, func() (registry.Registry, error) { return servers, nil }, false, strings.NewReader(""), &bytes.Buffer{}, nil,
-		func(string) (int, bool, error) { return 0, false, nil }, func(registry.Registry) error { return want })
+		func(string) (int, bool, error) { return 0, false, nil }, updateRegistry(&servers, func(registry.Registry) error { return want }))
 	if !errors.Is(err, want) {
 		t.Fatalf("err = %v", err)
 	}
@@ -139,14 +140,7 @@ func TestDeleteFromRegistryReloadsAfterConfirmation(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			loads := 0
-			load := func() (registry.Registry, error) {
-				loads++
-				if loads == 1 {
-					return registry.Registry{Servers: []registry.Server{target}}, nil
-				}
-				return test.reloaded, nil
-			}
+			load := func() (registry.Registry, error) { return registry.Registry{Servers: []registry.Server{target}}, nil }
 			runningChecks := 0
 			running := func(string) (int, bool, error) {
 				runningChecks++
@@ -154,12 +148,13 @@ func TestDeleteFromRegistryReloadsAfterConfirmation(t *testing.T) {
 			}
 			var saved registry.Registry
 			savedCalled := false
+			reloaded := test.reloaded
 			err := deleteFromRegistry(deleteOptions{name: target.Name, yes: true}, load, false, strings.NewReader(""), &bytes.Buffer{}, nil, running,
-				func(got registry.Registry) error {
+				updateRegistry(&reloaded, func(got registry.Registry) error {
 					savedCalled = true
 					saved = got
 					return nil
-				})
+				}))
 			if test.wantError == "" && err != nil || test.wantError != "" && (err == nil || !strings.Contains(err.Error(), test.wantError)) {
 				t.Fatalf("err = %v", err)
 			}
@@ -175,5 +170,55 @@ func TestDeleteFromRegistryReloadsAfterConfirmation(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func updateRegistry(servers *registry.Registry, save func(registry.Registry) error) registryUpdater {
+	return func(mutate func(*registry.Registry) error) error {
+		if err := mutate(servers); err != nil {
+			return err
+		}
+		return save(*servers)
+	}
+}
+
+func TestDeleteAndRecordLastPlayedDoNotRestoreDeletedServer(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	path, err := registry.Path()
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := registry.Server{Name: "survival", Config: "/srv/survival/hso.toml"}
+
+	for range 20 {
+		if err := registry.Save(path, registry.Registry{Servers: []registry.Server{server}}); err != nil {
+			t.Fatal(err)
+		}
+		start := make(chan struct{})
+		var group sync.WaitGroup
+		group.Add(2)
+		go func() {
+			defer group.Done()
+			<-start
+			if err := runDelete([]string{"--yes", server.Name}, strings.NewReader(""), &bytes.Buffer{}, false); err != nil {
+				t.Errorf("runDelete = %v", err)
+			}
+		}()
+		go func() {
+			defer group.Done()
+			<-start
+			recordLastPlayed(server.Name)
+		}()
+		close(start)
+		group.Wait()
+
+		servers, err := registry.Load(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, found := servers.Find(server.Name); found {
+			t.Fatalf("削除した登録が復活した: %#v", servers)
+		}
 	}
 }

--- a/cmd/hso/delete_test.go
+++ b/cmd/hso/delete_test.go
@@ -188,6 +188,7 @@ func updateRegistry(servers *registry.Registry, save func(registry.Registry) err
 func TestDeleteAndRecordLastPlayedDoNotRestoreDeletedServer(t *testing.T) {
 	configHome := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
 	path, err := registry.Path()
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/hso/tracking.go
+++ b/cmd/hso/tracking.go
@@ -29,15 +29,13 @@ func recordLastPlayed(name string) {
 	if err != nil {
 		return
 	}
-	servers, err := registry.Load(path)
-	if err != nil {
-		return
-	}
-	if servers.LastPlayed == name {
-		return
-	}
-	servers.LastPlayed = name
-	_ = registry.Save(path, servers)
+	_ = registry.Update(path, func(servers *registry.Registry) error {
+		if servers.LastPlayed == name {
+			return nil
+		}
+		servers.LastPlayed = name
+		return nil
+	})
 }
 
 func registeredName(configPath string) (string, bool, error) {

--- a/cmd/hso/tracking.go
+++ b/cmd/hso/tracking.go
@@ -31,7 +31,7 @@ func recordLastPlayed(name string) {
 	}
 	_ = registry.Update(path, func(servers *registry.Registry) error {
 		if servers.LastPlayed == name {
-			return nil
+			return registry.ErrUnchanged
 		}
 		servers.LastPlayed = name
 		return nil

--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -413,6 +413,14 @@ func CreateRegistryDirectoryFailed(err error) error {
 	return fmt.Errorf("create server registry directory: %w", err)
 }
 
+func OpenRegistryLockFailed(err error, path string) error {
+	return fmt.Errorf("open server registry lock file (%s): %w", path, err)
+}
+
+func LockRegistryFailed(err error, path string) error {
+	return fmt.Errorf("lock server registry (%s): %w", path, err)
+}
+
 func WriteRegistryFailed(err error) error {
 	return fmt.Errorf("write server registry: %w", err)
 }

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -411,6 +411,14 @@ func CreateRegistryDirectoryFailed(err error) error {
 	return fmt.Errorf("サーバー一覧のディレクトリを作る: %w", err)
 }
 
+func OpenRegistryLockFailed(err error, path string) error {
+	return fmt.Errorf("サーバー一覧のロックファイルを開く (%s): %w", path, err)
+}
+
+func LockRegistryFailed(err error, path string) error {
+	return fmt.Errorf("サーバー一覧をロックする (%s): %w", path, err)
+}
+
 func WriteRegistryFailed(err error) error {
 	return fmt.Errorf("サーバー一覧を書く: %w", err)
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/BurntSushi/toml"
 
@@ -121,6 +122,31 @@ func Load(path string) (Registry, error) {
 // Save はサーバー一覧を一時ファイルへ書いてから置き換える。
 func Save(path string, registry Registry) error {
 	return save(path, registry, os.WriteFile, os.Rename)
+}
+
+// Update はサーバー一覧を排他して読み、変更してから保存する。
+func Update(path string, mutate func(*Registry) error) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return msg.CreateRegistryDirectoryFailed(err)
+	}
+	lock, err := os.OpenFile(path+".lock", os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return msg.OpenRegistryLockFailed(err, path)
+	}
+	defer lock.Close()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		return msg.LockRegistryFailed(err, path)
+	}
+	defer syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+
+	servers, err := Load(path)
+	if err != nil {
+		return err
+	}
+	if err := mutate(&servers); err != nil {
+		return err
+	}
+	return Save(path, servers)
 }
 
 func save(

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -125,7 +125,12 @@ func Save(path string, registry Registry) error {
 	return save(path, registry, os.WriteFile, os.Rename)
 }
 
-// Update はサーバー一覧を排他して読み、変更してから保存する。
+// ErrUnchanged は mutate が何も変えなかったことを Update に伝える。返すと
+// 保存を飛ばすので、書くことがないときに config.toml を書き直さずに済む。
+var ErrUnchanged = errors.New("registry unchanged")
+
+// Update はサーバー一覧を排他して読み、変更してから保存する。mutate が
+// ErrUnchanged を返したときは保存しない。
 //
 // mutate はロックを握ったまま呼ぶ。中でユーザーの入力を待たない、Update を
 // 呼び直さない（同一プロセスでも自己デッドロックする）こと。
@@ -149,6 +154,9 @@ func Update(path string, mutate func(*Registry) error) error {
 		return err
 	}
 	if err := mutate(&servers); err != nil {
+		if errors.Is(err, ErrUnchanged) {
+			return nil
+		}
 		return err
 	}
 	return Save(path, servers)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -125,17 +125,21 @@ func Save(path string, registry Registry) error {
 }
 
 // Update はサーバー一覧を排他して読み、変更してから保存する。
+//
+// mutate はロックを握ったまま呼ぶ。中でユーザーの入力を待たない、Update を
+// 呼び直さない（同一プロセスでも自己デッドロックする）こと。
 func Update(path string, mutate func(*Registry) error) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return msg.CreateRegistryDirectoryFailed(err)
 	}
-	lock, err := os.OpenFile(path+".lock", os.O_RDWR|os.O_CREATE, 0o600)
+	lockPath := path + ".lock"
+	lock, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
-		return msg.OpenRegistryLockFailed(err, path)
+		return msg.OpenRegistryLockFailed(err, lockPath)
 	}
 	defer lock.Close()
 	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
-		return msg.LockRegistryFailed(err, path)
+		return msg.LockRegistryFailed(err, lockPath)
 	}
 	defer syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -119,7 +119,8 @@ func Load(path string) (Registry, error) {
 	return registry, nil
 }
 
-// Save はサーバー一覧を一時ファイルへ書いてから置き換える。
+// Save はサーバー一覧を一時ファイルへ書いてから置き換える。読み直しとの間に
+// 排他が要る書き込みは Save ではなく Update を通す。
 func Save(path string, registry Registry) error {
 	return save(path, registry, os.WriteFile, os.Rename)
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -382,10 +382,11 @@ func TestUpdateSerializesConcurrentChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := syscall.Flock(int(probe.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); !errors.Is(err, syscall.EWOULDBLOCK) {
-		t.Fatalf("Update の実行中にロックを取れた: err = %v", err)
-	}
+	probeErr := syscall.Flock(int(probe.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
 	probe.Close()
+	if !errors.Is(probeErr, syscall.EWOULDBLOCK) {
+		t.Fatalf("Update の実行中にロックを取れた: err = %v", probeErr)
+	}
 	go func() {
 		defer group.Done()
 		close(starting)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 )
 
@@ -375,6 +376,16 @@ func TestUpdateSerializesConcurrentChanges(t *testing.T) {
 		}
 	}()
 	<-held
+	// ロックが実際に握られていることを、順序に依存しない形で確かめる。
+	// 排他が外れれば、待たせている最中でも別の fd で取れてしまう。
+	probe, err := os.OpenFile(path+".lock", os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Flock(int(probe.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); !errors.Is(err, syscall.EWOULDBLOCK) {
+		t.Fatalf("Update の実行中にロックを取れた: err = %v", err)
+	}
+	probe.Close()
 	go func() {
 		defer group.Done()
 		close(starting)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -412,3 +412,24 @@ func TestUpdateSerializesConcurrentChanges(t *testing.T) {
 		t.Fatalf("last_played = %q", servers.LastPlayed)
 	}
 }
+
+// ErrUnchanged で保存を飛ばすのは、hso start のたびに config.toml を書き直して
+// 手書きのコメントを消さないため。書き直していないことは、Save が残さない
+// コメントが残っているかで見る。
+func TestUpdateSkipsSaveWhenUnchanged(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	contents := "# 手書きのコメント\nlast_played = \"survival\"\n"
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Update(path, func(*Registry) error { return ErrUnchanged }); err != nil {
+		t.Fatalf("Update = %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != contents {
+		t.Fatalf("config.toml = %q", got)
+	}
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -351,33 +351,41 @@ func TestSaveRoundTripsLastPlayed(t *testing.T) {
 
 func TestUpdateSerializesConcurrentChanges(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
-	if err := Save(path, Registry{Servers: []Server{{Name: "survival", Config: "/srv/survival/hso.toml"}}}); err != nil {
+	survival := Server{Name: "survival", Config: "/srv/survival/hso.toml"}
+	if err := Save(path, Registry{Servers: []Server{survival}}); err != nil {
 		t.Fatal(err)
 	}
-	entered := make(chan struct{})
+	// 先に走る Update がロックを握ったまま登録を消し、後から来た Update に
+	// last_played を書かせる。後者がロックの前に Load していたら、消した
+	// 登録が復活する。
+	held := make(chan struct{})
+	starting := make(chan struct{})
 	release := make(chan struct{})
 	var group sync.WaitGroup
 	group.Add(2)
 	go func() {
 		defer group.Done()
 		if err := Update(path, func(servers *Registry) error {
-			close(entered)
+			close(held)
 			<-release
-			servers.LastPlayed = "survival"
+			servers.Remove(survival.Name)
 			return nil
 		}); err != nil {
 			t.Errorf("Update = %v", err)
 		}
 	}()
-	<-entered
+	<-held
 	go func() {
 		defer group.Done()
+		close(starting)
 		if err := Update(path, func(servers *Registry) error {
-			return servers.Add(Server{Name: "creative", Config: "/srv/creative/hso.toml"})
+			servers.LastPlayed = survival.Name
+			return nil
 		}); err != nil {
 			t.Errorf("Update = %v", err)
 		}
 	}()
+	<-starting
 	close(release)
 	group.Wait()
 
@@ -385,7 +393,10 @@ func TestUpdateSerializesConcurrentChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if servers.LastPlayed != "survival" || len(servers.Servers) != 2 {
-		t.Fatalf("servers = %#v", servers)
+	if _, found := servers.Find(survival.Name); found {
+		t.Fatalf("消した登録が復活した: %#v", servers)
+	}
+	if servers.LastPlayed != survival.Name {
+		t.Fatalf("last_played = %q", servers.LastPlayed)
 	}
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -345,5 +346,46 @@ func TestSaveRoundTripsLastPlayed(t *testing.T) {
 	}
 	if len(got.Servers) != 2 {
 		t.Fatalf("Servers = %#v", got.Servers)
+	}
+}
+
+func TestUpdateSerializesConcurrentChanges(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := Save(path, Registry{Servers: []Server{{Name: "survival", Config: "/srv/survival/hso.toml"}}}); err != nil {
+		t.Fatal(err)
+	}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var group sync.WaitGroup
+	group.Add(2)
+	go func() {
+		defer group.Done()
+		if err := Update(path, func(servers *Registry) error {
+			close(entered)
+			<-release
+			servers.LastPlayed = "survival"
+			return nil
+		}); err != nil {
+			t.Errorf("Update = %v", err)
+		}
+	}()
+	<-entered
+	go func() {
+		defer group.Done()
+		if err := Update(path, func(servers *Registry) error {
+			return servers.Add(Server{Name: "creative", Config: "/srv/creative/hso.toml"})
+		}); err != nil {
+			t.Errorf("Update = %v", err)
+		}
+	}()
+	close(release)
+	group.Wait()
+
+	servers, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if servers.LastPlayed != "survival" || len(servers.Servers) != 2 {
+		t.Fatalf("servers = %#v", servers)
 	}
 }

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -99,14 +99,9 @@ func register(configPath string, cfg config.Config, runWizard func(*model) error
 }
 
 func registerServer(path, name, configPath string) error {
-	servers, err := registry.Load(path)
-	if err != nil {
-		return err
-	}
-	if err := servers.Add(registry.Server{Name: name, Config: configPath}); err != nil {
-		return err
-	}
-	return registry.Save(path, servers)
+	return registry.Update(path, func(servers *registry.Registry) error {
+		return servers.Add(registry.Server{Name: name, Config: configPath})
+	})
 }
 
 // candidate は起動スクリプトの候補。実行権限がないファイルも候補に出す。


### PR DESCRIPTION
Closes #105

## WHY

`~/.config/hso/config.toml`（サーバー一覧）の更新は、どの経路も `registry.Load` → 変更 → `registry.Save` の read-modify-write で、プロセス間の排他が無かった。

`Save` は一時ファイル + rename なのでファイルが壊れることはないが、古いスナップショットで一覧全体を上書きするため、並行すると片方の更新が消える。`recordLastPlayed` は TUI を開くたびに走るので、それが Load した後に別の端末の `hso delete` が Save し、その後 `recordLastPlayed` が Save すると、**削除したはずの登録が復活する。**

## What

- `internal/registry` に `Update(path, mutate)` を足し、Load → 変更 → Save を `syscall.Flock`（ブロッキングの `LOCK_EX`）で囲む
  - ロック対象は一覧そのものではなく隣の `config.toml.lock`。Save が rename で置き換えるため、一覧をロックしても inode が入れ替わって排他にならない
- 書き込み経路 3 つ（`setup.Register` / `hso delete` / `recordLastPlayed`）をすべて `Update` へ通す。片方だけ守っても復活は防げない
- `hso delete` の確認プロンプトはロックの外に置く。人間が考えている間ロックを握らないため、確認のあとに読み直してから消す既存の流れは保つ
- 削除と `last_played` の記録を並行させ、削除した登録が復活しないことを確かめる回帰テストを追加
- `.claude/docs/config.md` に排他の方針を追記（このファイルは gitignore のため差分には出ない）

`go test ./...` / `go test -tags en ./...` / `go vet` / `gofmt -l .` はいずれも通る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sMCzWJ3PXATsne1EeKWtH