### PR TITLE
feat: Δ に off-heap と添え、GC の total を stopped にする

### DIFF
--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -70,7 +70,7 @@ func (model *Model) statsLines() []string {
 		),
 		model.rssLine(),
 		fmt.Sprintf(
-			"GC   %s  total %s  last %s  freq %s",
+			"GC   %s  stopped %s  last %s  freq %s",
 			formatCollections(model.gcStats.Collections),
 			formatPause(
 				model.gcStats.TotalPause,
@@ -127,29 +127,30 @@ func (model *Model) rssLine() string {
 	ratio := highlight(formatRSSPercent(model.memory), rssRatio(model.memory))
 	delta := formatDelta(model.memory.RSS, model.metrics.Heap.Committed)
 
-	short := fmt.Sprintf("RSS  %s (%s)  Δ %s", rss, ratio, delta)
-	limit, source := rssDenominator(model.memory)
-	if source == "" {
-		return short
+	denominator := ""
+	if limit, source := rssDenominator(model.memory); source != "" {
+		label := "total"
+		if source == "cgroup" {
+			label = "limit"
+		}
+		denominator = fmt.Sprintf(" / %s %s", formatBytes(limit), label)
 	}
 
-	label := "total"
-	if source == "cgroup" {
-		label = "limit"
+	suffix := " off-heap usage"
+	if delta == "n/a" {
+		suffix = ""
 	}
-	full := fmt.Sprintf(
-		"RSS  %s / %s %s (%s)  Δ %s",
-		rss,
-		formatBytes(limit),
-		label,
-		ratio,
-		delta,
-	)
-	// 分母よりも診断上重要な RSS と heap committed の差分を残す。
-	if stringWidth(full) > model.layout.statsWidth-2 {
-		return short
+	short := fmt.Sprintf("RSS  %s (%s)  Δ %s", rss, ratio, delta)
+	for _, line := range []string{
+		fmt.Sprintf("RSS  %s%s (%s)  Δ %s%s", rss, denominator, ratio, delta, suffix),
+		fmt.Sprintf("RSS  %s%s (%s)  Δ %s", rss, denominator, ratio, delta),
+		fmt.Sprintf("RSS  %s (%s)  Δ %s%s", rss, ratio, delta, suffix),
+	} {
+		if stringWidth(line) <= model.layout.statsWidth-2 {
+			return line
+		}
 	}
-	return full
+	return short
 }
 
 func (model *Model) renderGraphPanel() string {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -1326,7 +1326,7 @@ func TestStatsRSSLineKeepsDeltaOnNarrowTerminals(t *testing.T) {
 	if stringWidth(narrow) > model.layout.statsWidth-2 {
 		t.Fatalf("narrow line = %q (%d 桁)", narrow, stringWidth(narrow))
 	}
-	if !strings.Contains(narrow, "Δ +3.2G") {
+	if !strings.Contains(narrow, "Δ +3.2G") || strings.Contains(narrow, "off-heap") {
 		t.Fatalf("narrow line = %q", narrow)
 	}
 
@@ -1334,7 +1334,7 @@ func TestStatsRSSLineKeepsDeltaOnNarrowTerminals(t *testing.T) {
 	model.resize(110, 30)
 	wide := stripANSI(model.rssLine())
 	if !strings.Contains(wide, "16.0G total") ||
-		!strings.Contains(wide, "Δ +3.2G") {
+		!strings.Contains(wide, "Δ +3.2G off-heap") {
 		t.Fatalf("wide line = %q", wide)
 	}
 
@@ -1977,7 +1977,7 @@ func TestModelShowsGCCollectionsAsUnavailableUntilFirstEvent(t *testing.T) {
 	_, _ = model.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
 
 	stats := strings.Join(model.statsLines(), "\n")
-	if !strings.Contains(stats, "GC   n/a  total") {
+	if !strings.Contains(stats, "GC   n/a  stopped") {
 		t.Fatalf("stats = %q", stats)
 	}
 
@@ -1987,7 +1987,7 @@ func TestModelShowsGCCollectionsAsUnavailableUntilFirstEvent(t *testing.T) {
 	}})
 
 	stats = strings.Join(model.statsLines(), "\n")
-	if !strings.Contains(stats, "GC   1 collections  total") {
+	if !strings.Contains(stats, "GC   1 collections  stopped") {
 		t.Fatalf("stats = %q", stats)
 	}
 }

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -49,6 +49,7 @@ func rememberNumber(last *hsperfdata.Number, next hsperfdata.Number) {
 }
 
 func (model *Model) updateServerAddress(message ServerAddressMsg) {
+	//前回stateを消すためnilであっても先に代入する
 	model.serverIP = message.IP
 	model.serverPort = message.Port
 	if message.IPErr != "" {


### PR DESCRIPTION
## WHY

Stats パネルの `Δ` と GC 行の `total` は、初見だと何の値なのか読めない。
`Δ` は RSS − heap committed（JVM が heap の外で使っている分）、`total` は GC の累積停止時間だが、どちらもラベルからは分からない。

## What

```
RSS  4.8G / 16.0G total (30%)  Δ +3.2G off-heap   ← 広いとき
RSS  4.8G / 16.0G total (30%)  Δ +3.2G            ← 狭いとき
GC   42 collections  stopped 12.3s  last 8ms  freq 3.00/min
```

- `Δ` の隣に `off-heap` を添える。ただし幅が足りないときは出さない
- GC の `total` を `stopped` に変える

## HOW

- `rssLine()` の落とす順を「off-heap → 分母 → 素の Δ」にした。診断に効く `Δ` 自体はどの幅でも残る。`Δ` が `n/a` のときは説明する対象が無いのでラベルも出さない
- `off-heap` にしたのは、この値が JVM の外ではなく heap の外（metaspace / code cache / スレッドスタック / direct buffer）で、いずれも JVM プロセス内のため
- `time stopped` ではなく `stopped` にしたのは、同じ行の `last` も停止時間で、`stopped 12.3s ... last 8ms` で「累積 / 直近」と読めるため

`updateServerAddress` のコメント追加も同じコミットに含めた（作業ツリーにあった 1 行）。