### PR TITLE
refactor: 配色の初期値を theme.go だけに寄せる

### DIFF
--- a/internal/ui/frame.go
+++ b/internal/ui/frame.go
@@ -2,6 +2,7 @@ package ui
 
 import "charm.land/lipgloss/v2"
 
+// style は theme.go の init() が既定プリセットから流し込む。
 type frame struct {
 	topLeft     string
 	topRight    string
@@ -20,7 +21,6 @@ var (
 		bottomRight: "┘",
 		horizontal:  "─",
 		vertical:    "│",
-		style:       lipgloss.NewStyle().Foreground(lipgloss.Color("#777777")),
 	}
 	selectedFrame = frame{
 		topLeft:     "┏",
@@ -29,9 +29,6 @@ var (
 		bottomRight: "┛",
 		horizontal:  "━",
 		vertical:    "┃",
-		style: lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#8BE9FD")).
-			Bold(true),
 	}
 	hoverFrame = frame{
 		topLeft:     "┌",
@@ -40,7 +37,6 @@ var (
 		bottomRight: "┘",
 		horizontal:  "─",
 		vertical:    "│",
-		style:       lipgloss.NewStyle().Foreground(lipgloss.Color("#8BE9FD")),
 	}
 	focusedFrame = frame{
 		topLeft:     "┏",
@@ -49,9 +45,6 @@ var (
 		bottomRight: "┛",
 		horizontal:  "━",
 		vertical:    "┃",
-		style: lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#F1FA8C")).
-			Bold(true),
 	}
 	// modalFrame はフォーカス中と同じ色の細枠。重ねて出すモーダルが
 	// 呼び出し元のパネルと同じものだと分かり、かつ枠の太さで区別できる。
@@ -62,7 +55,6 @@ var (
 		bottomRight: "┘",
 		horizontal:  "─",
 		vertical:    "│",
-		style:       focusedFrame.style,
 	}
 )
 

--- a/internal/ui/graph.go
+++ b/internal/ui/graph.go
@@ -7,7 +7,8 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-var overlapStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#F1FA8C"))
+// 初期値は theme.go の init() が既定プリセットから流し込む。
+var overlapStyle lipgloss.Style
 
 type memorySample struct {
 	heap      uint64

--- a/internal/ui/meter.go
+++ b/internal/ui/meter.go
@@ -11,15 +11,12 @@ import (
 	"github.com/hijoushoku7/hijo-server-ops/internal/procstats"
 )
 
+// 初期値は theme.go の init() が既定プリセットから流し込む。
 var (
-	meterFullStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#50FA7B"))
-	meterHighStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#FFB86C"))
-	meterOverStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#FF5555"))
-	meterEmptyStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#444444"))
+	meterFullStyle  lipgloss.Style
+	meterHighStyle  lipgloss.Style
+	meterOverStyle  lipgloss.Style
+	meterEmptyStyle lipgloss.Style
 )
 
 const (


### PR DESCRIPTION
Closes #121

## WHY
`theme.go` の `init()` が既定プリセットを流し込むようになった後も、`graph.go` / `meter.go` / `frame.go` にリテラルの初期値が残っていた。既定を変えたときに片方だけ古くなる。

## What
残っていたリテラルの初期値を消す。

## HOW
- `overlapStyle` / メーターの 4 スタイル / 各 `frame` の `style` を宣言だけにする
- 実際の色は `applyTheme` が入れるので挙動は変わらない
- 異常終了・正常終了の枠色は意味を持つ色なので `theme.go` にリテラルのまま残す