### PR TITLE
feat: c キーでサーバーアドレスをコピーする

### DIFF
--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -173,6 +173,10 @@ func ExitAutoQuit(seconds int) string {
 	return fmt.Sprintf("hso exits in %d seconds (press a key to stay)", seconds)
 }
 
+func AddressCopied(address string) string {
+	return "copied address: " + address
+}
+
 // Key bar (the hint line at the bottom of the screen).
 const (
 	BarItem         = "item"

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -171,6 +171,10 @@ func ExitAutoQuit(seconds int) string {
 	return fmt.Sprintf("%d 秒後に hso を終了します（キー入力で解除）", seconds)
 }
 
+func AddressCopied(address string) string {
+	return "アドレスをコピーしました: " + address
+}
+
 // キーバー（画面下部のキー説明）。日本語は全角なので、最小端末幅 72 桁に
 // 収まるよう短くしている。
 const (

--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -109,7 +109,9 @@ func (model *Model) serverAddressLine() string {
 	if !ok {
 		return "Server n/a"
 	}
-	return "Server " + address
+	// c キーでコピーできることをアドレスの隣に出す。c は複数モードで効くので
+	// キーバー 1 本では覆えず、どのキーバーも最小幅 72 で埋まっていて足せない。
+	return "Server " + address + " (c)"
 }
 
 // serverAddress は IP と port が両方取れているときだけ "IP:port" を返す。

--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -105,10 +105,19 @@ func (model *Model) statsLines() []string {
 }
 
 func (model *Model) serverAddressLine() string {
-	if model.serverIP == "" || model.serverPort == 0 {
+	address, ok := model.serverAddress()
+	if !ok {
 		return "Server n/a"
 	}
-	return fmt.Sprintf("Server %s:%d", model.serverIP, model.serverPort)
+	return "Server " + address
+}
+
+// serverAddress は IP と port が両方取れているときだけ "IP:port" を返す。
+func (model *Model) serverAddress() (string, bool) {
+	if model.serverIP == "" || model.serverPort == 0 {
+		return "", false
+	}
+	return fmt.Sprintf("%s:%d", model.serverIP, model.serverPort), true
 }
 
 func (model *Model) rssLine() string {

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -33,6 +33,10 @@ func (model *Model) handleKey(message tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		model.settingCursor = 0
 		return model, nil
 	}
+	if model.timeModal == nil && !model.settingsOpen && !model.quitMenuOpen &&
+		message.String() == "c" && !model.editingConsole() {
+		return model, model.copyServerAddress()
+	}
 	if !model.editingConsole() {
 		key = hjklArrowKey(key)
 	}

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -162,6 +163,37 @@ func TestModelUsesHJKLInExitView(t *testing.T) {
 	pressRune(model, 'j')
 	if offset := model.logs.Offset(viewport); offset != 0 {
 		t.Fatalf("j の後の offset = %d, want 0", offset)
+	}
+}
+
+// TestModelCopiesServerAddressWithC は c キーがアドレスをクリップボードへ
+// コピーし、ログにも残すことを見る。アドレスが取れていないときは何もしない
+// （issue #110）。
+func TestModelCopiesServerAddressWithC(t *testing.T) {
+	model := newTestModel()
+	model.resize(80, 24)
+	model.mode = modeSelect
+
+	_, command := model.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	if command != nil {
+		t.Fatalf("アドレス無しでも command が返った")
+	}
+	if model.logs.Len() != 0 {
+		t.Fatalf("アドレス無しでもログが増えた: %d 件", model.logs.Len())
+	}
+
+	model.serverIP = "203.0.113.1"
+	model.serverPort = 25565
+
+	_, command = model.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	if command == nil {
+		t.Fatal("アドレスがあるのに command が nil")
+	}
+	if model.logs.Len() != 1 {
+		t.Fatalf("ログの件数 = %d, want 1", model.logs.Len())
+	}
+	if text := model.logs.At(0).text; !strings.Contains(text, "203.0.113.1:25565") {
+		t.Fatalf("ログの内容 = %q にアドレスが含まれていない", text)
 	}
 }
 

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -236,10 +236,10 @@ func TestModelDisplaysServerAddressAndReportsFailure(t *testing.T) {
 
 	_, _ = model.Update(ServerAddressMsg{
 		Generation: 2,
-		IP:         "203.0.113.10",
-		Port:       25565,
+		IP:         "255.255.255.255",
+		Port:       65535,
 	})
-	if got := model.serverAddressLine(); got != "Server 203.0.113.10:25565" {
+	if got := model.serverAddressLine(); got != "Server 255.255.255.255:65535 (c)" {
 		t.Fatalf("address = %q", got)
 	}
 	if width := stringWidth(model.serverAddressLine()); width > model.layout.statsWidth-2 {
@@ -252,7 +252,7 @@ func TestModelDisplaysServerAddressAndReportsFailure(t *testing.T) {
 		IP:         "198.51.100.1",
 		Port:       25566,
 	})
-	if got := model.serverAddressLine(); got != "Server 203.0.113.10:25565" {
+	if got := model.serverAddressLine(); got != "Server 255.255.255.255:65535 (c)" {
 		t.Fatalf("stale address was accepted: %q", got)
 	}
 

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -1,10 +1,14 @@
 package ui
 
 import (
+	"fmt"
 	"time"
+
+	tea "charm.land/bubbletea/v2"
 
 	"github.com/hijoushoku7/hijo-server-ops/internal/gclog"
 	"github.com/hijoushoku7/hijo-server-ops/internal/hsperfdata"
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
 	"github.com/hijoushoku7/hijo-server-ops/internal/procstats"
 	"github.com/hijoushoku7/hijo-server-ops/internal/serverlog"
 )
@@ -56,6 +60,20 @@ func (model *Model) updateServerAddress(message ServerAddressMsg) {
 		model.serverPort = 0
 		model.logUnavailableAddress("server-port", message.PortErr)
 	}
+}
+
+// copyServerAddress は c キーで呼ばれる。アドレスが取れていないときは
+// クリップボードを書き換えず、無反応のままにする。
+func (model *Model) copyServerAddress() tea.Cmd {
+	if model.serverIP == "" || model.serverPort == 0 {
+		return nil
+	}
+	address := fmt.Sprintf("%s:%d", model.serverIP, model.serverPort)
+	model.addLog(serverlog.Entry{
+		Kind:    serverlog.KindOther,
+		Message: msg.AddressCopied(address),
+	})
+	return tea.SetClipboard(address)
 }
 
 func (model *Model) logUnavailableAddress(source, detail string) {

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"fmt"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -65,10 +64,10 @@ func (model *Model) updateServerAddress(message ServerAddressMsg) {
 // copyServerAddress は c キーで呼ばれる。アドレスが取れていないときは
 // クリップボードを書き換えず、無反応のままにする。
 func (model *Model) copyServerAddress() tea.Cmd {
-	if model.serverIP == "" || model.serverPort == 0 {
+	address, ok := model.serverAddress()
+	if !ok {
 		return nil
 	}
-	address := fmt.Sprintf("%s:%d", model.serverIP, model.serverPort)
 	model.addLog(serverlog.Entry{
 		Kind:    serverlog.KindOther,
 		Message: msg.AddressCopied(address),


### PR DESCRIPTION
Closes #110

## WHY
サーバーのアドレスを人に伝えるとき、画面を見て手で打ち直すしかなかった。

## What
- ダッシュボードで `c` を押すと `internal/serveraddr` で取得済みのアドレスを `tea.SetClipboard`（OSC 52）でコピーする
- コピーしたことが分かるよう Log にも同じ内容を残す
- IP または port が取れていないときは何もしない（クリップボードもログも変更しない）
- キーバーへの追加は最小端末幅 72 桁を超えるため見送った（select モードの余裕は 5 桁しかなく、1 文字ラベルでも収まらない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPHyHUkJrmg5twCpwNm49w