### PR TITLE
modeSelect で Esc を押すと OPTIONS/QUIT メニューを出す

### DIFF
--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -50,6 +50,8 @@ const (
 	TimeModalTitle    = "Set current time"
 )
 
+const QuitMenuTitle = "Menu"
+
 // Color preset names.
 const (
 	OptDefault  = "default"
@@ -182,6 +184,7 @@ const (
 	BarSelectPanel  = "select"
 	BarFocus        = "focus"
 	BarSettings     = "settings"
+	BarMenu         = "menu"
 	BarBackToSelect = "select"
 	BarConsoleTab   = "input/restart/stop"
 	BarComplete     = "complete"

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -48,6 +48,8 @@ const (
 	TimeModalTitle    = "現在時刻の設定"
 )
 
+const QuitMenuTitle = "メニュー"
+
 // 配色プリセットの表示名。
 const (
 	OptDefault  = "既定"
@@ -181,6 +183,7 @@ const (
 	BarSelectPanel  = "選ぶ"
 	BarFocus        = "開く"
 	BarSettings     = "設定"
+	BarMenu         = "メニュー"
 	BarBackToSelect = "選択"
 	BarConsoleTab   = "入力/再起動/停止"
 	BarComplete     = "補完"

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -26,7 +26,7 @@ func (model *Model) handleKey(message tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	// g/G は既存どおり設定専用にする。vim の gg/G を追加すると既存キーを
 	// 奪うため、先頭・末尾への移動には使わない。
-	if model.timeModal == nil && !model.settingsOpen &&
+	if model.timeModal == nil && !model.settingsOpen && !model.quitMenuOpen &&
 		(message.String() == "g" || message.String() == "G") &&
 		!model.editingConsole() {
 		model.settingsOpen = true
@@ -41,6 +41,9 @@ func (model *Model) handleKey(message tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	if model.settingsOpen {
 		return model.handleSettingsKey(key)
+	}
+	if model.quitMenuOpen {
+		return model.handleQuitMenuKey(key)
 	}
 	if model.mode == modeSelect {
 		return model.handleSelectKey(key)
@@ -260,8 +263,38 @@ func (model *Model) handleSelectKey(key tea.Key) (tea.Model, tea.Cmd) {
 	case tea.KeyEscape:
 		if buffer, _ := model.bufferFor(model.panel); buffer != nil && !buffer.Following() {
 			buffer.ScrollToEnd()
-		} else if model.panel == panelChat || model.panel == panelLog {
+		} else if (model.panel == panelChat || model.panel == panelLog) && model.selected {
 			model.selected = false
+		} else {
+			model.openQuitMenu()
+		}
+	}
+	return model, nil
+}
+
+// openQuitMenu は選択モードで Esc がもう何も戻す先を持たないときに開く。
+// 画面遷移はせず、モーダルを重ねるだけ。
+func (model *Model) openQuitMenu() {
+	model.quitMenuOpen = true
+	model.quitMenuCursor = 0
+}
+
+func (model *Model) handleQuitMenuKey(key tea.Key) (tea.Model, tea.Cmd) {
+	switch key.Code {
+	case tea.KeyEscape:
+		model.quitMenuOpen = false
+	case tea.KeyUp:
+		model.quitMenuCursor = max(0, model.quitMenuCursor-1)
+	case tea.KeyDown:
+		model.quitMenuCursor = min(quitMenuItemCount-1, model.quitMenuCursor+1)
+	case tea.KeyEnter, tea.KeyKpEnter:
+		model.quitMenuOpen = false
+		switch model.quitMenuCursor {
+		case quitMenuOptions:
+			model.settingsOpen = true
+			model.settingCursor = 0
+		case quitMenuQuit:
+			return model, model.requestQuit()
 		}
 	}
 	return model, nil

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -141,6 +141,8 @@ type Model struct {
 	settingsOpen      bool
 	settingCursor     int
 	timeModal         *timeModalState
+	quitMenuOpen      bool
+	quitMenuCursor    int
 	exit              *exitState
 	restart           restartTracker
 	// 0 は停止中、1..3 は表示する点の数。

--- a/internal/ui/mouse.go
+++ b/internal/ui/mouse.go
@@ -4,6 +4,7 @@ import tea "charm.land/bubbletea/v2"
 
 func (model *Model) mouseDiscarded() bool {
 	return model.settingsOpen || model.timeModal != nil || model.completionOpen ||
+		model.quitMenuOpen ||
 		(model.mode == modeFocus && model.panel == panelPlayers &&
 			model.playerStage == playerStageCommands)
 }

--- a/internal/ui/quitmenu.go
+++ b/internal/ui/quitmenu.go
@@ -1,0 +1,102 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
+)
+
+const (
+	quitMenuOptions = iota
+	quitMenuQuit
+	quitMenuItemCount
+)
+
+// glyph4 は幅可変・高さ4の粗いビットマップフォント。'#' が点灯、それ以外は
+// 消灯。OPTIONS / QUIT の描画にしか使わないので、必要な文字だけ持つ。
+var glyph4 = map[rune][4]string{
+	'O': {".##.", "#..#", "#..#", ".##."},
+	'P': {"###.", "#.#.", "###.", "#..."},
+	'T': {"####", ".#..", ".#..", ".#.."},
+	'I': {"###", ".#.", ".#.", "###"},
+	'N': {"#..#", "##.#", "#.##", "#..#"},
+	'S': {".###", "##..", "..##", "###."},
+	'Q': {".##.", "#..#", "#.#.", ".###"},
+	'U': {"#..#", "#..#", "#..#", ".##."},
+}
+
+// bigText は word を half-block 2 行のアスキーアートに描く。4 行分のビット
+// マップを、1 セルに縦 2 ピクセルを詰める半角ブロック文字で 2 行に圧縮する。
+func bigText(word string) [2]string {
+	var rows [4]strings.Builder
+	for index, letter := range word {
+		glyph, ok := glyph4[letter]
+		if !ok {
+			continue
+		}
+		if index > 0 {
+			for row := range rows {
+				rows[row].WriteByte(' ')
+			}
+		}
+		for row, line := range glyph {
+			rows[row].WriteString(line)
+		}
+	}
+	return [2]string{
+		halfBlockLine(rows[0].String(), rows[1].String()),
+		halfBlockLine(rows[2].String(), rows[3].String()),
+	}
+}
+
+func halfBlockLine(top, bottom string) string {
+	topRunes := []rune(top)
+	bottomRunes := []rune(bottom)
+	width := max(len(topRunes), len(bottomRunes))
+	var line strings.Builder
+	for index := 0; index < width; index++ {
+		on := index < len(topRunes) && topRunes[index] == '#'
+		off := index < len(bottomRunes) && bottomRunes[index] == '#'
+		switch {
+		case on && off:
+			line.WriteRune('█')
+		case on:
+			line.WriteRune('▀')
+		case off:
+			line.WriteRune('▄')
+		default:
+			line.WriteRune(' ')
+		}
+	}
+	return line.String()
+}
+
+func (model *Model) quitMenuModal() (string, int, int) {
+	options := bigText("OPTIONS")
+	quit := bigText("QUIT")
+
+	optionsStyle, quitStyle := dimStyle, dimStyle
+	if model.quitMenuCursor == quitMenuOptions {
+		optionsStyle = selectedStyle
+	} else {
+		quitStyle = selectedStyle
+	}
+
+	lines := []string{
+		optionsStyle.Render(options[0]),
+		optionsStyle.Render(options[1]),
+		"",
+		quitStyle.Render(quit[0]),
+		quitStyle.Render(quit[1]),
+	}
+
+	width := stringWidth(msg.QuitMenuTitle) + 4
+	for _, line := range lines {
+		width = max(width, stringWidth(line)+4)
+	}
+	width = min(width, model.layout.width)
+	height := len(lines) + 2
+	x := max(0, (model.layout.width-width)/2)
+	y := max(0, (model.layout.height-height)/2)
+	return renderPanel(msg.QuitMenuTitle, lines, width, height, false, modalFrame), x, y
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -87,6 +87,9 @@ func (model *Model) View() tea.View {
 		case model.settingsOpen:
 			box, x, y := model.settingsModal()
 			content = overlay(content, box, x, y)
+		case model.quitMenuOpen:
+			box, x, y := model.quitMenuModal()
+			content = overlay(content, box, x, y)
 		case model.mode == modeFocus && model.panel == panelPlayers &&
 			model.playerStage == playerStageCommands:
 			box, x, y := model.commandModal()
@@ -96,7 +99,8 @@ func (model *Model) View() tea.View {
 			content = overlay(content, box, x, y)
 		}
 		// モーダルが重なっている間はキーが入力欄へ届かない。
-		if model.exit != nil || model.timeModal != nil || model.settingsOpen {
+		if model.exit != nil || model.timeModal != nil || model.settingsOpen ||
+			model.quitMenuOpen {
 			caretX = -1
 		}
 	}
@@ -349,10 +353,18 @@ func (model *Model) keybar() string {
 			{"Enter/Esc", msg.BarClose},
 			{"^C", msg.BarExit},
 		}
+	case model.quitMenuOpen:
+		keys = [][2]string{
+			{"kj/↑↓", msg.BarItem},
+			{"Enter", msg.BarConfirm},
+			{"Esc", msg.BarClose},
+			{"^C", msg.BarExit},
+		}
 	case model.mode == modeSelect:
 		keys = [][2]string{
 			{"hjkl/←↑↓→", msg.BarSelectPanel},
 			{"Enter", msg.BarFocus},
+			{"Esc", msg.BarMenu},
 			{"G", msg.BarSettings},
 			{"^C", msg.BarExit},
 		}


### PR DESCRIPTION
Closes #99

## WHY
Esc を押しても何も起きないパネル（Players/Console）があり、設定モーダルへの入口（G）も分かりづらかった。

## What
- modeSelect で Esc がもう何も戻す先を持たないとき（ログ/チャットの巻き戻し・選択解除が済んでいる、または元々対象外のパネル）に、中央へ OPTIONS/QUIT の2択モーダルを出す
- kj/↑↓ で選択、Enter で実行、Esc で閉じる
- OPTIONS → 既存の設定モーダルを開く（G キーは従来どおり残す）
- QUIT → モーダルを閉じて ^C とまったく同じ経路（`requestQuit`）を通す。停止処理は独自に持たない
- 項目は half-block（▀▄█）を使った2行のアスキーアートで描画
- キーバーに Esc 案内を追加、`internal/msg` の ja/en 両方に文字列を追加

## Test plan
- [x] `go test ./...` / `go test -tags en ./...`
- [x] `gofmt -l .` / `go vet ./...`
- [x] tmux 実機テストで Esc → メニュー表示 → OPTIONS で設定モーダル、QUIT で安全停止(exitモーダル)を確認