### PR TITLE
feat: 設定から server.properties を編集できるようにする

### DIFF
--- a/cmd/hso/app.go
+++ b/cmd/hso/app.go
@@ -34,8 +34,9 @@ func runTUI(configPath string, cfg config.Config) error {
 		initialGeneration,
 		settingsFrom(cfg),
 		ui.ServerInfo{
-			Name:    serverDisplayName(configPath, cfg, registeredName),
-			Version: version,
+			Name:           serverDisplayName(configPath, cfg, registeredName),
+			Version:        version,
+			PropertiesPath: filepath.Join(cfg.Server.WorkDir, "server.properties"),
 		},
 	)
 	program := tea.NewProgram(model, tea.WithContext(ctx))

--- a/internal/msg/msg_en.go
+++ b/internal/msg/msg_en.go
@@ -38,15 +38,17 @@ const (
 	LabelSelection  = "selection"
 	LabelLog        = "log"
 
-	LabelAutoRestart = "auto restart"
-	LabelTimezone    = "time zone"
-	LabelCurrentTime = "current time"
-	LabelTimeDrift   = "offset"
+	LabelAutoRestart      = "auto restart"
+	LabelTimezone         = "time zone"
+	LabelServerProperties = "edit server.properties"
+	LabelCurrentTime      = "current time"
+	LabelTimeDrift        = "offset"
 )
 
 const (
 	OptSystemTime     = "system time"
 	TimeSettingButton = "set"
+	EditButton        = "edit"
 	TimeModalTitle    = "Set current time"
 )
 
@@ -101,7 +103,8 @@ const (
 const (
 	StatusIdle = "idle"
 	// StatusStopping is shown while ^C waits for the server to shut down.
-	StatusStopping = "stopping, waiting for the save"
+	StatusStopping            = "stopping, waiting for the save"
+	PropertiesRestartRequired = "changes take effect after the server restarts"
 )
 
 // ServerStoppedNotice is the line hso leaves on the terminal when it exits, after
@@ -110,6 +113,10 @@ const ServerStoppedNotice = "server stopped"
 
 func SaveSettingsFailed(err error) string {
 	return "failed to save settings: " + err.Error()
+}
+
+func EditorLaunchFailed(err error) string {
+	return "failed to launch editor: " + err.Error()
 }
 
 func ActionFailed(err error) string {

--- a/internal/msg/msg_ja.go
+++ b/internal/msg/msg_ja.go
@@ -36,15 +36,17 @@ const (
 	LabelSelection  = "選択行"
 	LabelLog        = "ログ"
 
-	LabelAutoRestart = "自動再起動"
-	LabelTimezone    = "タイムゾーン"
-	LabelCurrentTime = "現在時刻"
-	LabelTimeDrift   = "ずれ"
+	LabelAutoRestart      = "自動再起動"
+	LabelTimezone         = "タイムゾーン"
+	LabelServerProperties = "server.properties を編集する"
+	LabelCurrentTime      = "現在時刻"
+	LabelTimeDrift        = "ずれ"
 )
 
 const (
 	OptSystemTime     = "システム時刻"
 	TimeSettingButton = "設定"
+	EditButton        = "編集"
 	TimeModalTitle    = "現在時刻の設定"
 )
 
@@ -99,7 +101,8 @@ const (
 const (
 	StatusIdle = "操作待ち"
 	// StatusStopping は ^C でサーバーの終了を待っている間の表示。
-	StatusStopping = "停止中 保存を待っています"
+	StatusStopping            = "停止中 保存を待っています"
+	PropertiesRestartRequired = "変更はサーバーの再起動後に反映されます"
 )
 
 // ServerStoppedNotice は hso が終わるときに端末へ残す 1 行。alt screen を畳んだ
@@ -108,6 +111,10 @@ const ServerStoppedNotice = "サーバーを停止しました"
 
 func SaveSettingsFailed(err error) string {
 	return "設定の保存に失敗: " + err.Error()
+}
+
+func EditorLaunchFailed(err error) string {
+	return "エディタの起動に失敗: " + err.Error()
 }
 
 func ActionFailed(err error) string {

--- a/internal/msg/msg_test.go
+++ b/internal/msg/msg_test.go
@@ -254,6 +254,10 @@ func TestMessagesAreNotEmpty(t *testing.T) {
 		"JavaVersionInstall":  JavaVersionInstall(21),
 		"CommandRequired":     CommandRequired().Error(),
 	}
+	messages["LabelServerProperties"] = LabelServerProperties
+	messages["EditButton"] = EditButton
+	messages["PropertiesRestartRequired"] = PropertiesRestartRequired
+	messages["EditorLaunchFailed"] = EditorLaunchFailed(sample)
 
 	for name, message := range messages {
 		if strings.TrimSpace(message) == "" {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -32,10 +32,11 @@ type Action struct {
 	Command string
 }
 
-// ServerInfo は画面に出す識別情報。表示専用で、取れなくても動作に影響しない。
+// ServerInfo はサーバー固有の表示情報と操作対象。値がなくても基本動作は続けられる。
 type ServerInfo struct {
-	Name    string
-	Version string
+	Name           string
+	Version        string
+	PropertiesPath string
 }
 
 type LogMsg struct {
@@ -311,6 +312,12 @@ func (model *Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if message.Action.Kind == ActionSendCommand {
 			model.addLog(serverlog.SentCommand(message.Action.Command))
+		}
+	case editorFinishedMsg:
+		if message.err != nil {
+			model.status = msg.EditorLaunchFailed(message.err)
+		} else {
+			model.status = msg.PropertiesRestartRequired
 		}
 	case ProcessExitedMsg:
 		if !model.accepts(message.Generation) {

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"os"
+	"os/exec"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -52,12 +54,13 @@ type settingOption struct {
 type settingItem struct {
 	section string
 	label   string
+	button  string
 	options []settingOption
 	get     func(Settings) string
 	set     func(*Settings, string)
 	// options が空の項目では、get は現在値の表示だけに使う。Enter で
 	// open を呼び、設定モーダルを残したまま追加のモーダルを開く。
-	open func(*Model)
+	open func(*Model) tea.Cmd
 }
 
 var settingItems = []settingItem{
@@ -200,7 +203,19 @@ var settingItems = []settingItem{
 	},
 	{
 		section: msg.SectionAdvanced,
-		label:   msg.LabelAutoRestart,
+		label:   msg.LabelServerProperties,
+		button:  msg.EditButton,
+		get:     func(Settings) string { return "server.properties" },
+		open: func(model *Model) tea.Cmd {
+			parts := resolveEditor()
+			command := exec.Command(parts[0], append(parts[1:], model.info.PropertiesPath)...)
+			return tea.ExecProcess(command, func(err error) tea.Msg {
+				return editorFinishedMsg{err: err}
+			})
+		},
+	},
+	{
+		label: msg.LabelAutoRestart,
 		// 値は文字列で持たせる。項目 1 つのために get/set を型で分けると、
 		// モーダルが項目の中身を知らずに済む今の形が崩れる。
 		options: []settingOption{
@@ -218,15 +233,31 @@ var settingItems = []settingItem{
 		},
 	},
 	{
-		label: msg.LabelTimezone,
+		label:  msg.LabelTimezone,
+		button: msg.TimeSettingButton,
 		get: func(settings Settings) string {
 			if settings.TimeOffsetMinutes == 0 {
 				return msg.OptSystemTime
 			}
 			return formatTimeOffset(settings.TimeOffsetMinutes)
 		},
-		open: func(model *Model) { model.openTimeModal() },
+		open: func(model *Model) tea.Cmd {
+			model.openTimeModal()
+			return nil
+		},
 	},
+}
+
+type editorFinishedMsg struct{ err error }
+
+func resolveEditor() []string {
+	for _, name := range []string{"VISUAL", "EDITOR"} {
+		// ponytail: 引用符を含む空白入りパスは解釈しない。
+		if parts := strings.Fields(os.Getenv(name)); len(parts) > 0 {
+			return parts
+		}
+	}
+	return []string{"vi"}
 }
 
 const (
@@ -272,8 +303,7 @@ func (item settingItem) shift(settings *Settings, step int) {
 func (model *Model) handleSettingsKey(key tea.Key) (tea.Model, tea.Cmd) {
 	item := settingItems[model.settingCursor]
 	if (key.Code == tea.KeyEnter || key.Code == tea.KeyKpEnter) && item.open != nil {
-		item.open(model)
-		return model, nil
+		return model, item.open(model)
 	}
 	switch key.Code {
 	case tea.KeyEscape, tea.KeyEnter, tea.KeyKpEnter:
@@ -320,7 +350,7 @@ func (model *Model) settingsModal() (string, int, int) {
 		valueWidth = max(valueWidth, stringWidth(item.valueLabel(model.settings)))
 		sectionWidth = max(sectionWidth, stringWidth(item.section))
 		if item.open != nil {
-			actionWidth = stringWidth(msg.TimeSettingButton) + 4
+			actionWidth = max(actionWidth, stringWidth(item.button)+4)
 		}
 	}
 	// 1 項目をラベル行と値行の 2 行に割るので、値は行いっぱいの
@@ -351,7 +381,7 @@ func (model *Model) settingsModal() (string, int, int) {
 		// ラベルは値行の "‹ 値 ›" と中心を揃える。
 		label := pad(settingsPad+max(0, (field-stringWidth(item.label))/2)) + item.label
 		if item.open != nil {
-			button := "[" + msg.TimeSettingButton + "]"
+			button := "[" + item.button + "]"
 			label = fitLine(label, max(0, contentWidth-settingsPad-stringWidth(button))) +
 				button + pad(settingsPad)
 		}

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -301,3 +301,40 @@ func TestSettingsModalKeepsCursorVisible(t *testing.T) {
 		t.Fatalf("cursor row is off screen:\n%s", content)
 	}
 }
+
+func TestResolveEditor(t *testing.T) {
+	tests := []struct {
+		name   string
+		visual string
+		editor string
+		want   string
+	}{
+		{name: "VISUAL", visual: "code -w", editor: "nano", want: "code -w"},
+		{name: "EDITOR", editor: "nano -w", want: "nano -w"},
+		{name: "fallback", want: "vi"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("VISUAL", test.visual)
+			t.Setenv("EDITOR", test.editor)
+			if got := strings.Join(resolveEditor(), " "); got != test.want {
+				t.Fatalf("resolveEditor() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSettingsEnterReturnsOpenCommand(t *testing.T) {
+	original := settingItems
+	t.Cleanup(func() { settingItems = original })
+	want := func() tea.Msg { return "opened" }
+	settingItems = []settingItem{{
+		get:  func(Settings) string { return "value" },
+		open: func(*Model) tea.Cmd { return want },
+	}}
+	model := New(make(chan Action, 1), nil, 0, DefaultSettings(), ServerInfo{})
+	_, got := model.handleSettingsKey(tea.Key{Code: tea.KeyEnter})
+	if got == nil || got() != "opened" {
+		t.Fatal("Enter did not return the item's open command")
+	}
+}


### PR DESCRIPTION
Closes #108

## WHY
server.properties を直すには hso を抜けてファイルを探しに行くしかなかった。設定画面まで来ているなら、そこから開けたほうが早い。

## What
設定モーダル（Esc → OPTIONS）の Advanced に「server.properties」項目を追加し、Enter で既定のエディタを開く。

## HOW
- `settingItem.open` が `tea.Cmd` を返す形にして、`tea.ExecProcess` でエディタへ画面を渡す
- エディタは `$VISUAL` → `$EDITOR` → `vi` の順で決める
- 項目ごとのボタン文字列を `button` フィールドに持たせ、`[編集]` と `[設定]` を出し分ける
- 編集から戻っても設定モーダルは閉じず、status に再起動で反映される旨を出す
- パスは `ServerInfo.PropertiesPath` として `cmd/hso` から渡す
