### PR TITLE
feat: コマンド名も Tab で補完する

### DIFF
--- a/internal/ui/complete.go
+++ b/internal/ui/complete.go
@@ -19,8 +19,12 @@ var (
 // completionScan は打ちかけの入力を解析し、候補の手前に残す文字列と候補を返す。
 func (model *Model) completionScan() (string, []string) {
 	original := string(model.input)
-	// 先頭の空白と "/" は打ち方の揺れなので、語の切り出しからだけ外す。
-	// 置き換え位置は original から取るため、打った空白はそのまま残る。
+	// "/" の直後の空白は打ち方の揺れではなく実行できない形なので、original
+	// 側でも畳んでおく。以降は先頭の空白と "/" を語の切り出しからだけ外す。
+	// 置き換え位置は original から取るため、語の間に打った空白は残る。
+	if rest, found := strings.CutPrefix(strings.TrimLeft(original, " "), "/"); found {
+		original = strings.Repeat(" ", len(original)-len(rest)-1) + "/" + strings.TrimLeft(rest, " ")
+	}
 	input := strings.TrimPrefix(strings.TrimLeft(original, " "), "/")
 	// 空白で区切った語だけを見る。末尾の空白は「次の引数を打ち始めていない」
 	// という情報なので、空の語として 1 つだけ残す。Split で作った空要素を
@@ -29,10 +33,9 @@ func (model *Model) completionScan() (string, []string) {
 	if strings.HasSuffix(input, " ") {
 		words = append(words, "")
 	}
-	// 空白しか打っていないなら何も打っていないのと同じ。末尾の空白を候補の
-	// 手前に残すと "/ clear" のような実行できない文字列になる。
-	if strings.TrimSpace(input) == "" {
-		words = nil
+	// 空白しか打っていないなら何も打っていないのと同じ。残すと先頭に空白の
+	// 入った文字列になり、灰色の候補まで出てしまう。
+	if len(words) == 0 {
 		original = strings.TrimRight(original, " ")
 	}
 
@@ -97,7 +100,7 @@ func (model *Model) completionHint() string {
 	keep, candidates := model.completionScan()
 	// 何も打っていないうちは灰色を出さない。キャレットの桁が候補で埋まり、
 	// 空の入力欄が打ちかけと見分けられなくなる。
-	if len(candidates) == 0 || strings.TrimSpace(string(model.input)) == "" {
+	if len(candidates) == 0 || len(model.input) == 0 {
 		return ""
 	}
 	cursor := clamp(model.completionCursor, 0, len(candidates)-1)

--- a/internal/ui/complete.go
+++ b/internal/ui/complete.go
@@ -7,6 +7,8 @@ import (
 )
 
 var (
+	// コマンド名そのものの候補。引数まで補完できる並びに /clear を足したもの。
+	commandCompletions     = []string{"clear", "tell", "time", "weather"}
 	timeCommandCompletions = []string{"set"}
 	timeCompletions        = []string{"day", "night", "noon", "midnight"}
 	weatherCompletions     = []string{"clear", "rain", "thunder"}
@@ -28,6 +30,8 @@ func (model *Model) completionScan() (string, []string) {
 
 	candidatesFor := func(command []string) []string {
 		switch strings.Join(command, " ") {
+		case "":
+			return commandCompletions
 		case "tell":
 			return model.playerList
 		case "time":
@@ -44,15 +48,19 @@ func (model *Model) completionScan() (string, []string) {
 	prefix := ""
 	keep := original
 	candidates := candidatesFor(words)
-	if len(candidates) > 0 {
+	// 語が 1 つも無いとき（空か "/" だけ）はコマンド名の候補をそのまま出す。
+	// 空白を足すと先頭に空白の入った入力になってしまう。
+	if len(words) > 0 && len(candidates) > 0 {
 		if !strings.HasSuffix(keep, " ") {
 			keep += " "
 		}
 	} else if len(words) > 0 {
 		prefix = words[len(words)-1]
 		candidates = candidatesFor(words[:len(words)-1])
-		start := strings.LastIndex(original, " ") + 1
-		keep = original[:start]
+		// 語の切り出しで外した先頭の空白と "/" の分だけずらす。
+		// original 側で探すと 1 語目に空白が無く、"/" を落としてしまう。
+		offset := len(original) - len(input)
+		keep = original[:offset+strings.LastIndex(input, " ")+1]
 	}
 	if len(candidates) == 0 {
 		return "", nil

--- a/internal/ui/complete.go
+++ b/internal/ui/complete.go
@@ -29,6 +29,12 @@ func (model *Model) completionScan() (string, []string) {
 	if strings.HasSuffix(input, " ") {
 		words = append(words, "")
 	}
+	// 空白しか打っていないなら何も打っていないのと同じ。末尾の空白を候補の
+	// 手前に残すと "/ clear" のような実行できない文字列になる。
+	if strings.TrimSpace(input) == "" {
+		words = nil
+		original = strings.TrimRight(original, " ")
+	}
 
 	candidatesFor := func(command []string) []string {
 		switch strings.Join(command, " ") {
@@ -91,7 +97,7 @@ func (model *Model) completionHint() string {
 	keep, candidates := model.completionScan()
 	// 何も打っていないうちは灰色を出さない。キャレットの桁が候補で埋まり、
 	// 空の入力欄が打ちかけと見分けられなくなる。
-	if len(candidates) == 0 || len(model.input) == 0 {
+	if len(candidates) == 0 || strings.TrimSpace(string(model.input)) == "" {
 		return ""
 	}
 	cursor := clamp(model.completionCursor, 0, len(candidates)-1)

--- a/internal/ui/complete.go
+++ b/internal/ui/complete.go
@@ -8,6 +8,8 @@ import (
 
 var (
 	// コマンド名そのものの候補。引数まで補完できる並びに /clear を足したもの。
+	// candidatesFor の case を増やしたらここにも足す（clear のように case を
+	// 持たない語があるため自動では導けない）。
 	commandCompletions     = []string{"clear", "tell", "time", "weather"}
 	timeCommandCompletions = []string{"set"}
 	timeCompletions        = []string{"day", "night", "noon", "midnight"}
@@ -87,7 +89,9 @@ func (model *Model) completions() []string {
 // completionHint は入力の続きとして表示する未確定の候補を返す。
 func (model *Model) completionHint() string {
 	keep, candidates := model.completionScan()
-	if len(candidates) == 0 {
+	// 何も打っていないうちは灰色を出さない。キャレットの桁が候補で埋まり、
+	// 空の入力欄が打ちかけと見分けられなくなる。
+	if len(candidates) == 0 || len(model.input) == 0 {
 		return ""
 	}
 	cursor := clamp(model.completionCursor, 0, len(candidates)-1)

--- a/internal/ui/complete_test.go
+++ b/internal/ui/complete_test.go
@@ -28,6 +28,12 @@ func TestModelCompletions(t *testing.T) {
 		{name: "tell 引数の後", input: "tell Alice ", players: []string{"Alice"}, want: nil},
 		{name: "weather 引数の後", input: "weather clear ", want: nil},
 		{name: "対象外", input: "gamemode ", want: nil},
+		// コマンド名そのものも補完する。
+		{name: "コマンド名 空", input: "", want: []string{"clear", "tell", "time", "weather"}},
+		{name: "コマンド名 / だけ", input: "/", want: []string{"clear", "tell", "time", "weather"}},
+		{name: "コマンド名 打ちかけ", input: "/w", want: []string{"weather"}},
+		{name: "コマンド名 c", input: "c", want: []string{"clear"}},
+		{name: "コマンド名 対象外", input: "gamemode", want: nil},
 		// 先頭に空白があってもコマンド語を見失わない。"/" との併用も同じ。
 		{name: "先頭の空白", input: "  weather ", want: []string{"clear", "rain", "thunder"}},
 		{name: "先頭の空白と /", input: "  /tell Al", players: []string{"Alice"}, want: []string{"Alice"}},
@@ -45,6 +51,18 @@ func TestModelCompletions(t *testing.T) {
 				t.Fatalf("completions() = %#v, want %#v", got, test.want)
 			}
 		})
+	}
+}
+
+func TestModelInsertsCommandCompletionOnTab(t *testing.T) {
+	tests := map[string]string{"/w": "/weather ", "w": "weather ", "  /cl": "  /clear "}
+	for input, want := range tests {
+		model := newTestModel()
+		model.input = []rune(input)
+		_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+		if got := string(model.input); got != want {
+			t.Fatalf("input %q: got %q, want %q", input, got, want)
+		}
 	}
 }
 

--- a/internal/ui/complete_test.go
+++ b/internal/ui/complete_test.go
@@ -66,6 +66,23 @@ func TestModelInsertsCommandCompletionOnTab(t *testing.T) {
 	}
 }
 
+func TestModelInsertsCommandCompletionFromModal(t *testing.T) {
+	model := newTestModel()
+	model.input = []rune("/t")
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if got := string(model.input); got != "/tell " {
+		t.Fatalf("got %q, want %q", got, "/tell ")
+	}
+}
+
+func TestModelHidesCompletionHintOnEmptyInput(t *testing.T) {
+	model := newTestModel()
+	if got := model.completionHint(); got != "" {
+		t.Fatalf("completionHint() = %q, want empty", got)
+	}
+}
+
 func TestModelInsertsTimeSetCompletionOnTab(t *testing.T) {
 	for _, input := range []string{"time", "time ", "time s"} {
 		model := newTestModel()

--- a/internal/ui/complete_test.go
+++ b/internal/ui/complete_test.go
@@ -55,7 +55,9 @@ func TestModelCompletions(t *testing.T) {
 }
 
 func TestModelInsertsCommandCompletionOnTab(t *testing.T) {
-	tests := map[string]string{"/w": "/weather ", "w": "weather ", "  /cl": "  /clear "}
+	tests := map[string]string{
+		"/w": "/weather ", "w": "weather ", "  /cl": "  /clear ",
+	}
 	for input, want := range tests {
 		model := newTestModel()
 		model.input = []rune(input)
@@ -67,19 +69,26 @@ func TestModelInsertsCommandCompletionOnTab(t *testing.T) {
 }
 
 func TestModelInsertsCommandCompletionFromModal(t *testing.T) {
-	model := newTestModel()
-	model.input = []rune("/t")
-	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyTab})
-	_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	if got := string(model.input); got != "/tell " {
-		t.Fatalf("got %q, want %q", got, "/tell ")
+	// 空白しか打っていないときは、その空白を残さず挿入する。
+	tests := map[string]string{"/t": "/tell ", "/ ": "/clear ", " ": "clear "}
+	for input, want := range tests {
+		model := newTestModel()
+		model.input = []rune(input)
+		_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+		_, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+		if got := string(model.input); got != want {
+			t.Fatalf("input %q: got %q, want %q", input, got, want)
+		}
 	}
 }
 
 func TestModelHidesCompletionHintOnEmptyInput(t *testing.T) {
-	model := newTestModel()
-	if got := model.completionHint(); got != "" {
-		t.Fatalf("completionHint() = %q, want empty", got)
+	for _, input := range []string{"", " ", "/ "} {
+		model := newTestModel()
+		model.input = []rune(input)
+		if got := model.completionHint(); got != "" {
+			t.Fatalf("input %q: completionHint() = %q, want empty", input, got)
+		}
 	}
 }
 

--- a/internal/ui/complete_test.go
+++ b/internal/ui/complete_test.go
@@ -57,6 +57,8 @@ func TestModelCompletions(t *testing.T) {
 func TestModelInsertsCommandCompletionOnTab(t *testing.T) {
 	tests := map[string]string{
 		"/w": "/weather ", "w": "weather ", "  /cl": "  /clear ",
+		// "/" の直後の空白は残さない。残すと実行できないコマンドになる。
+		"/ cl": "/clear ", "  / w": "  /weather ",
 	}
 	for input, want := range tests {
 		model := newTestModel()
@@ -70,7 +72,7 @@ func TestModelInsertsCommandCompletionOnTab(t *testing.T) {
 
 func TestModelInsertsCommandCompletionFromModal(t *testing.T) {
 	// 空白しか打っていないときは、その空白を残さず挿入する。
-	tests := map[string]string{"/t": "/tell ", "/ ": "/clear ", " ": "clear "}
+	tests := map[string]string{"/t": "/tell ", "/ ": "/clear ", " ": "clear ", "/  ": "/clear "}
 	for input, want := range tests {
 		model := newTestModel()
 		model.input = []rune(input)


### PR DESCRIPTION
Closes #127

## WHY
Console の Tab 補完は引数の並びしか対象にしておらず、`/weather` や `/clear` はコマンド名を全部打つ必要があった。

## What
コマンド名（`clear` / `tell` / `time` / `weather`）も候補に出す。空入力や `/` だけの状態で Tab を押すと一覧が出る。

## HOW
`completionScan` の語が 1 つも無いときにコマンド名の候補を返す。1 語目を置き換えるときは、語の切り出しで外した先頭の `/` と空白の分だけ位置をずらして打った文字を残す。