### PR TITLE
feat: ^C で止めたときは終了モーダルを出さずに終わる

### DIFF
--- a/cmd/hso/app.go
+++ b/cmd/hso/app.go
@@ -53,16 +53,17 @@ func runTUI(configPath string, cfg config.Config) error {
 	if model.Err() != nil {
 		return model.Err()
 	}
-	// 終了モーダルを出さずに終わる道（^C）があるので、止まったことは端末に
-	// 残す。alt screen を畳んだ後なので画面には最後の 1 行として残る。
-	fmt.Fprintln(os.Stdout, msg.ServerStoppedNotice)
 	if stopErr != nil {
 		return stopErr
 	}
-	if ui.IsExpectedExit(programErr) {
-		return nil
+	if !ui.IsExpectedExit(programErr) {
+		return programErr
 	}
-	return programErr
+	// 終了モーダルを出さずに終わる道（^C）があるので、止まったことは端末に
+	// 残す。alt screen を畳んだ後なので画面には最後の 1 行として残る。
+	// 失敗を返すときは hso: のエラーだけを出す。
+	fmt.Fprintln(os.Stdout, msg.ServerStoppedNotice)
+	return nil
 }
 
 // displayNameRunes は画面に出す名前の上限。サーバー一覧の登録名と同じ長さに

--- a/cmd/hso/app.go
+++ b/cmd/hso/app.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"unicode"
@@ -9,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/hijoushoku7/hijo-server-ops/internal/config"
+	"github.com/hijoushoku7/hijo-server-ops/internal/msg"
 	"github.com/hijoushoku7/hijo-server-ops/internal/ui"
 )
 
@@ -50,6 +53,9 @@ func runTUI(configPath string, cfg config.Config) error {
 	if model.Err() != nil {
 		return model.Err()
 	}
+	// 終了モーダルを出さずに終わる道（^C）があるので、止まったことは端末に
+	// 残す。alt screen を畳んだ後なので画面には最後の 1 行として残る。
+	fmt.Fprintln(os.Stdout, msg.ServerStoppedNotice)
 	if stopErr != nil {
 		return stopErr
 	}

--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -93,6 +93,10 @@ const (
 	StatusStopping = "stopping, waiting for the save"
 )
 
+// ServerStoppedNotice is the line hso leaves on the terminal when it exits, after
+// the alt screen is gone.
+const ServerStoppedNotice = "server stopped"
+
 func SaveSettingsFailed(err error) string {
 	return "failed to save settings: " + err.Error()
 }

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -91,6 +91,10 @@ const (
 	StatusStopping = "停止中 保存を待っています"
 )
 
+// ServerStoppedNotice は hso が終わるときに端末へ残す 1 行。alt screen を畳んだ
+// 後なので、TUI が消えても停止したことが手元に残る。
+const ServerStoppedNotice = "サーバーを停止しました"
+
 func SaveSettingsFailed(err error) string {
 	return "設定の保存に失敗: " + err.Error()
 }

--- a/internal/msg/msg_test.go
+++ b/internal/msg/msg_test.go
@@ -142,6 +142,7 @@ func TestMessagesAreNotEmpty(t *testing.T) {
 		"OptCharcoal":           OptCharcoal,
 		"StatusIdle":            StatusIdle,
 		"StatusStopping":        StatusStopping,
+		"ServerStoppedNotice":   ServerStoppedNotice,
 		"BarItem":               BarItem,
 		"BarValue":              BarValue,
 		"BarCandidate":          BarCandidate,

--- a/internal/ui/exit.go
+++ b/internal/ui/exit.go
@@ -153,10 +153,21 @@ func (model *Model) setProcessExit(message ProcessExitedMsg) tea.Cmd {
 		err = model.runErr
 		crashed = true
 	}
+	// ^C で止めて無事に終わったなら、そのまま hso も終わる。自分で終了を
+	// 指示した後にログ全面のモーダルを見せられ、カウントダウンを待たされる
+	// 理由がない。
+	if model.quitting && !crashed {
+		return tea.Quit
+	}
 	state := model.newExitState(crashed, err, message.ExitCode, startedAt, exitedAt)
 	// hso 自身の失敗で開いていたモーダルを、その後始末で届く終了通知が
 	// 普通のクラッシュに見せかけないようにする。
 	state.fatal = model.exit != nil && model.exit.fatal
+	// ^C 由来の異常終了はもう終わらせるつもりの世代なので、三択のカーソルを
+	// 最初から終了に置く。原因は読ませたいのでモーダル自体は出す。
+	if model.quitting {
+		state.button = 2
+	}
 	model.exit = state
 	model.restart.record(startedAt, exitedAt, state.crashed && !state.fatal)
 	if state.crashed {

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -284,7 +284,8 @@ func TestModelCtrlCQuitsWhenTheServerIsGone(t *testing.T) {
 
 // TestModelCtrlCThenRestartClearsWaiting は ^C で止めた後にモーダルから
 // 再起動したとき、停止待ちが残らないことを見る。残るとキーを受け付けない
-// まま、^C だけが効く画面になる。
+// まま、^C だけが効く画面になる。正常終了ではモーダルが出ないので、
+// 異常終了で止まった場合を見る。
 func TestModelCtrlCThenRestartClearsWaiting(t *testing.T) {
 	actions := make(chan Action, 2)
 	model := New(actions, nil, 1, DefaultSettings(), ServerInfo{})
@@ -293,9 +294,9 @@ func TestModelCtrlCThenRestartClearsWaiting(t *testing.T) {
 	_, _ = model.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
 	<-actions
 	_, _ = model.Update(ActionResultMsg{Action: Action{Kind: ActionSendCommand, Command: "stop"}})
-	_, _ = model.Update(ProcessExitedMsg{Generation: 1, ExitCode: 0})
-	// モーダルの三択で「再起動」を選ぶ。
-	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	_, _ = model.Update(ProcessExitedMsg{Generation: 1, ExitCode: 1})
+	// モーダルの三択で「再起動」を選ぶ。^C 由来なのでカーソルは終了から動く。
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
 	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	<-actions
 	_, _ = model.Update(ServerStartedMsg{Generation: 2, StartedAt: time.Now()})
@@ -306,5 +307,54 @@ func TestModelCtrlCThenRestartClearsWaiting(t *testing.T) {
 	_, _ = model.Update(tea.KeyPressMsg{Code: 'g', Text: "g"})
 	if string(model.input) != "g" {
 		t.Fatalf("キーを受け付けていない: input = %q", model.input)
+	}
+}
+
+// TestModelCtrlCQuitsWithoutExitModal は ^C で止めてサーバーが無事に終わった
+// とき、終了モーダルを出さずそのまま終わることを見る。自分で終了を指示した
+// のにログ確認画面を挟まれ、カウントダウンを待たされる必要がない。
+func TestModelCtrlCQuitsWithoutExitModal(t *testing.T) {
+	actions := make(chan Action, 1)
+	model := New(actions, nil, 1, DefaultSettings(), ServerInfo{})
+	model.resize(80, 24)
+
+	_, _ = model.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	<-actions
+	_, _ = model.Update(ActionResultMsg{Action: Action{Kind: ActionSendCommand, Command: "stop"}})
+	_, command := model.Update(ProcessExitedMsg{Generation: 1, ExitCode: 0})
+
+	if model.exit != nil {
+		t.Fatalf("終了モーダルが開いている: exit = %#v", model.exit)
+	}
+	if command == nil {
+		t.Fatal("command = nil")
+	}
+	if _, ok := command().(tea.QuitMsg); !ok {
+		t.Fatalf("command = %T", command())
+	}
+}
+
+// TestModelCtrlCCrashKeepsExitModal は ^C で止めたのに異常終了したとき、
+// モーダルは出したままカーソルを終了に合わせることを見る。原因は読ませたい
+// が、終わらせるつもりだった以上は Enter 一発で終われるようにする。
+func TestModelCtrlCCrashKeepsExitModal(t *testing.T) {
+	actions := make(chan Action, 1)
+	model := New(actions, nil, 1, DefaultSettings(), ServerInfo{})
+	model.resize(80, 24)
+
+	_, _ = model.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	<-actions
+	_, _ = model.Update(ActionResultMsg{Action: Action{Kind: ActionSendCommand, Command: "stop"}})
+	_, _ = model.Update(ProcessExitedMsg{Generation: 1, ExitCode: 1})
+
+	if model.exit == nil {
+		t.Fatal("終了モーダルが開いていない")
+	}
+	if model.exit.button != 2 {
+		t.Fatalf("button = %d", model.exit.button)
+	}
+	_, command := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if _, ok := command().(tea.QuitMsg); !ok {
+		t.Fatalf("command = %T", command())
 	}
 }


### PR DESCRIPTION
Closes #117

## WHY

^C はサーバーに stop を送り、終わるのを待つ（#109 / #111）。
サーバーが停止すると終了モーダルが開き、背景がログ全面に切り替わって 3 秒のカウントダウンを待たされる。
自分で終了を指示したのに、確認画面を見せられて待たされる理由がない。

## What

- ^C で止めて正常終了したら、モーダルを出さずそのまま hso も終わる
- ^C 後の異常終了は今までどおりモーダルを出す。ただしカーソルを最初から「終了」に置く
- 終了時に stdout へ「サーバーを停止しました」を 1 行残す
- Console の停止ボタン・クラッシュ・自動再起動は変更なし

## HOW

`setProcessExit` で `crashed` を確定させた直後に分岐する。`model.quitting && !crashed` なら `exitState` を作らず `tea.Quit`、`model.quitting && crashed` なら `state.button = 2`（終了）にする。
モーダルを挟まずに終わる道ができたので、`program.Run()` の後に停止した旨を出す。alt screen を畳んだ後なので最後の 1 行として残る。