### PR TITLE
feat: メニューと設定モーダルの見た目を btop 風にする

### DIFF
--- a/internal/ui/mouse.go
+++ b/internal/ui/mouse.go
@@ -22,7 +22,16 @@ func (model *Model) handleMouseMotion(message tea.MouseMotionMsg) (tea.Model, te
 }
 
 func (model *Model) handleMouseClick(message tea.MouseClickMsg) (tea.Model, tea.Cmd) {
-	if model.exit != nil || model.mouseDiscarded() || message.Button != tea.MouseLeft {
+	if model.exit != nil || message.Button != tea.MouseLeft {
+		return model, nil
+	}
+	// メニューは画面の中央に大きく出る。外したクリックは「やめる」の意図と
+	// 見て閉じる。
+	if model.quitMenuOpen {
+		model.quitMenuOpen = false
+		return model, nil
+	}
+	if model.mouseDiscarded() {
 		return model, nil
 	}
 	if index, ok := model.playerAt(message.X, message.Y); ok {

--- a/internal/ui/quitmenu.go
+++ b/internal/ui/quitmenu.go
@@ -12,88 +12,111 @@ const (
 	quitMenuItemCount
 )
 
-// glyph4 は幅可変・高さ4の粗いビットマップフォント。'#' が点灯、それ以外は
-// 消灯。OPTIONS / QUIT の描画にしか使わないので、必要な文字だけ持つ。
-var glyph4 = map[rune][4]string{
-	'O': {".##.", "#..#", "#..#", ".##."},
-	'P': {"###.", "#.#.", "###.", "#..."},
-	'T': {"####", ".#..", ".#..", ".#.."},
-	'I': {"###", ".#.", ".#.", "###"},
-	'N': {"#..#", "##.#", "#.##", "#..#"},
-	'S': {".###", "##..", "..##", "###."},
-	'Q': {".##.", "#..#", "#.#.", ".###"},
-	'U': {"#..#", "#..#", "#..#", ".##."},
+// 罫線素片で組んだ高さ 3 行の字形。選択の有無で字形は変えず、色と太字だけを
+// 変える。行の末尾の空白は幅を揃えるためのもので、詰めてはいけない
+var (
+	bigOptions = [3]string{
+		"╭─╮╭─╮╭┬╮┬╭─╮╭╮╷╭─╮",
+		"│ │├─╯ │ ││ ││││╰─╮",
+		"╰─╯╵   ┴ ┴╰─╯╵╰╯╰─╯",
+	}
+	bigQuit = [3]string{
+		"╭─╮ ┬ ┬ ┬ ╭┬╮",
+		"│─┼╮│ │ │  │ ",
+		"╰─╯╰╰─╯ ┴  ┴ ",
+	}
+)
+
+// ブロック要素の本体と、右下へ 1 セルずらした影。影は本体より暗い色で描く。
+var bigLogo = [8]string{
+	"██   ██  ███████  ███████ ",
+	"██░  ██░ ██░░░░░░ ██░░░██░",
+	"██░  ██░ ██░      ██░  ██░",
+	"███████░ ███████  ██░  ██░",
+	"██░░░██░  ░░░░██░ ██░  ██░",
+	"██░  ██░      ██░ ██░  ██░",
+	"██░  ██░ ███████░ ███████░",
+	" ░░   ░░  ░░░░░░░  ░░░░░░░",
 }
 
-// bigText は word を half-block 2 行のアスキーアートに描く。4 行分のビット
-// マップを、1 セルに縦 2 ピクセルを詰める半角ブロック文字で 2 行に圧縮する。
-func bigText(word string) [2]string {
-	var rows [4]strings.Builder
-	for index, letter := range word {
-		glyph, ok := glyph4[letter]
-		if !ok {
-			continue
-		}
-		if index > 0 {
-			for row := range rows {
-				rows[row].WriteByte(' ')
-			}
-		}
-		for row, line := range glyph {
-			rows[row].WriteString(line)
-		}
-	}
-	return [2]string{
-		halfBlockLine(rows[0].String(), rows[1].String()),
-		halfBlockLine(rows[2].String(), rows[3].String()),
-	}
-}
+const logoSubtitle = "hijo server ops"
 
-func halfBlockLine(top, bottom string) string {
-	topRunes := []rune(top)
-	bottomRunes := []rune(bottom)
-	width := max(len(topRunes), len(bottomRunes))
-	var line strings.Builder
-	for index := 0; index < width; index++ {
-		on := index < len(topRunes) && topRunes[index] == '#'
-		off := index < len(bottomRunes) && bottomRunes[index] == '#'
-		switch {
-		case on && off:
-			line.WriteRune('█')
-		case on:
-			line.WriteRune('▀')
-		case off:
-			line.WriteRune('▄')
+// 左右の余白。枠に文字が貼り付かないよう広めに取る。
+const quitMenuPad = 4
+
+// ロゴを出すのに要る画面の大きさ。これを下回る端末ではロゴを落とし、
+// OPTIONS / QUIT だけ出す。
+const (
+	quitMenuLogoHeight = 22
+	quitMenuLogoWidth  = 26 + quitMenuPad*2 + 2
+)
+
+// styleLogo は本体（█）にアクセント色を、影（░）に dim を当てる。同じ文字が
+// 続く区間をまとめて 1 回で描き、セルごとにエスケープを吐かない。
+func styleLogo(line string) string {
+	var result strings.Builder
+	runes := []rune(line)
+	for start := 0; start < len(runes); {
+		end := start
+		for end < len(runes) && runes[end] == runes[start] {
+			end++
+		}
+		segment := string(runes[start:end])
+		switch runes[start] {
+		case '█':
+			result.WriteString(titleStyle.Render(segment))
+		case '░':
+			result.WriteString(dimStyle.Render(segment))
 		default:
-			line.WriteRune(' ')
+			result.WriteString(segment)
 		}
+		start = end
 	}
-	return line.String()
+	return result.String()
 }
 
 func (model *Model) quitMenuModal() (string, int, int) {
-	options := bigText("OPTIONS")
-	quit := bigText("QUIT")
-
+	// 選択は背景の反転ではなく、暗い文字から明るいアクセント色＋太字への
+	// 変化で示す。どの配色プリセットでも dim とアクセントには明暗差がある。
 	optionsStyle, quitStyle := dimStyle, dimStyle
 	if model.quitMenuCursor == quitMenuOptions {
-		optionsStyle = selectedStyle
+		optionsStyle = titleStyle
 	} else {
-		quitStyle = selectedStyle
+		quitStyle = titleStyle
 	}
 
-	lines := []string{
-		optionsStyle.Render(options[0]),
-		optionsStyle.Render(options[1]),
-		"",
-		quitStyle.Render(quit[0]),
-		quitStyle.Render(quit[1]),
+	showLogo := model.layout.height >= quitMenuLogoHeight &&
+		model.layout.width >= quitMenuLogoWidth
+	inner := stringWidth(bigOptions[0])
+	if showLogo {
+		inner = max(inner, stringWidth(bigLogo[0]))
+	}
+	center := func(line string) string {
+		return strings.Repeat(" ", quitMenuPad+(inner-stringWidth(line))/2) + line
 	}
 
-	width := stringWidth(msg.QuitMenuTitle) + 4
-	for _, line := range lines {
-		width = max(width, stringWidth(line)+4)
+	var lines []string
+	lines = append(lines, "")
+	if showLogo {
+		for _, line := range bigLogo {
+			lines = append(lines, styleLogo(center(line)))
+		}
+		lines = append(lines,
+			"",
+			dimStyle.Italic(true).Render(center(logoSubtitle)),
+			"",
+		)
 	}
+	for _, line := range bigOptions {
+		lines = append(lines, optionsStyle.Render(center(line)))
+	}
+	lines = append(lines, "")
+	for _, line := range bigQuit {
+		lines = append(lines, quitStyle.Render(center(line)))
+	}
+	lines = append(lines, "")
+
+	width := max(stringWidth(msg.QuitMenuTitle)+4, inner+quitMenuPad*2+2)
 	width = min(width, model.layout.width)
 	height := len(lines) + 2
 	x := max(0, (model.layout.width-width)/2)

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -228,7 +228,12 @@ var settingItems = []settingItem{
 const (
 	settingOn  = "on"
 	settingOff = "off"
+	// 設定モーダルの左右の余白と、広げすぎないための上限幅。
+	settingsPad      = 2
+	settingsMaxWidth = 60
 )
+
+func pad(width int) string { return strings.Repeat(" ", max(0, width)) }
 
 func (item settingItem) optionIndex(settings Settings) int {
 	current := item.get(settings)
@@ -314,37 +319,68 @@ func (model *Model) settingsModal() (string, int, int) {
 			actionWidth = stringWidth(msg.TimeSettingButton) + 4
 		}
 	}
-	// " ラベル  ‹ 値 › " の飾りと枠の 2 列を足した幅。見出しが長ければそちらに
-	// 合わせる。
-	width := max(labelWidth+valueWidth+actionWidth+10, sectionWidth+4)
+	// 1 項目をラベル行と値行の 2 行に割るので、値は行いっぱいの
+	// "‹ 値 ›" として置ける。幅はラベル・値・見出しのうち一番広いものに
+	// 左右の余白 2 列ずつと枠の 2 列を足す。
+	inner := max(labelWidth+actionWidth+2, max(valueWidth+6, sectionWidth))
+	// 中身に合わせるだけだと細く貧相になる。画面の 3/5 を目安に広げ、
+	// 中身がそれより広ければ中身を優先する。
+	width := max(inner+settingsPad*2+2, min(model.layout.width*3/5, settingsMaxWidth))
 	width = min(width, model.layout.width)
+	contentWidth := width - 2
+	field := max(0, contentWidth-settingsPad*2)
 
-	lines := make([]string, 0, len(settingItems)+2)
+	lines := make([]string, 0, len(settingItems)*2+6)
+	lines = append(lines, "")
+	// 選択中の項目の値行。画面に収まらないときはここを中心に窓を取る。
+	cursorLine := 0
 	for index, item := range settingItems {
 		if item.section != "" {
 			// 先頭の見出し以外は、区切りとして 1 行空ける。
-			if len(lines) > 0 {
+			if len(lines) > 1 {
 				lines = append(lines, "")
 			}
 			lines = append(lines,
-				titleStyle.Render(fitLine(" "+item.section, width-2)))
+				titleStyle.Render(fitLine(pad(settingsPad)+item.section, contentWidth)))
 		}
-		value := item.valueLabel(model.settings)
-		line := " " + fitLine(item.label, labelWidth) + "  ‹ " +
-			strings.Repeat(" ", max(0, valueWidth-stringWidth(value))) +
-			value + " ›"
+
+		// ラベルは値行の "‹ 値 ›" と中心を揃える。
+		label := pad(settingsPad+max(0, (field-stringWidth(item.label))/2)) + item.label
 		if item.open != nil {
 			button := "[" + msg.TimeSettingButton + "]"
-			line += strings.Repeat(" ", max(2, width-2-stringWidth(line)-stringWidth(button))) +
-				button
+			label = fitLine(label, max(0, contentWidth-settingsPad-stringWidth(button))) +
+				button + pad(settingsPad)
 		}
-		line = fitLine(line, width-2)
+		label = fitLine(label, contentWidth)
+		// 選択中はラベル行と値行の 2 行まとめて反転させ、項目 1 つが
+		// 選ばれていることを見せる。
 		if index == model.settingCursor {
-			line = selectedStyle.Render(line)
+			label = selectedStyle.Render(label)
+		}
+		lines = append(lines, label)
+
+		value := item.valueLabel(model.settings)
+		left := max(0, (field-2-stringWidth(value))/2)
+		line := pad(settingsPad) + "‹" + pad(left) + value
+		line = fitLine(line, contentWidth-settingsPad-1) + "›" + pad(settingsPad)
+		// 値行はラベル行と見分けが付くよう灰色に落とす。選択中だけ反転する。
+		if index == model.settingCursor {
+			cursorLine = len(lines)
+			line = selectedStyle.Render(fitLine(line, contentWidth))
+		} else {
+			line = dimStyle.Render(line)
 		}
 		lines = append(lines, line)
 	}
-	height := len(lines) + 2
+	lines = append(lines, "")
+
+	height := min(len(lines)+2, model.layout.height)
+	// 端末が低いと全項目は入らない。選択行を中心に窓を切り、カーソルが
+	// 常に見えるようにする。
+	if contentHeight := height - 2; contentHeight < len(lines) {
+		start := min(max(0, cursorLine-contentHeight/2), len(lines)-contentHeight)
+		lines = lines[start : start+contentHeight]
+	}
 
 	x := max(0, (model.layout.width-width)/2)
 	y := max(0, (model.layout.height-height)/2)

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -271,3 +271,19 @@ func TestSettingsToggleAutoRestart(t *testing.T) {
 		t.Fatalf("saved = %#v", saved)
 	}
 }
+
+// 端末が低いと全項目は入らない。窓を切っても選択中の項目が消えないこと。
+func TestSettingsModalKeepsCursorVisible(t *testing.T) {
+	model := newTestModel()
+	model.layout = calculateLayout(minimumWidth, minimumHeight)
+	model.settingCursor = len(settingItems) - 1
+	box, _, _ := model.settingsModal()
+	content := stripANSI(box)
+	if strings.Count(content, "\n")+1 > minimumHeight {
+		t.Fatalf("modal is taller than the screen:\n%s", content)
+	}
+	last := settingItems[model.settingCursor]
+	if !strings.Contains(content, last.valueLabel(model.settings)) {
+		t.Fatalf("cursor row is off screen:\n%s", content)
+	}
+}


### PR DESCRIPTION
## WHY

Esc で出るメニューの OPTIONS / QUIT は、4 行のビットマップを半角ブロックで
2 行に圧縮して描いていた。縦が潰れて字として読めない。

設定モーダルも同じくらい窮屈だった。1 項目 1 行で枠に文字が貼り付き、
どの項目を選んでいるかは値の反転だけが頼り。項目名と値が同じ行に並ぶので、
どちらを見ているのか目が迷う。

btop のメニューは、罫線素片で組んだ細い字形と、色の明暗だけで選択を示す。
同じ作りに寄せる。

## What

### メニュー（Esc）

- OPTIONS / QUIT を罫線素片の高さ 3 行の字形に差し替え。圧縮しないので潰れない
- ブロック要素の `HSO` ロゴと副題を追加。画面が 22 行 × 36 桁を下回るときは
  ロゴを落として OPTIONS / QUIT だけ出す
- 選択の表現を反転から「dim → 配色プリセットのアクセント色＋太字」に変更。
  `titleStyle` と `dimStyle` をそのまま使うので、新しいパレット定義は無い。
  7 プリセット全部で明暗差がある
- 上下左右の余白を広げた
- メニュー表示中の左クリックはどこでも閉じる

### 設定モーダル

- 1 項目をラベル行と値行の 2 行に分割。ラベルは中央揃え、値は `‹ … ›` を
  行幅いっぱいに広げて中央に置く
- 値行は灰色。選択中の項目はラベル行と値行の 2 行まとめて反転する
- 横幅を画面の 3/5（上限 60 桁）に、上下左右の余白も広げた
- 2 行化で高さが最小サイズ（21 行）に収まらなくなるため、選択行を中心に
  窓を切ってスクロールする。カーソルは常に画面内に居る

字形と使える文字は `.claude/docs/bigtext.md` にまとめてある。

## テスト

- `go test ./...` / `go test -tags en ./...` / `gofmt` / `go vet`
- 窓を切る処理に `TestSettingsModalKeepsCursorVisible` を追加（最小サイズで
  最終項目を選び、はみ出さず値が見えること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)